### PR TITLE
Fix for find usage was not working from bean method to Camel bean DSL

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/refereance/CamelBeanReferenceContributor.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/refereance/CamelBeanReferenceContributor.java
@@ -65,7 +65,7 @@ public class CamelBeanReferenceContributor extends PsiReferenceContributor {
                 final PsiLiteral beanNameElement = PsiTreeUtil.findChildOfType(PsiTreeUtil.getParentOfType(beanClassElement, PsiExpressionList.class), PsiLiteral.class);
                 String methodName = beanNameElement.getText().replace("\"", "");
                 if (!methodName.isEmpty()) {
-                    return new PsiReference[] {new CamelBeanMethodReference(psiClass, beanNameElement, methodName, new TextRange(1, methodName.length() + 1))};
+                    return new PsiReference[] {new CamelBeanMethodReference(element, psiClass, methodName, new TextRange(1, methodName.length() + 1))};
                 }
             }
         }

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,7 @@
   <change-notes><![CDATA[
       v0.5.3
       <ul>
+        <li>Find usage where methods are called from Camel routes.</li>
         <li>The preference UI has now a separate page for validation settings</li>
         <li>Bug fixes</li>
       </ul>

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
@@ -160,8 +160,8 @@ public class JavaCamelBeanReferenceSmartCompletionTestIT extends CamelLightCodeI
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
         assertThat(strings, Matchers.not(Matchers.contains("thisIsVeryPrivate")));
-        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod", "mySuperMethod"));
-        assertEquals("There is many options", 4, strings.size());
+        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod", "mySuperMethod","myOverLoadedBean","myOverLoadedBean"));
+        assertEquals("There is many options", 6, strings.size());
     }
 
     public void testJavaBeanTestDataCompletion2File() {
@@ -175,8 +175,8 @@ public class JavaCamelBeanReferenceSmartCompletionTestIT extends CamelLightCodeI
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
         assertThat(strings, Matchers.not(Matchers.contains("thisIsVeryPrivate")));
-        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod"));
-        assertEquals("There is many options", 3, strings.size());
+        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod","myOverLoadedBean","myOverLoadedBean"));
+        assertEquals("There is many options", 5, strings.size());
     }
 
     public void testJavaFieldBeanWithNoReference() {

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
@@ -160,7 +160,7 @@ public class JavaCamelBeanReferenceSmartCompletionTestIT extends CamelLightCodeI
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
         assertThat(strings, Matchers.not(Matchers.contains("thisIsVeryPrivate")));
-        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod", "mySuperMethod","myOverLoadedBean","myOverLoadedBean"));
+        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod", "mySuperMethod", "myOverLoadedBean", "myOverLoadedBean"));
         assertEquals("There is many options", 6, strings.size());
     }
 
@@ -175,7 +175,7 @@ public class JavaCamelBeanReferenceSmartCompletionTestIT extends CamelLightCodeI
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
         assertThat(strings, Matchers.not(Matchers.contains("thisIsVeryPrivate")));
-        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod","myOverLoadedBean","myOverLoadedBean"));
+        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod", "myOverLoadedBean", "myOverLoadedBean"));
         assertEquals("There is many options", 5, strings.size());
     }
 

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/reference/JavaCamelBeanMethodReferenceTest.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/reference/JavaCamelBeanMethodReferenceTest.java
@@ -16,10 +16,17 @@
  */
 package org.apache.camel.idea.reference;
 
+import java.util.ArrayList;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLiteralExpression;
 import com.intellij.psi.ResolveResult;
