### PR TITLE
Fix setup environment on Windows

### DIFF
--- a/install-intellij-libs.bat
+++ b/install-intellij-libs.bat
@@ -31,6 +31,6 @@ for %%i in ("%INTELLIJ_HOME%\lib\*.jar") do (
 )
 
 call mvn install:install-file -Dfile="%INTELLIJ_HOME%/plugins/properties/lib/properties.jar" -DgroupId=com.intellij.plugins -DartifactId=properties -Dversion=%IDEA_VERSION% -Dpackaging=jar
-call mvn install:install-file -Dfile="%INTELLIJ_HOME%/plugins/properties/lib/resources_en.jar" -DgroupId=com.intellij.plugins -DartifactId=resources_en -Dversion=%IDEA_VERSION% -Dpackaging=jar
+call mvn install:install-file -Dfile="%INTELLIJ_HOME%/plugins/properties/lib/resources_en.jar" -DgroupId=com.intellij.plugins -DartifactId=properties-resources_en -Dversion=%IDEA_VERSION% -Dpackaging=jar
 call mvn install:install-file -Dfile="%INTELLIJ_HOME%/plugins/yaml/lib/yaml.jar" -DgroupId=com.jetbrains.plugins -DartifactId=yaml -Dversion=%IDEA_VERSION% -Dpackaging=jar
 call mvn install:install-file -Dfile="%INTELLIJ_HOME%/plugins/yaml/lib/resources_en.jar" -DgroupId=com.jetbrains.plugins -DartifactId=yaml-resources_en -Dversion=%IDEA_VERSION% -Dpackaging=jar


### PR DESCRIPTION
the artifact installed in local .m2 has been renamed from resources_en
to properties-resources_en during work on #285 as another resources fo
ryaml has been introduced

Signed-off-by: Aurélien Pupier <apupier@redhat.com>