### PR TITLE
Fix an issue with code end point completion did not work in properties files

### DIFF
--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -98,7 +98,7 @@
     <!-- allow code completion of Camel endpoints-->
     <completion.contributor language="JAVA" implementationClass="org.apache.camel.idea.completion.contributor.CamelJavaReferenceContributor"/>
     <completion.contributor language="XML" implementationClass="org.apache.camel.idea.completion.contributor.CamelXmlReferenceContributor"/>
-    <completion.contributor language="any" implementationClass="org.apache.camel.idea.completion.contributor.CamelPropertiesOrYamlFileReferenceContributor"/>
+    <completion.contributor language="any" implementationClass="org.apache.camel.idea.completion.contributor.CamelPropertiesOrYamlFileReferenceContributor" order="before javaClassReference"/>
 
     <!-- puts the Camel icon in the gutter for each line that starts a Camel route -->
     <codeInsight.lineMarkerProvider language="JAVA" implementationClass="org.apache.camel.idea.gutter.CamelRouteLineMarkerProvider"/>


### PR DESCRIPTION
At some point between IDEA upgrades this has changed and the end point
completion in property files stop working. The reason why it's behave
like this can be find in the JavaClassReferenceCompletionContributor,
and the fact that it find a JavaClassReference for the specific
property result in it call the result.stopHere method

I post a question regarding this behaviour
https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000181079-Strange-problem-with-our-customer-property-completion-contributor