### PR TITLE
Update the method reference to handle method calls with parameters

### DIFF
--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/CamelBeanMethodAnnotator.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/annotator/CamelBeanMethodAnnotator.java
@@ -96,7 +96,7 @@ public class CamelBeanMethodAnnotator implements Annotator {
 
             final boolean allPrivates = privateMethods == matchMethods.size() ? true : false;
 
-            if (methodName.indexOf("(", methodNameWithParameters.length()) > 0 && methodNameWithParameters.endsWith(")") && !allPrivates) {
+            if (methodNameWithParameters.indexOf("(", methodName.length()) > 0 && methodNameWithParameters.endsWith(")") && !allPrivates) {
                 //TODO implement logic for matching on parameters.
                 return;
             }

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/refereance/CamelBeanMethodReference.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/refereance/CamelBeanMethodReference.java
@@ -43,6 +43,7 @@ public class CamelBeanMethodReference extends PsiPolyVariantReferenceBase<PsiEle
 
     private final PsiClass psiClass;
     private final String methodName;
+    private final String methodNameOnly;
 
     /**
      * Reference between the Camel bean method DSL and the actually method.
@@ -55,13 +56,15 @@ public class CamelBeanMethodReference extends PsiPolyVariantReferenceBase<PsiEle
         super(element, textRange);
         this.psiClass = psiClass;
         this.methodName = methodName;
+        this.methodNameOnly = getJavaMethodUtils().getMethodNameWithOutParameters(methodName);
     }
 
     @NotNull
     @Override
     public ResolveResult[] multiResolve(boolean b) {
         List<ResolveResult> results = new ArrayList<>();
-        final PsiMethod[] methodsByName = getPsiClass().findMethodsByName(methodName, true);
+
+        final PsiMethod[] methodsByName = getPsiClass().findMethodsByName(methodNameOnly, true);
         for (PsiMethod psiMethod : getJavaMethodUtils().getBeanMethods(Arrays.asList(methodsByName))) {
             if (getCamelIdeaUtils().isAnnotatedWithHandler(psiMethod)) {
                 return new ResolveResult[] {new PsiElementResolveResult(psiMethod)};
@@ -87,7 +90,8 @@ public class CamelBeanMethodReference extends PsiPolyVariantReferenceBase<PsiEle
     @Override
     public PsiElement handleElementRename(String newElementName) throws IncorrectOperationException {
         //Find all the method with the registered method name on it's class.
-        final PsiMethod[] methodsByName = getPsiClass().findMethodsByName(methodName, true);
+
+        final PsiMethod[] methodsByName = getPsiClass().findMethodsByName(methodNameOnly, true);
 
         for (PsiMethod psiMethod : methodsByName) {
             psiMethod.setName(newElementName);

--- a/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/JavaMethodUtils.java
+++ b/camel-idea-plugin/src/main/java/org/apache/camel/idea/util/JavaMethodUtils.java
@@ -112,11 +112,18 @@ public class JavaMethodUtils implements Disposable {
      * @return the text representation of the method name
      */
     public String getMethodNameWithOutParameters(PsiElement methodLiteral) {
-        String completeMethodText = methodLiteral.getText();
-        if (completeMethodText.indexOf("(") > 0) {
-            return completeMethodText.substring(0, completeMethodText.indexOf("("));
+        return getMethodNameWithOutParameters(methodLiteral.getText());
+    }
+    /**
+     * Return only the method name in free text from an {@link String}
+     * @param completeMethodWithParmText - The text representation of the method name and it's parameters
+     * @return the text representation of the method name
+     */
+    public String getMethodNameWithOutParameters(String completeMethodWithParmText) {
+        if (completeMethodWithParmText.indexOf("(") > 0) {
+            return completeMethodWithParmText.substring(0, completeMethodWithParmText.indexOf("("));
         }
-        return completeMethodText;
+        return completeMethodWithParmText;
     }
 
     @Override

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/annotator/CamelBeanMethodAnnotatorTestIT.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/annotator/CamelBeanMethodAnnotatorTestIT.java
@@ -80,5 +80,16 @@ public class CamelBeanMethodAnnotatorTestIT extends CamelLightCodeInsightFixture
         assertEquals(1, list.stream().filter(i -> i.getSeverity().getName().equals("ERROR")).count());
     }
 
+    /**
+     * Test if the calling methods is ambiguous and the Camel DSL bean calling method is with parameters
+     */
+    public void testAnnotatorJavaBeanAmbiguousMatchWithParameter() {
+        myFixture.configureByFiles("AnnotatorJavaBeanRoute5TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
+        myFixture.checkHighlighting(false, false, true, true);
+
+        List<HighlightInfo> list = myFixture.doHighlighting();
+        assertEquals(1, list.stream().filter(i -> i.getSeverity().getName().equals("ERROR")).count());
+    }
+
 
 }

--- a/camel-idea-plugin/src/test/java/org/apache/camel/idea/reference/CamelBeanMethodReferenceTest.java
+++ b/camel-idea-plugin/src/test/java/org/apache/camel/idea/reference/CamelBeanMethodReferenceTest.java
@@ -81,4 +81,17 @@ public class CamelBeanMethodReferenceTest extends CamelLightCodeInsightFixtureTe
         assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
         assertEquals("(beanTestData, \"myOverLoadedBean\")", referenceElement.getParent().getText());
     }
+
+    /**
+     * Test if the find usage is working with camel DSL bean method call with parameters
+     */
+    public void testFindUsageFromWithAmbiguousToBeanDSLWithParameters() {
+        ArrayList<UsageInfo> usageInfos = (ArrayList<UsageInfo>) myFixture.testFindUsages("CompleteJavaBeanTest3Data.java", "CompleteJavaBeanRoute8TestData.java");
+        assertEquals(1, usageInfos.size());
+
+        final UsageInfo usageInfo = usageInfos.get(0);
+        final PsiElement referenceElement = usageInfo.getElement();
+        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
+        assertEquals("(beanTestData, \"myAmbiguousMethod(${body})\")", referenceElement.getParent().getText());
+    }
 }

