### PR TITLE
Fix the issue with invalid range when the simple expression was not t…

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/CamelSimpleAnnotator.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/CamelSimpleAnnotator.java
@@ -106,9 +106,9 @@ public class CamelSimpleAnnotator extends AbstractCamelAnnotator {
             endIdx = text.indexOf(" ", startIdx) - 1;
         }
         //calc the end index for highlighted word
-        endIdx = endIdx < 0 ? (range.getEndOffset() - 1) : (range.getStartOffset() + endIdx) + 1;
+        endIdx = endIdx < 0 ? range.getEndOffset() : (range.getStartOffset() + endIdx) + 1;
 
-        if (endIdx <= startIdx) {
+        if (endIdx < startIdx) {
             endIdx = range.getEndOffset();
         }
         range = TextRange.create(range.getStartOffset() + result.getIndex(), endIdx);

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/annotator/CamelEndpointAnnotatorTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/annotator/CamelEndpointAnnotatorTestIT.java
@@ -24,7 +24,6 @@ import com.intellij.lang.annotation.HighlightSeverity;
 
 /**
  * Test Camel URI validation and the expected value is highlighted
- * TODO : Still need to find out how we can make a positive test without it complaining about it can't find SDK classes
  *
  * TIP : Writing highlighting test can be tricky because if the highlight is one character off
  * it will fail, but the error messaged might still be correct. In this case it's likely the TextRange
@@ -78,10 +77,15 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
         myFixture.checkHighlighting(false, false, true, true);
     }
 
+    public void testExpectedSymbolFunctionEndButWasEOL() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaExpectedSymbolFunctionEndTestData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
+
     public void testAnnotatorUnknownOptionWithConsumerAnnotationValidation() {
-        assertTrue("Ignored until we fix the issue with running the test with SDK", true);
-        //myFixture.configureByText("AnnotatorTestData.java", getJavaUnknownOptionsConsumerAnnotationTestData());
-        //myFixture.checkHighlighting(false, false, true, true);
+        //assertTrue("Ignored until we fix the issue with running the test with SDK", true);
+        myFixture.configureByText("AnnotatorTestData.java", getJavaUnknownOptionsConsumerAnnotationTestData());
+        myFixture.checkHighlighting(false, false, true, true);
     }
 
     public void testXmlAnnotatorInvalidBooleanPropertyValidation() {
@@ -246,8 +250,9 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
 
     private String getJavaUnknownOptionsConsumerAnnotationTestData() {
         return "import org.apache.camel.builder.RouteBuilder;\n"
-            + "public class MyRouteBuilder extends RouteBuilder {\n"
-            + "         @Consumer(file:test?allowNullBody=true&<error descr=\"Unknown option\">foo</error>=bar);"
+            + "import org.apache.camel.Consume;\n"
+            + "public class MyPojoConsumer {\n"
+            + "         @Consumer(uri = \"file:test?allowNullBody=true&<error descr=\"Unknown option\">foo</error>=bar\");"
             + "         public void onCheese(String name) {}"
             + "    }";
     }
@@ -258,6 +263,17 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
             + "        public void configure() throws Exception {\n"
             + "            from(\"timer:trigger?bridgeErrorHandler=false\")\n"
             + "                .to(\"file:test?allowNullBody=<error descr=\"Invalid boolean value: FISH\">FISH</error>\")\n"
+            + "        }\n"
+            + "    }";
+    }
+
+    private String getJavaExpectedSymbolFunctionEndTestData() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"direct:start\")\n"
+            + "                  .setHeader(Exchange.HTTP_URI, simple(\"{{api.url}}/customer/${header<error descr=\"expected symbol functionEnd but was eol\">.\"</error>))\n"
+            + "                  .to(\"mock:result\");\n"
             + "        }\n"
             + "    }";
     }

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/annotator/CamelSimpleAnnotatorTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/annotator/CamelSimpleAnnotatorTestIT.java
@@ -135,7 +135,7 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
             + "            from(\"netty-http:http://localhost/cdi?matchOnUriPrefix=true&nettySharedHttpServer=#httpServer\")\n"
             + "            .id(\"http-route-cdi\")\n"
             + "            .transform()\n"
-            + "            .simple(\"Response from Camel CDI on route${routeId} using thread: ${threadNam<error descr=\"expected symbol functionEnd but was eol\">e</error>\");"
+            + "            .simple(\"Response from Camel CDI on route${routeId} using thread: ${threadNam<error descr=\"expected symbol functionEnd but was eol\">e\"</error>);"
             + "        }\n"
             + "    }";
     }
@@ -147,7 +147,7 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
             + "            from(\"netty-http:http://localhost/cdi?matchOnUriPrefix=true&nettySharedHttpServer=#httpServer\")\n"
             + "            .id(\"http-route-cdi\")\n"
             + "            .transform()\n"
-            + "            .simple(\"Response from Camel CDI on route${routeId} using thread: ${threadNam<error descr=\"expected symbol functionEnd but was eol\">e</error>\");"
+            + "            .simple(\"Response from Camel CDI on route${routeId} using thread: ${threadNam<error descr=\"expected symbol functionEnd but was eol\">e\"</error>);"
             + "        }\n"
             + "    }";
     }


### PR DESCRIPTION
…erminated correctly.

If the simple expression was not terminated correctly the calculated
end index was less the 0, and in this case the endIdx was set to the
range end offset - 1. This result in the range start offset was higher
than the end offset and cause an Invalid range specified