+import com.intellij.usageView.UsageInfo;
 import org.apache.camel.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import org.apache.camel.idea.refereance.CamelBeanMethodReference;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 /**
  * Test method reference link between the Java Camel DSL bean reference method @{code bean(MyClass.class,"myMethodName")}
@@ -48,5 +55,25 @@ public class JavaCamelBeanMethodReferenceTest extends CamelLightCodeInsightFixtu
         myFixture.configureByFiles("CompleteJavaBeanRoute4TestData.java");
         PsiElement element = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
         assertEquals(0, element.getReferences().length);
+    }
+
+    public void testFindUsageFromMethodToBeanDSL() {
+        ArrayList<UsageInfo> usageInfos = (ArrayList<UsageInfo>) myFixture.testFindUsages("CompleteJavaBeanTestData.java", "CompleteJavaBeanRoute1TestData.java");
+        assertEquals(1, usageInfos.size());
+
+        final UsageInfo usageInfo = usageInfos.get(0);
+        final PsiElement referenceElement = usageInfo.getElement();
+        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
+        assertEquals("(beanTestData, \"anotherBeanMethod\")", referenceElement.getParent().getText());
+    }
+
+    public void testFindUsageFromWithOverloadedMethodToBeanDSL() {
+        ArrayList<UsageInfo> usageInfos = (ArrayList<UsageInfo>) myFixture.testFindUsages("CompleteJavaBeanTest2Data.java", "CompleteJavaBeanRoute7TestData.java");
+        assertEquals(1, usageInfos.size());
+
+        final UsageInfo usageInfo = usageInfos.get(0);
+        final PsiElement referenceElement = usageInfo.getElement();
+        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
+        assertEquals("(beanTestData, \"myOverLoadedBean\")", referenceElement.getParent().getText());
     }
 }

--- a/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanRoute7TestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanRoute7TestData.java
@@ -16,21 +16,20 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanTestData;
+import testData.CompleteJavaBeanTest2Data;
 
-public final class CompleteJavaBeanRoute1TestData extends RouteBuilder {
+/**
+ * Test route for testing find usage from bean method "myOverLoadedBean" to the route Camel bean DSL.
+ * The purpose of the class is to setup a test scenario with overload methods and find usage
+ */
+public final class CompleteJavaBeanRoute7TestData extends RouteBuilder {
 
-    private CompleteJavaBeanTestData beanTestData;
+    private CompleteJavaBeanTest2Data beanTestData;
 
     @Override
     public void configure() {
         from("file:inbox")
-            .bean(beanTestData, "<caret>")
+            .bean(beanTestData, "myOverLoadedBean")
             .to("log:out");
-
-        //use for testing find usage from bean method to Camel bean DSL
-        from("file:inbox2")
-            .bean(beanTestData, "anotherBeanMethod")
-            .to("log:out2");
     }
 }

--- a/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanTest2Data.java
+++ b/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanTest2Data.java
@@ -14,23 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanTestData;
+import testData.CompleteJavaBeanSuperClassTestData;
 
-public final class CompleteJavaBeanRoute1TestData extends RouteBuilder {
+/**
+ * Use for testing find usage with overload methods
+ */
+public class CompleteJavaBeanTest2Data extends CompleteJavaBeanSuperClassTestData {
 
-    private CompleteJavaBeanTestData beanTestData;
+    public void letsDoThis() {}
+    public void another<caret>BeanMethod() {}
+    public void mySuperAbstractMethod() {}
+    public void myOverLoadedBean() {}
+    public void myOver<caret>LoadedBean(String name) {}
 
-    @Override
-    public void configure() {
-        from("file:inbox")
-            .bean(beanTestData, "<caret>")
-            .to("log:out");
+    private void thisIsVeryPrivate() {}
 
-        //use for testing find usage from bean method to Camel bean DSL
-        from("file:inbox2")
-            .bean(beanTestData, "anotherBeanMethod")
-            .to("log:out2");
-    }
 }

--- a/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanTestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/CompleteJavaBeanTestData.java
@@ -19,8 +19,10 @@ import testData.CompleteJavaBeanSuperClassTestData;
 public class CompleteJavaBeanTestData extends CompleteJavaBeanSuperClassTestData {
 
     public void letsDoThis() {}
-    public void anotherBeanMethod() {}
+    public void another<caret>BeanMethod() {}
     public void mySuperAbstractMethod() {}
+    public void myOverLoadedBean() {}
+    public void myOverLoadedBean(String name) {}
 
     private void thisIsVeryPrivate() {}
 

--- a/camel-idea-plugin/src/test/resources/testData/RenameCamelBeanMethodRefResultTestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/RenameCamelBeanMethodRefResultTestData.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.main.Main;
 import testData.CompleteJavaBeanTestData;
 
 public final class RenameCamelBeanMethodRefTestData extends RouteBuilder {

--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,9 @@ Jetbrains provides a FAQ for the IDEA SDK which is massive and takes time to lea
 They also provide a forum for API Plugin Development.
 - https://intellij-support.jetbrains.com/hc/en-us/community/topics/200366979-IntelliJ-IDEA-Open-API-and-Plugin-Development
 
+For Gitter Channel
+- https://gitter.im/IntelliJ-Plugin-Developers
+
 ### Camel IDEA Plugin FAQ
 
 We created a FAQ page to help other developers with common errors when working with the plugin sources.


### PR DESCRIPTION
This fix an issue with the CamelBeanMethodReference was used
incorrectly, and referer to the bean method and not the PsiLiteral bean DSL.
The result was when using "find usage" it just pointed to the
method itself and not the Camel Bean DSL