### PR TITLE
Add missing dependency

### DIFF
--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -77,6 +77,8 @@
   <!-- depend on the yml plugin -->
   <depends>org.jetbrains.plugins.yaml</depends>
 
+  <depends>com.intellij.java</depends>
+
   <extensions defaultExtensionNs="org.apache.camel">
     <IdeaUtilsSupport implementation="com.github.cameltooling.idea.service.extension.idea.JavaIdeaUtils" />
     <IdeaUtilsSupport implementation="com.github.cameltooling.idea.service.extension.idea.XmlIdeaUtils" />


### PR DESCRIPTION
For some reason this dependency was not needed in IDEA 2019.x
but in 2020.1 it is requirement