### PR TITLE
Re-enable inspection test case.

### DIFF
--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectXmlSimpleTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectXmlSimpleTestIT.java
@@ -16,75 +16,24 @@
  */
 package com.github.cameltooling.idea.inspection;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-
 import com.intellij.codeInspection.ex.LocalInspectionToolWrapper;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.command.WriteCommandAction;
-import com.intellij.openapi.roots.ModuleRootModificationUtil;
-import com.intellij.openapi.roots.OrderRootType;
-import com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable;
-import com.intellij.openapi.roots.libraries.Library;
-import com.intellij.openapi.roots.libraries.LibraryTable;
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
-import com.intellij.openapi.vfs.LocalFileSystem;
-import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.testFramework.InspectionTestCase;
-import com.intellij.util.ui.UIUtil;
+import com.intellij.testFramework.PsiTestUtil;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
-public class CamelInspectXmlSimpleTestIT extends InspectionTestCase {
-    private ArrayList<Library> libraries = new ArrayList<>();
-    public static final String CAMEL_CORE_MAVEN_ARTIFACT = "org.apache.camel:camel-core:2.22.0";
+import java.io.File;
+
+public class CamelInspectXmlSimpleTestIT extends CamelInspectionTestHelper {
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        File[] mavenArtifacts = getMavenArtifacts(CAMEL_CORE_MAVEN_ARTIFACT);
-        VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(mavenArtifacts[0]);
-        final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(myModule.getProject());
-        ApplicationManager.getApplication().runWriteAction(() -> {
-            Library library = projectLibraryTable.createLibrary("Maven: " + CAMEL_CORE_MAVEN_ARTIFACT);
-            final Library.ModifiableModel libraryModifiableModel = library.getModifiableModel();
-            libraryModifiableModel.addRoot(virtualFile, OrderRootType.CLASSES);
-            libraryModifiableModel.commit();
-            libraries.add(library);
-            ModuleRootModificationUtil.addDependency(myModule, library);
-        });
-        UIUtil.dispatchAllInvocationEvents();
-    }
-
-    protected void tearDown() throws Exception {
-        libraries.forEach(library -> removeLibrary(library));
-        super.tearDown();
-    }
-
-    void removeLibrary(Library library) {
-        WriteCommandAction.runWriteCommandAction(null, ()-> {
-            LibraryTable table = ProjectLibraryTable.getInstance(getProject());
-            LibraryTable.ModifiableModel model = table.getModifiableModel();
-            model.removeLibrary(library);
-            model.commit();
-
-        });
-    }
-
-    private File[] getMavenArtifacts(String... mavenAritfiact) throws IOException {
-        File[] libs = Maven.resolver().resolve(mavenAritfiact).withoutTransitivity().asFile();
-        return libs;
-    }
-
-    @Override
-    protected String getTestDataPath() {
-        return "src/test/resources/";
+        File[] mavenArtifacts =  Maven.resolver().resolve(CAMEL_CORE_MAVEN_ARTIFACT).withoutTransitivity().asFile();
+        PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), myFixture.getModule(), "Maven: " + CAMEL_CORE_MAVEN_ARTIFACT, mavenArtifacts[0].getParent(), mavenArtifacts[0].getName());
     }
 
     public void testSimpleInspection() {
         // force Camel enabled so the inspection test can run
         CamelInspection inspection = new CamelInspection(true);
-
         doTest("testData/inspectionsimplexml/", new LocalInspectionToolWrapper(inspection));
     }
 

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectionTestHelper.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectionTestHelper.java
@@ -1,0 +1,49 @@
+package com.github.cameltooling.idea.inspection;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.projectRoots.JavaSdk;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ContentEntry;
+import com.intellij.openapi.roots.LanguageLevelModuleExtension;
+import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.pom.java.LanguageLevel;
+import com.intellij.testFramework.InspectionTestCase;
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.jps.model.java.JpsJavaSdkType;
+
+/**
+ * Test helper for setup test case to test inspection code. The class create a new {@link LightProjectDescriptor} for
+ * each test to make sure it start with a clean state and all previous added libraries is removed
+ *
+ */
+public abstract class CamelInspectionTestHelper extends InspectionTestCase {
+
+    private static final String BUILD_MOCK_JDK_DIRECTORY = "build/mockJDK-";
+
+    public static final String CAMEL_CORE_MAVEN_ARTIFACT = "org.apache.camel:camel-core:2.22.0";
+
+    @NotNull
+    @Override
+    protected LightProjectDescriptor getProjectDescriptor() {
+        LanguageLevel languageLevel = LanguageLevel.JDK_1_8;
+        return new DefaultLightProjectDescriptor() {
+            @Override
+            public Sdk getSdk() {
+                String compilerOption = JpsJavaSdkType.complianceOption(languageLevel.toJavaVersion());
+                return JavaSdk.getInstance().createJdk( "java " + compilerOption, BUILD_MOCK_JDK_DIRECTORY + compilerOption, false );
+            }
+
+            @Override
+            public void configureModule(@NotNull Module module, @NotNull ModifiableRootModel model, @NotNull ContentEntry contentEntry) {
+                model.getModuleExtension( LanguageLevelModuleExtension.class ).setLanguageLevel( languageLevel );
+            }
+        };
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources/";
+    }
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogServiceTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogServiceTestIT.java
@@ -33,21 +33,13 @@ public class CamelCatalogServiceTestIT extends CamelLightCodeInsightFixtureTestC
         super.setUp();
     }
 
-    /*
-      After upgrading to IDEA 2019.1 new constraints is added or changed on how test cases are behaving,
-      and for some reason I suspect another test case does not clean up it's state and the CamelCatalogService is instantiated.
-      Running the test case locally from IDEA and Maven works fine, but Travis CI fails the test.
-
-      One of the things I observed was Travis runs test cases in a different order.
-     */
-
-//    public void testNoCatalogInstance() {
-//        ServiceManager.getService(myModule.getProject(), CamelService.class).setCamelPresent(false);
-//        myFixture.configureByFiles("CompleteJavaEndpointConsumerTestData.java", "CompleteYmlPropertyTestData.java",
-//             "CompleteJavaPropertyTestData.properties", "CompleteYmlPropertyTestData.java", "CompleteYmlPropertyTestData.yml");
-//        myFixture.complete(CompletionType.BASIC, 1);
-//        assertEquals(false, ServiceManager.getService(myModule.getProject(), CamelCatalogService.class).isInstantiated());
-//    }
+    public void testNoCatalogInstance() {
+        ServiceManager.getService(myModule.getProject(), CamelService.class).setCamelPresent(false);
+        myFixture.configureByFiles("CompleteJavaEndpointConsumerTestData.java", "CompleteYmlPropertyTestData.java",
+            "CompleteJavaPropertyTestData.properties", "CompleteYmlPropertyTestData.java", "CompleteYmlPropertyTestData.yml");
+        myFixture.complete(CompletionType.BASIC, 1);
+        assertEquals(false, ServiceManager.getService(myModule.getProject(), CamelCatalogService.class).isInstantiated());
+    }
 
     public void testCatalogInstance() {
         myFixture.configureByFiles("CompleteJavaEndpointConsumerTestData.java", "CompleteYmlPropertyTestData.java",


### PR DESCRIPTION
It turns out after 2019.1 the InspectionTestCase has become "light",
so modifications to the test project like adding libraries etc.
are "sticking". You'll need to undo any (temporary) changes to your
project setp carefully in tearDown() or use dedicated LightProjectDescriptor instead.

https://intellij-support.jetbrains.com/hc/en-us/community/posts/360004337839-Inspection-TestCase-start-failing-after-upgrade