### PR TITLE
fix idea.version in ultimate profile (2018.1.6 -> 2018.3.4)

### DIFF
--- a/camel-idea-plugin/pom.xml
+++ b/camel-idea-plugin/pom.xml
@@ -58,7 +58,7 @@
     <profile>
       <id>ultimate</id>
       <properties>
-        <idea.version>2018.1.6</idea.version>
+        <idea.version>2018.3.4</idea.version>
         <!-- PLEASE DON'T DELETE THIS EMPTY TAG. IT'S NECESSARY TO KEEP THIS EMPTY TAG FOR IDEA ULTIMATE! -->
         <idea.platform.prefix></idea.platform.prefix>
       </properties>


### PR DESCRIPTION
I think the old version (2018.1.6) was left in the 'ultimate' profile by mistake