### PR TITLE
Add validation for call ambiguous methods in bean calls

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/IdeaUtils.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/IdeaUtils.java
@@ -45,6 +45,7 @@ import com.intellij.psi.PsiPolyadicExpression;
 import com.intellij.psi.TokenType;
 import com.intellij.psi.impl.source.tree.JavaDocElementType;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.java.IJavaDocElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
 import com.intellij.psi.xml.XmlTag;
@@ -423,7 +424,7 @@ public final class IdeaUtils implements Disposable {
 
     public boolean isJavaDoc(PsiElement element) {
         IElementType type = element.getNode().getElementType();
-        if (JavaDocElementType.ALL_JAVADOC_ELEMENTS.contains(type)) {
+        if (IJavaDocElementType.class.isAssignableFrom(type.getClass()) || JavaDocElementType.ALL_JAVADOC_ELEMENTS.contains(element.getNode().getElementType())) {
             return true;
         }
         return false;

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/JavaMethodUtils.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/JavaMethodUtils.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import com.intellij.lang.jvm.JvmModifier;
 import com.intellij.openapi.Disposable;
 import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiParameter;
 
@@ -103,6 +104,19 @@ public class JavaMethodUtils implements Disposable {
         return methods.stream()
             .filter(method -> !method.isConstructor())
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Return only the method name in free text from an {@link PsiElement}
+     * @param methodLiteral - PsiElement is parse for method name
+     * @return the text representation of the method name
+     */
+    public String getMethodNameWithOutParameters(PsiElement methodLiteral) {
+        String completeMethodText = methodLiteral.getText();
+        if (completeMethodText.indexOf("(") > 0) {
+            return completeMethodText.substring(0, completeMethodText.indexOf("("));
+        }
+        return completeMethodText;
     }
 
     @Override

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
       <ul>
         <li>Code completion for Camel endpoints in Java, XML, properties or yaml files (ctrl + space)</li>
         <li>Code completion for Camel property placeholders (cursor after {{)</li>
+        <li>Code completion for bean methods inside Camel bean DSL</li>
         <li>Endpoint options filtered to only include applicable options when used as consumer vs producer only mode</li>
         <li>Quick navigation to other Camel routes routing to this route by clicking the Camel icon in the gutter</li>
         <li>Intention to add new Camel endpoint (alt + enter in empty string)</li>
@@ -31,6 +32,7 @@
   <change-notes><![CDATA[
       v0.5.3
       <ul>
+        <li>Upgrade to IntelliJ 2018.1</li>
         <li>Find usage where methods are called from Camel routes.</li>
         <li>The preference UI has now a separate page for validation settings</li>
         <li>Bug fixes</li>

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/annotator/CamelBeanMethodAnnotatorTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/annotator/CamelBeanMethodAnnotatorTestIT.java
@@ -57,5 +57,28 @@ public class CamelBeanMethodAnnotatorTestIT extends CamelLightCodeInsightFixture
         assertEquals(3, list.stream().filter(i -> i.getSeverity().getName().equals("ERROR")).count());
     }
 
+    /**
+     * Test if the annotator mark the bean call "myOverLoadedBean" as errors because it's Ambiguous. This test also test if the scenario where one of the
+     * overloaded methods is private and the other is public
+     */
+    public void testAnnotatorJavaBeanAmbiguousMatch() {
+        myFixture.configureByFiles("AnnotatorJavaBeanRoute3TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
+        myFixture.checkHighlighting(false, false, true, true);
+
+        List<HighlightInfo> list = myFixture.doHighlighting();
+        assertEquals(3, list.stream().filter(i -> i.getSeverity().getName().equals("ERROR")).count());
+    }
+
+    /**
+     * Test if the annotator is false and don't mark any methods even it's ambiguous, but one of the methods are marked as @Handle
+     */
+    public void testAnnotatorJavaBeanWithHandlerAnnotation() {
+        myFixture.configureByFiles("AnnotatorJavaBeanRoute4TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
+        myFixture.checkHighlighting(false, false, true, true);
+
+        List<HighlightInfo> list = myFixture.doHighlighting();
+        assertEquals(1, list.stream().filter(i -> i.getSeverity().getName().equals("ERROR")).count());
+    }
+
 
 }

--- a/camel-idea-plugin/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute3TestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute3TestData.java
@@ -16,24 +16,20 @@
  */
 package testData.annotator.method;
 
-import org.apache.camel.Handler;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.main.Main;
+import testData.annotator.method.AnnotatorJavaBeanTestData;
 import testData.annotator.method.AnnotatorJavaBeanSuperClassTestData;
 
-public class AnnotatorJavaBeanTestData extends AnnotatorJavaBeanSuperClassTestData {
+public final class AnnotatorJavaBeanRoute3TestData extends RouteBuilder {
 
-    public void letsDoThis() {}
-    public void anotherBeanMethod() {}
-    public void mySuperAbstractMethod() {}
-    public void myOverLoadedBean() {}
-    public void myOverLoadedBean(String name) {}
+    private AnnotatorJavaBeanTestData beanTestData = new AnnotatorJavaBeanTestData();
 
-    private void myOverLoadedBean2(String name) {}
-    public void myOverLoadedBean2(String name, int count) {}
-
-    @Handler
-    public void myOverLoadedBean3(String name) {}
-    public void myOverLoadedBean3(String name, int count) {}
-
-    private void thisIsVeryPrivate() {}
-
+    public void configure() {
+        from("file:inbox")
+            .bean(beanTestData, "myOverLoadedBean2")
+            .bean(beanTestData, <error descr="Ambiguous matches 'myOverLoadedBean(${body})' in bean 'testData.annotator.method.AnnotatorJavaBeanTestData'">"myOverLoadedBean(${body})"</error>)
+            .bean(beanTestData, <error descr="Ambiguous matches 'myOverLoadedBean' in bean 'testData.annotator.method.AnnotatorJavaBeanTestData'">"myOverLoadedBean"</error>)
+            .to("log:out");
+    }
 }

--- a/camel-idea-plugin/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute4TestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute4TestData.java
@@ -16,24 +16,18 @@
  */
 package testData.annotator.method;
 
-import org.apache.camel.Handler;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.main.Main;
+import testData.annotator.method.AnnotatorJavaBeanTestData;
 import testData.annotator.method.AnnotatorJavaBeanSuperClassTestData;
 
-public class AnnotatorJavaBeanTestData extends AnnotatorJavaBeanSuperClassTestData {
+public final class AnnotatorJavaBeanRoute4TestData extends RouteBuilder {
 
-    public void letsDoThis() {}
-    public void anotherBeanMethod() {}
-    public void mySuperAbstractMethod() {}
-    public void myOverLoadedBean() {}
-    public void myOverLoadedBean(String name) {}
+    private AnnotatorJavaBeanTestData beanTestData = new AnnotatorJavaBeanTestData();
 
-    private void myOverLoadedBean2(String name) {}
-    public void myOverLoadedBean2(String name, int count) {}
-
-    @Handler
-    public void myOverLoadedBean3(String name) {}
-    public void myOverLoadedBean3(String name, int count) {}
-
-    private void thisIsVeryPrivate() {}
-
+    public void configure() {
+        from("file:inbox")
+            .bean(beanTestData, "myOverLoadedBean3")
+            .to("log:out");
+    }
 }


### PR DESCRIPTION
This is the first version of validation of ambiguous method calls
from camel bean DSL.