--- a/camel-idea-plugin/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute3TestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute3TestData.java
@@ -28,7 +28,7 @@ public final class AnnotatorJavaBeanRoute3TestData extends RouteBuilder {
     public void configure() {
         from("file:inbox")
             .bean(beanTestData, "myOverLoadedBean2")
-            .bean(beanTestData, <error descr="Ambiguous matches 'myOverLoadedBean(${body})' in bean 'testData.annotator.method.AnnotatorJavaBeanTestData'">"myOverLoadedBean(${body})"</error>)
+            .bean(beanTestData, "myOverLoadedBean(${body})")
             .bean(beanTestData, <error descr="Ambiguous matches 'myOverLoadedBean' in bean 'testData.annotator.method.AnnotatorJavaBeanTestData'">"myOverLoadedBean"</error>)
             .to("log:out");
     }

--- a/camel-idea-plugin/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute5TestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute5TestData.java
@@ -14,21 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import testData.CompleteJavaBeanSuperClassTestData;
+package testData.annotator.method;
 
-/**
- * Use for testing find usage with overload methods
- */
-public class CompleteJavaBeanTest2Data extends CompleteJavaBeanSuperClassTestData {
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.main.Main;
+import testData.annotator.method.AnnotatorJavaBeanTestData;
+import testData.annotator.method.AnnotatorJavaBeanSuperClassTestData;
 
-    public void letsDoThis() {}
-    public void another<caret>BeanMethod() {}
-    public void mySuperAbstractMethod() {}
-    public void myOverLoadedBean() {}
-    public void myOver<caret>LoadedBean(String name) {}
+public final class AnnotatorJavaBeanRoute4TestData extends RouteBuilder {
 
-    public void <caret>myAmbiguousMethod() {}
-    public void myAmbiguousMethod(String name) {}
-    private void thisIsVeryPrivate() {}
+    private AnnotatorJavaBeanTestData beanTestData = new AnnotatorJavaBeanTestData();
 
+    public void configure() {
+        from("file:inbox")
+            .bean(beanTestData, "myOverLoadedBean(${body})")
+            .to("log:out");
+    }
 }

--- a/camel-idea-plugin/src/test/resources/testData/completion/method/CompleteJavaBeanRoute8TestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/completion/method/CompleteJavaBeanRoute8TestData.java
@@ -14,21 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import testData.CompleteJavaBeanSuperClassTestData;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.main.Main;
+import testData.CompleteJavaBeanTest2Data;
 
 /**
- * Use for testing find usage with overload methods
+ * Test route for testing find usage from bean method "myOverLoadedBean" to the route Camel bean DSL.
+ * The purpose of the class is to setup a test scenario with overload methods and find usage
  */
-public class CompleteJavaBeanTest2Data extends CompleteJavaBeanSuperClassTestData {
+public final class CompleteJavaBeanRoute8TestData extends RouteBuilder {
 
-    public void letsDoThis() {}
-    public void another<caret>BeanMethod() {}
-    public void mySuperAbstractMethod() {}
-    public void myOverLoadedBean() {}
-    public void myOver<caret>LoadedBean(String name) {}
+    private CompleteJavaBeanTest3Data beanTestData;
 
-    public void <caret>myAmbiguousMethod() {}
-    public void myAmbiguousMethod(String name) {}
-    private void thisIsVeryPrivate() {}
-
+    @Override
+    public void configure() {
+        from("file:inbox")
+            .bean(beanTestData, "myAmbiguousMethod(${body})")
+            .to("log:out");
+    }
 }

--- a/camel-idea-plugin/src/test/resources/testData/completion/method/CompleteJavaBeanTest2Data.java
+++ b/camel-idea-plugin/src/test/resources/testData/completion/method/CompleteJavaBeanTest2Data.java
@@ -27,8 +27,6 @@ public class CompleteJavaBeanTest2Data extends CompleteJavaBeanSuperClassTestDat
     public void myOverLoadedBean() {}
     public void myOver<caret>LoadedBean(String name) {}
 
-    public void <caret>myAmbiguousMethod() {}
-    public void myAmbiguousMethod(String name) {}
     private void thisIsVeryPrivate() {}
 
 }

--- a/camel-idea-plugin/src/test/resources/testData/completion/method/CompleteJavaBeanTest3Data.java
+++ b/camel-idea-plugin/src/test/resources/testData/completion/method/CompleteJavaBeanTest3Data.java
@@ -20,7 +20,7 @@
  */
 public class CompleteJavaBeanTest3Data {
 
-    public void <caret>myAmbiguousMethod() {}
+    public void myAmbiguousMethod() {}
     public void <caret>myAmbiguousMethod(String name) {}
 
 }

--- a/camel-idea-plugin/src/test/resources/testData/completion/method/CompleteJavaBeanTest3Data.java
+++ b/camel-idea-plugin/src/test/resources/testData/completion/method/CompleteJavaBeanTest3Data.java
@@ -14,21 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import testData.CompleteJavaBeanSuperClassTestData;
 
 /**
  * Use for testing find usage with overload methods
  */
-public class CompleteJavaBeanTest2Data extends CompleteJavaBeanSuperClassTestData {
-
-    public void letsDoThis() {}
-    public void another<caret>BeanMethod() {}
-    public void mySuperAbstractMethod() {}
-    public void myOverLoadedBean() {}
-    public void myOver<caret>LoadedBean(String name) {}
+public class CompleteJavaBeanTest3Data {
 
     public void <caret>myAmbiguousMethod() {}
-    public void myAmbiguousMethod(String name) {}
-    private void thisIsVeryPrivate() {}
+    public void <caret>myAmbiguousMethod(String name) {}
 
 }


### PR DESCRIPTION
- This fix an issue with the reference logic preventing the user
for jumping to bean method when using parameters in the bean call.

The reference logic is limit to show all the matching method names regardless
it's a parameter references. Later we add more support to link it more
accurately to the method with parameters it should match.

- Fix an issue with ambiguous methods was mark, if the bean method call
was with parameters. Currently we are not able to accurately match the
bean method call. This will come later.