### PR TITLE
Ref #700 - Support specific catalog version for a Camel runtime provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,12 +58,6 @@ subprojects {
     }
 
     test {
-        filter {
-            //exclude specific method because they fail other tests, not sure why at this point but it might be because it 
-            //not cleanup after itself.
-            excludeTestsMatching "*.testShouldChangeStateOfRealTimeJSonPathValidationCatalogCheckBox"
-            excludeTestsMatching "*.testShouldChangeStateOfRealTimeBeanMethodValidationCheckBox"
-        }
         afterTest { desc, result ->
             logger.quiet "Executing test ${desc.name} [${desc.className}] with result: ${result.resultType}"
         }

--- a/camel-idea-plugin/build.gradle
+++ b/camel-idea-plugin/build.gradle
@@ -77,3 +77,15 @@ tasks.register('prepareTest') {
 }
 
 tasks.test.dependsOn("prepareTest")
+
+test {
+// Start: To get Grape log messages
+//    systemProperty("groovy.grape.report.downloads", "true")
+//    systemProperty("ivy.message.logger.level", "4")
+//    testLogging {
+//        showStandardStreams = true
+//    }
+// End: To get Grape log messages
+// To enable the remote debug
+//    jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+}

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/catalog/CamelCatalogProvider.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/catalog/CamelCatalogProvider.java
@@ -16,9 +16,12 @@
  */
 package com.github.cameltooling.idea.catalog;
 
+import java.util.List;
 import java.util.function.Supplier;
 
+import com.github.cameltooling.idea.service.CamelCatalogService;
 import com.github.cameltooling.idea.service.CamelService;
+import com.github.cameltooling.idea.util.ArtifactCoordinates;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.apache.camel.catalog.CamelCatalog;
@@ -29,6 +32,8 @@ import org.apache.camel.catalog.karaf.KarafRuntimeProvider;
 import org.apache.camel.catalog.quarkus.QuarkusRuntimeProvider;
 import org.apache.camel.springboot.catalog.SpringBootRuntimeProvider;
 import org.apache.camel.tooling.model.MainModel;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@code CamelCatalogProvider} defines all the Camel Runtime supported by the plugin.
@@ -38,20 +43,19 @@ public enum CamelCatalogProvider {
      * The mode that automatically detects the right {@code CamelCatalogProvider} according to the libraries found
      * in the project.
      */
-    AUTO("Auto detect", null) {
+    AUTO("Auto detect", null, null, List.of(), null, null) {
         @Override
         public CamelCatalogProvider getActualProvider(final Project project) {
             LOG.debug("Trying to automatically detect the Camel Runtime");
             final CamelService camelService = project.getService(CamelService.class);
-            if (camelService.containsLibrary("camel-spring-boot", false)) {
-                LOG.info("The Camel Spring Boot Runtime has been detected");
-                return SPRING_BOOT;
-            } else if (camelService.containsLibrary("camel-quarkus-core", false)) {
-                LOG.info("The Camel Quarkus Runtime has been detected");
-                return QUARKUS;
-            } else if (camelService.containsLibrary("camel-core-osgi", false)) {
-                LOG.info("The Camel Karaf Runtime has been detected");
-                return KARAF;
+            for (CamelCatalogProvider provider : CamelCatalogProvider.values()) {
+                if (provider.coreArtifactId == null) {
+                    continue;
+                }
+                if (camelService.containsLibrary(provider.coreArtifactId, false)) {
+                    LOG.info("The Camel " + provider.getName() + " Runtime has been detected");
+                    return provider;
+                }
             }
             LOG.info("No specific Camel Runtime has been detected, the default runtime is used");
             return DEFAULT;
@@ -60,18 +64,31 @@ public enum CamelCatalogProvider {
     /**
      * The default mode corresponding to the legacy way to retrieve the catalog.
      */
-    DEFAULT("Default", DefaultRuntimeProvider::new),
+    DEFAULT("Default", DefaultRuntimeProvider::new, null, List.of(), null, null) {
+        @Override
+        public boolean loadRuntimeProviderVersion(Project project) {
+            // No specific artifact to load
+            return true;
+        }
+    },
     /**
      * The {@code CamelCatalogProvider} for Quarkus.
      */
-    QUARKUS("Quarkus", QuarkusRuntimeProvider::new),
+    QUARKUS(
+        "Quarkus", QuarkusRuntimeProvider::new, null, List.of("org.apache.camel.quarkus"),
+        "camel-quarkus-core", "camel-quarkus-catalog"
+    ),
     /**
      * The {@code CamelCatalogProvider} for Karaf with an empty main model.
      */
-    KARAF("Karaf", KarafRuntimeProvider::new) {
+    KARAF(
+        "Karaf", KarafRuntimeProvider::new, null, List.of("org.apache.camel", "org.apache.camel.karaf"),
+        "camel-core-osgi", "camel-catalog-provider-karaf"
+
+    ) {
         @Override
         protected CamelCatalog createCatalog(final Project project) {
-            return new DefaultCamelCatalog(true) {
+            return new DefaultCamelCatalog() {
                 @Override
                 public MainModel mainModel() {
                     // Empty Main model in case of Karaf
@@ -85,7 +102,11 @@ public enum CamelCatalogProvider {
      * merge the main and component schemas with the Spring configuration metadata available in the classpath of the
      * project.
      */
-    SPRING_BOOT("Spring Boot", SpringBootRuntimeProvider::new) {
+    SPRING_BOOT(
+        "Spring Boot", SpringBootRuntimeProvider::new, "org.apache.camel.catalog.springboot.SpringBootRuntimeProvider",
+        List.of("org.apache.camel", "org.apache.camel.springboot"),
+        "camel-spring-boot", "camel-catalog-provider-springboot"
+    ) {
         @Override
         protected CamelCatalog createCatalog(final Project project) {
             final CamelCatalog catalog = super.createCatalog(project);
@@ -109,22 +130,55 @@ public enum CamelCatalogProvider {
      */
     private final String name;
     /**
+     * The potential group ids of the artifacts of the Runtime Provider.
+     */
+    @NotNull
+    private final List<String> groupIds;
+    /**
+     * The id of the core artifact of the Runtime Provider.
+     */
+    @Nullable
+    private final String coreArtifactId;
+    /**
+     * The id of the artifact containing the catalog of the Runtime Provider.
+     */
+    private final String catalogArtifactId;
+    /**
      * The supplier of {@code RuntimeProvider} to use to retrieve the metadata at the right location according to
      * the runtime.
      */
     private final Supplier<RuntimeProvider> runtimeProviderSupplier;
+    /**
+     * The fully qualified name of the legacy {@code RuntimeProvider}.
+     */
+    @Nullable
+    private final String runtimeProviderLegacyClass;
 
     /**
      * Constructs a {@code CamelCatalogProvider} with the given parameters.
-     * @param name the display name of the {@code CamelCatalogProvider}.
+     *
+     * @param name                    the display name of the {@code CamelCatalogProvider}.
      * @param runtimeProviderSupplier the supplier of {@code RuntimeProvider} to use to retrieve the metadata at the
      *                                right location according to the runtime.
+     * @param runtimeProviderLegacyClass the fully qualified name of the legacy {@code RuntimeProvider}.
+     * @param groupIds                the potential group ids of the artifacts of the Runtime Provider.
+     * @param coreArtifactId          the id of the core artifact of the Runtime Provider.
+     * @param catalogArtifactId       the id of the artifact containing the catalog of the Runtime Provider.
      */
-    CamelCatalogProvider(String name, Supplier<RuntimeProvider> runtimeProviderSupplier) {
+    CamelCatalogProvider(String name, Supplier<RuntimeProvider> runtimeProviderSupplier,
+                         @Nullable String runtimeProviderLegacyClass, @NotNull List<String> groupIds,
+                         @Nullable String coreArtifactId, String catalogArtifactId) {
         this.name = name;
+        this.groupIds = groupIds;
+        this.coreArtifactId = coreArtifactId;
+        this.catalogArtifactId = catalogArtifactId;
         this.runtimeProviderSupplier = runtimeProviderSupplier;
+        this.runtimeProviderLegacyClass = runtimeProviderLegacyClass;
     }
 
+    /**
+     * @return The display name of the {@code CamelCatalogProvider}.
+     */
     public String getName() {
         return name;
     }
@@ -147,14 +201,16 @@ public enum CamelCatalogProvider {
     /**
      * @param project the project for which a {@code CamelCatalog} should be created.
      * @return a new instance of {@code CamelCatalog} corresponding to the current {@code CamelCatalogProvider}.
+     * with the cache disabled to prevent loading incorrect data into the cache while loading the catalog.
      */
     protected CamelCatalog createCatalog(final Project project) {
-        return new DefaultCamelCatalog(true);
+        return new DefaultCamelCatalog();
     }
 
     /**
      * @param project the project for which the {@code CamelCatalog} is expected.
-     * @return a new instance of {@code CamelCatalog} corresponding to the current {@code CamelCatalogProvider}.
+     * @return a new instance of {@code CamelCatalog} corresponding to the current {@code CamelCatalogProvider}
+     * with the cache disabled to prevent loading incorrect data into the cache while loading the catalog.
      */
     public CamelCatalog get(final Project project) {
         final CamelCatalogProvider provider = getActualProvider(project);
@@ -163,5 +219,87 @@ public enum CamelCatalogProvider {
         runtimeProvider.setCamelCatalog(catalog);
         catalog.setRuntimeProvider(runtimeProvider);
         return catalog;
+    }
+
+    /**
+     * @param project the project from which the core artifact is extracted.
+     * @return an instance of {@link ArtifactCoordinates} if the core artifact could be found in the dependency of the
+     * given project, {@code null} otherwise.
+     */
+    @Nullable
+    protected ArtifactCoordinates getCoreArtifactCoordinates(final Project project) {
+        final CamelService camelService = project.getService(CamelService.class);
+        for (String groupId : groupIds) {
+            ArtifactCoordinates coordinates = camelService.getProjectLibraryCoordinates(groupId, coreArtifactId);
+            if (coordinates != null) {
+                return coordinates;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Loads the catalog of the Runtime provider by first finding the core artifact in the dependency of the project to
+     * retrieve the group id and version and if they can be found it completes them with the corresponding catalog
+     * artifact id and finally load this specific Runtime provider version.
+     *
+     * @param project the project from which the core artifact is extracted.
+     * @return {@code true} if the specific Runtime provider version could be loaded, {@code false} otherwise.
+     */
+    public boolean loadRuntimeProviderVersion(final Project project) {
+        final ArtifactCoordinates coordinates = getCoreArtifactCoordinates(project);
+        if (coordinates == null) {
+            LOG.debug("No core artifact could be found in the project");
+            return false;
+        }
+        final String version = coordinates.getVersion();
+        if (version == null) {
+            LOG.debug("No version of the core artifact has been set");
+            return false;
+        }
+        return project.getService(CamelCatalogService.class)
+            .loadRuntimeProviderVersion(coordinates.getGroupId(), catalogArtifactId, version);
+    }
+
+    /**
+     * @param classLoader the class loader from which the legacy class of the {@code RuntimeProvider} is retrieved.
+     * @return a new instance of the legacy {@code RuntimeProvider} corresponding to the current
+     * {@code CamelCatalogProvider} that could be found in the given class loader, {@code null} otherwise.
+     */
+    @Nullable
+    private RuntimeProvider createLegacyRuntimeProvider(final ClassLoader classLoader) {
+        if (runtimeProviderLegacyClass == null) {
+            LOG.debug("There is no legacy provider defined");
+            return null;
+        }
+        try {
+            LOG.debug("Trying to instantiate the legacy class of the runtime provider");
+            Class<?> clazz = classLoader.loadClass(runtimeProviderLegacyClass);
+            return (RuntimeProvider) clazz.getConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            LOG.warn("The class " + runtimeProviderLegacyClass + " could not be found");
+        } catch (Exception e) {
+            LOG.warn("Could not instantiate the class " + runtimeProviderLegacyClass, e);
+        }
+        return null;
+    }
+
+    /**
+     * Updates the {@code RuntimeProvider} in the given catalog using the legacy implementation if any that can be found
+     * in the given class loader.
+     * @param project the project from which the actual {@code RuntimeProvider} is retrieved.
+     * @param catalog the catalog in which the {@code RuntimeProvider} is updated if needed.
+     * @param classLoader the class loader from which the legacy {@code RuntimeProvider} is retrieved.
+     */
+    public void updateRuntimeProvider(final Project project, final CamelCatalog catalog, final ClassLoader classLoader) {
+        // Retrieve the runtime provider available in the project
+        final RuntimeProvider runtimeProvider = getActualProvider(project).createLegacyRuntimeProvider(classLoader);
+        if (runtimeProvider == null) {
+            LOG.debug("No legacy runtime provider to use");
+        } else {
+            LOG.debug("Replacing the initial legacy runtime provider with the legacy one");
+            runtimeProvider.setCamelCatalog(catalog);
+            catalog.setRuntimeProvider(runtimeProvider);
+        }
     }
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelMavenVersionManager.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelMavenVersionManager.java
@@ -22,6 +22,8 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.intellij.openapi.diagnostic.Logger;
 import groovy.grape.Grape;
 import groovy.lang.GroovyClassLoader;
 import org.apache.camel.catalog.VersionManager;
@@ -32,10 +34,13 @@ import org.apache.camel.catalog.VersionManager;
  */
 class CamelMavenVersionManager implements VersionManager {
 
+    /**
+     * The logger.
+     */
+    private static final Logger LOG = Logger.getInstance(CamelMavenVersionManager.class);
     private final ClassLoader classLoader = new GroovyClassLoader();
     private String version;
     private String runtimeProviderVersion;
-    private String cacheDirectory;
 
     /**
      * To add a 3rd party Maven repository.
@@ -58,23 +63,24 @@ class CamelMavenVersionManager implements VersionManager {
     @Override
     public boolean loadVersion(String version) {
         try {
-            if (cacheDirectory != null) {
-                System.setProperty("grape.root", cacheDirectory);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Trying to load the catalog version: " + version);
             }
-
             Grape.setEnableAutoDownload(true);
 
-            Map<String, Object> param = new HashMap<>();
+            final Map<String, Object> param = createMapDependency("org.apache.camel", "camel-catalog", version);
             param.put("classLoader", classLoader);
-            param.put("group", "org.apache.camel");
-            param.put("module", "camel-catalog");
-            param.put("version", version);
 
             Grape.grab(param);
 
             this.version = version;
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The catalog version " + version + " has been loaded");
+            }
             return true;
         } catch (Exception e) {
+            LOG.warn("Could not load the catalog version " + version + ": " + e.getMessage());
+            LOG.debug(e);
             // ignore
             return false;
         }
@@ -88,20 +94,27 @@ class CamelMavenVersionManager implements VersionManager {
     @Override
     public boolean loadRuntimeProviderVersion(String groupId, String artifactId, String version) {
         try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Trying to load the runtime provider " + groupId + ":" + artifactId + ":" + version);
+            }
             Grape.setEnableAutoDownload(true);
 
-            Map<String, Object> param = new HashMap<>();
+            final Map<String, Object> param = createMapDependency(groupId, artifactId, version);
             param.put("classLoader", classLoader);
-            param.put("group", groupId);
-            param.put("module", artifactId);
-            param.put("version", version);
 
             Grape.grab(param);
 
             this.runtimeProviderVersion = version;
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The runtime provider version " + groupId + ":" + artifactId + ":" + version + " has been loaded");
+            }
             return true;
         } catch (Exception e) {
             // ignore
+            LOG.warn(
+                "Could not load the runtime provider " + groupId + ":" + artifactId + ":" + version + ": " + e.getMessage()
+            );
+            LOG.debug(e);
             return false;
         }
     }
@@ -109,14 +122,18 @@ class CamelMavenVersionManager implements VersionManager {
     @Override
     public InputStream getResourceAsStream(String name) {
         InputStream is = null;
-
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Trying to find the resource " + name + " from the catalog");
+        }
         if (runtimeProviderVersion != null) {
             is = doGetResourceAsStream(name, runtimeProviderVersion);
         }
         if (is == null && version != null) {
             is = doGetResourceAsStream(name, version);
         }
-
+        if (LOG.isDebugEnabled() && is == null) {
+            LOG.debug("The resource " + name + " could not be found in the catalog");
+        }
         return is;
     }
 
@@ -143,6 +160,24 @@ class CamelMavenVersionManager implements VersionManager {
         }
 
         return null;
+    }
+
+    ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    /**
+     * @param groupId the group id of the dependency to download
+     * @param artifactId the artifact id of the dependency to download
+     * @param version the version of the dependency to download
+     * @return the maven coordinates of the dependency to download as a {@code Map}.
+     */
+    private static Map<String, Object> createMapDependency(String groupId, String artifactId, String version) {
+        final Map<String, Object> param = new HashMap<>();
+        param.put("group", groupId);
+        param.put("module", artifactId);
+        param.put("version", version);
+        return param;
     }
 }
 

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelPreferenceService.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelPreferenceService.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.NotNull;
 @State(
     name = "CamelPreferences",
     storages = {@Storage("apachecamelplugin.xml")})
-public final class CamelPreferenceService implements PersistentStateComponent<CamelPreferenceService>, Disposable {
+public class CamelPreferenceService implements PersistentStateComponent<CamelPreferenceService>, Disposable {
 
     @Transient
     public static final Icon CAMEL_ICON = IconLoader.getIcon("/META-INF/pluginIcon.svg", CamelPreferenceService.class);
@@ -82,7 +82,7 @@ public final class CamelPreferenceService implements PersistentStateComponent<Ca
     private List<String> ignorePropertyList = new ArrayList<>();
     private List<String> excludePropertyFiles = new ArrayList<>();
 
-    private CamelPreferenceService() { }
+    protected CamelPreferenceService() { }
 
     public static CamelPreferenceService getService() {
         return ApplicationManager.getApplication().getService(CamelPreferenceService.class);

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/ArtifactCoordinates.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/ArtifactCoordinates.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.util;
+
+import com.intellij.openapi.roots.LibraryOrderEntry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Identifies the coordinates of a given artifact.
+ */
+public final class ArtifactCoordinates {
+    /**
+     * The id of the group of the artifact.
+     */
+    private final String groupId;
+    /**
+     * The id of the artifact.
+     */
+    private final String artifactId;
+    /**
+     * The version of the artifact.
+     */
+    private final String version;
+
+    /**
+     * Construct a {@code ArtifactCoordinates} with the given parameters.
+     * @param groupId the id of the group of the artifact.
+     * @param artifactId the id of the artifact.
+     * @param version the version of the artifact.
+     */
+    private ArtifactCoordinates(@NotNull String groupId, @NotNull String artifactId, @Nullable String version) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
+
+    /**
+     * Parses the user-visible name of the given {@link LibraryOrderEntry} to extract the coordinates of the
+     * corresponding artifact.
+     *
+     * @param libraryOrderEntry the entry to convert into {@code ArtifactCoordinates}.
+     * @return a new instance of {@code ArtifactCoordinates} corresponding to what could be extracted from user-visible
+     * name of the given {@link LibraryOrderEntry} if possible, {@code null} otherwise.
+     */
+    @Nullable
+    public static ArtifactCoordinates parse(LibraryOrderEntry libraryOrderEntry) {
+        String[] split = libraryOrderEntry.getPresentableName().toLowerCase().split(":");
+        if (split.length < 3) {
+            return null;
+        }
+        int startIdx = 0;
+        if (split[0].equalsIgnoreCase("maven")
+            || split[0].equalsIgnoreCase("gradle")
+            || split[0].equalsIgnoreCase("sbt")) {
+            startIdx = 1;
+        }
+        boolean hasVersion = split.length > (startIdx + 2);
+
+        String groupId = split[startIdx++].trim();
+        String artifactId = split[startIdx++].trim();
+        String version = null;
+        if (hasVersion) {
+            version = split[startIdx].trim();
+            // adjust snapshot which must be in uppercase
+            version = version.replace("snapshot", "SNAPSHOT");
+        }
+        return new ArtifactCoordinates(groupId, artifactId, version);
+    }
+
+    /**
+     * @return the id of the group of the artifact.
+     */
+    @NotNull
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @return the id of the artifact.
+     */
+    @NotNull
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    /**
+     * @return the version of the artifact.
+     */
+    @Nullable
+    public String getVersion() {
+        return version;
+    }
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
@@ -34,15 +34,7 @@ public class JavaCamelBeanReferenceSmartCompletionTestIT extends CamelLightCodeI
 
     private static final String SPRING_CONTEXT_MAVEN_ARTIFACT = "org.springframework:spring-context:5.1.6.RELEASE";
 
-    private static File[] springMavenArtifacts;
-
-    static {
-        try {
-            springMavenArtifacts = getMavenArtifacts(SPRING_CONTEXT_MAVEN_ARTIFACT);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+    private static final File[] springMavenArtifacts = getMavenArtifacts(SPRING_CONTEXT_MAVEN_ARTIFACT);
 
     @Override
     protected String getTestDataPath() {

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaHeaderNameCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaHeaderNameCompletionTestIT.java
@@ -31,20 +31,10 @@ import com.intellij.testFramework.PsiTestUtil;
  */
 public class JavaHeaderNameCompletionTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
-    private static String CAMEL_CORE_MODEL_MAVEN_ARTIFACT = "org.apache.camel:camel-core-model:%s";
-    private static String CAMEL_FILE_MAVEN_ARTIFACT = "org.apache.camel:camel-file:%s";
+    private static final String CAMEL_CORE_MODEL_MAVEN_ARTIFACT = String.format("org.apache.camel:camel-core-model:%s", CAMEL_VERSION);
+    private static final String CAMEL_FILE_MAVEN_ARTIFACT = String.format("org.apache.camel:camel-file:%s", CAMEL_VERSION);
 
-    private static final File[] mavenArtifacts;
-
-    static {
-        try {
-            CAMEL_CORE_MODEL_MAVEN_ARTIFACT = String.format(CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_VERSION);
-            CAMEL_FILE_MAVEN_ARTIFACT = String.format(CAMEL_FILE_MAVEN_ARTIFACT, CAMEL_VERSION);
-            mavenArtifacts = getMavenArtifacts(CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_FILE_MAVEN_ARTIFACT);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    private static final File[] mavenArtifacts = getMavenArtifacts(CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_FILE_MAVEN_ARTIFACT);
 
     protected void setUp() throws Exception {
         super.setUp();

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaHeaderValueCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaHeaderValueCompletionTestIT.java
@@ -30,20 +30,11 @@ import com.intellij.testFramework.PsiTestUtil;
  */
 public class JavaHeaderValueCompletionTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
-    private static String CAMEL_CORE_MODEL_MAVEN_ARTIFACT = "org.apache.camel:camel-core-model:%s";
-    private static String CAMEL_ATHENA_MAVEN_ARTIFACT = "org.apache.camel:camel-aws2-athena:%s";
+    private static final String CAMEL_CORE_MODEL_MAVEN_ARTIFACT = String.format("org.apache.camel:camel-core-model:%s", CAMEL_VERSION);
+    private static final String CAMEL_ATHENA_MAVEN_ARTIFACT = String.format("org.apache.camel:camel-aws2-athena:%s", CAMEL_VERSION);
 
-    private static final File[] mavenArtifacts;
+    private static final File[] mavenArtifacts = getMavenArtifacts(CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_ATHENA_MAVEN_ARTIFACT);
 
-    static {
-        try {
-            CAMEL_CORE_MODEL_MAVEN_ARTIFACT = String.format(CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_VERSION);
-            CAMEL_ATHENA_MAVEN_ARTIFACT = String.format(CAMEL_ATHENA_MAVEN_ARTIFACT, CAMEL_VERSION);
-            mavenArtifacts = getMavenArtifacts(CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_ATHENA_MAVEN_ARTIFACT);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     protected void setUp() throws Exception {
         super.setUp();

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionSpringBootLegacyTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionSpringBootLegacyTestIT.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.completion;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import com.intellij.openapi.roots.ModifiableRootModel;
+import org.codehaus.plexus.util.FileUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The integration test allowing to ensure that a specific legacy version of the catalog can be downloaded in case of
+ * the Spring Boot runtime.
+ */
+public class PropertiesPropertyKeyCompletionSpringBootLegacyTestIT extends PropertiesPropertyKeyCompletionSpringBootTestIT {
+
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{
+            "com.sun.xml.bind:jaxb-core:2.3.0",
+            "com.sun.xml.bind:jaxb-impl:2.3.0",
+            "org.apache.camel:camel-core:2.25.4",
+            "org.apache.camel:camel-spring-boot:2.25.4",
+            "org.apache.camel:camel-sql-starter:2.25.4"
+        };
+    }
+
+    @Override
+    protected void loadDependencies(@NotNull ModifiableRootModel model) {
+        // Ugly hack to prevent Grape issues due to the absence of jaxb-core-2.3.0.jar in the local maven repository only the pom exists
+        // Here we remove jaxb-core and jaxb-impl from the local maven repository and from the Gradle cache
+        // to ensure that the jar file will properly be downloaded along with its pom file
+        try {
+            File[] files = getMavenArtifacts("com.sun.xml.bind:jaxb-core:2.3.0", "org.apache.camel:camel-core:2.25.4");
+            // Remove the folder of jaxb-core and jaxb-impl from the Gradle cache
+            FileUtils.deleteDirectory(files[0].getParentFile().getParentFile().getParentFile().getParentFile());
+            // Remove the folder of jaxb-core and jaxb-impl from the local maven repository
+            FileUtils.deleteDirectory(
+                new File(
+                    files[1].getParentFile().getParentFile().getParentFile().getParentFile().getParentFile().getParentFile(),
+                    "com/sun/xml/bind"
+                )
+            );
+            super.loadDependencies(model);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void assertComponentOptionSuggestion(List<String> strings) {
+        assertContainsElements(strings, "camel.component.sql.data-source = ", "camel.component.sql.use-placeholder = ",
+            "camel.component.sql.resolve-property-placeholders = ", "camel.component.sql.enabled = ");
+    }
+
+    protected void assertDataFormatNameSuggestion(List<String> strings) {
+        assertContainsElements(strings, "camel.dataformat.json-jackson.", "camel.dataformat.csv.", "camel.dataformat.bindy-csv.");
+    }
+
+    /**
+     * Ensures that data format option suggestions can properly be proposed even with an old name.
+     */
+    public void testDataFormatOptionWithOldName() {
+        myFixture.configureByFiles(getFileName("data-format-options-with-old-name"));
+        myFixture.completeBasic();
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertContainsElements(
+            strings, "camel.dataformat.json-jackson.include = ", "camel.dataformat.json-jackson.pretty-print = ",
+            "camel.dataformat.json-jackson.json-view = "
+        );
+        assertDoesntContain(strings, "camel.dataformat.json-jackson.id = ");
+    }
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionSpringBootNoDownloadTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionSpringBootNoDownloadTestIT.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.completion;
+
+import com.github.cameltooling.idea.service.CamelPreferenceServiceMock;
+
+/**
+ * The integration test allowing to ensure that the internal catalog can be used in case of the Spring Boot runtime
+ * when the preference download artifact is disabled.
+ */
+public class PropertiesPropertyKeyCompletionSpringBootNoDownloadTestIT extends PropertiesPropertyKeyCompletionSpringBootTestIT {
+
+    @Override
+    protected void setUp() throws Exception {
+        CamelPreferenceServiceMock.setDownloadCatalogDisabled(true);
+        super.setUp();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            CamelPreferenceServiceMock.setDownloadCatalogDisabled(false);
+        } finally {
+            super.tearDown();
+        }
+    }
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionSpringBootTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionSpringBootTestIT.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.completion;
+
+import java.util.List;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The integration test allowing to ensure that a specific version 3 of the catalog can be downloaded in case of
+ * the Spring Boot runtime.
+ */
+public class PropertiesPropertyKeyCompletionSpringBootTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{
+            "org.apache.camel:camel-core-engine:3.16.0",
+            "org.apache.camel.springboot:camel-spring-boot:3.16.0",
+            "org.apache.camel.springboot:camel-sql-starter:3.16.0"
+        };
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources/testData/completion/property";
+    }
+
+    /**
+     * Ensures that group suggestions can properly be proposed.
+     */
+    public void testGroupSuggestion() {
+        myFixture.configureByFiles(getFileName("full-first-key-with-separator"));
+        myFixture.completeBasic();
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertDoesntContain(strings, "camel.main.");
+        assertContainsElements(strings, "camel.springboot.", "camel.component.", "camel.language.", "camel.dataformat.");
+    }
+
+    /**
+     * Ensures that main option suggestions can properly be proposed.
+     */
+    public void testMainOptionSuggestionNonFiltered() {
+        myFixture.configureByFiles(getFileName("springboot-options"));
+        myFixture.completeBasic();
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertContainsElements(strings, "camel.springboot.debugging = ", "camel.springboot.duration-max-seconds = ", "camel.springboot.auto-startup = ");
+    }
+
+    /**
+     * Ensures that component name suggestions can properly be proposed.
+     */
+    public void testComponentNameSuggestion() {
+        myFixture.configureByFiles(getFileName("component-names-non-filtered"));
+        myFixture.completeBasic();
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertContainsElements(strings, "camel.component.ftp.", "camel.component.bean.", "camel.component.cql.");
+    }
+
+    /**
+     * Ensures that component option suggestions can properly be proposed.
+     */
+    public void testComponentOptionSuggestion() {
+        myFixture.configureByFiles(getFileName("component-options"));
+        myFixture.completeBasic();
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertComponentOptionSuggestion(strings);
+    }
+
+    protected void assertComponentOptionSuggestion(List<String> strings) {
+        assertContainsElements(strings, "camel.component.sql.lazy-start-producer = ", "camel.component.sql.use-placeholder = ",
+            "camel.component.sql.bridge-error-handler = ", "camel.component.sql.enabled = ");
+    }
+
+    /**
+     * Ensures that language name suggestions can properly be proposed.
+     */
+    public void testLanguageNameSuggestion() {
+        myFixture.configureByFiles(getFileName("language-names"));
+        myFixture.completeBasic();
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertContainsElements(strings, "camel.language.jsonpath.", "camel.language.bean.", "camel.language.xpath.");
+    }
+
+    /**
+     * Ensures that data format name suggestions can properly be proposed.
+     */
+    public void testDataFormatNameSuggestion() {
+        myFixture.configureByFiles(getFileName("data-format-names-non-filtered"));
+        myFixture.completeBasic();
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertDataFormatNameSuggestion(strings);
+    }
+
+    protected void assertDataFormatNameSuggestion(List<String> strings) {
+        assertContainsElements(strings, "camel.dataformat.jackson.", "camel.dataformat.csv.", "camel.dataformat.bindyCsv.");
+    }
+
+    protected String getFileName(String fileNamePrefix) {
+        return String.format("%s.properties", fileNamePrefix);
+    }
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/reference/CamelBeanMethodReferenceTest.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/reference/CamelBeanMethodReferenceTest.java
@@ -37,15 +37,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 public class CamelBeanMethodReferenceTest extends CamelLightCodeInsightFixtureTestCaseIT {
     private static final String SPRING_CONTEXT_MAVEN_ARTIFACT = "org.springframework:spring-context:5.1.6.RELEASE";
 
-    private static File[] springMavenArtifacts;
-
-    static {
-        try {
-            springMavenArtifacts = getMavenArtifacts(SPRING_CONTEXT_MAVEN_ARTIFACT);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+    private static final File[] springMavenArtifacts = getMavenArtifacts(SPRING_CONTEXT_MAVEN_ARTIFACT);
 
     @Override
     protected void setUp() throws Exception {

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogServiceTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogServiceTestIT.java
@@ -71,7 +71,7 @@ public class CamelCatalogServiceTestIT extends CamelLightCodeInsightFixtureTestC
         CamelCatalog catalog = service.get();
         assertSame(catalog, service.get());
         CamelPreferenceService.getService().setCamelCatalogProvider(CamelCatalogProvider.QUARKUS);
-        assertFalse(service.isInstantiated());
+        assertTrue(service.isInstantiated());
         assertNotSame(catalog, service.get());
     }
 

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelPreferenceServiceMock.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelPreferenceServiceMock.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.service;
+
+/**
+ * a {@code CamelPreferenceService} for testing purpose.
+ */
+public class CamelPreferenceServiceMock extends CamelPreferenceService {
+
+    /**
+     * Flag indicating whether the preference "Download Catalog" should be disabled or not.
+     */
+    private static boolean DOWNLOAD_CATALOG_DISABLED;
+
+    @Override
+    public boolean isDownloadCatalog() {
+        if (DOWNLOAD_CATALOG_DISABLED) {
+            return false;
+        }
+        return super.isDownloadCatalog();
+    }
+
+    public static void setDownloadCatalogDisabled(boolean downloadCatalogDisabled) {
+        DOWNLOAD_CATALOG_DISABLED = downloadCatalogDisabled;
+    }
+}

--- a/camel-idea-plugin/src/test/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/test/resources/META-INF/plugin.xml
@@ -1,0 +1,14 @@
+<idea-plugin>
+    <name>Apache Camel Integration Tests</name>
+    <id>org.apache.camel.tests</id>
+    <description>Overriding services for testing purpose.</description>
+
+    <depends>org.apache.camel</depends>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceInterface="com.github.cameltooling.idea.service.CamelPreferenceService"
+                            serviceImplementation="com.github.cameltooling.idea.service.CamelPreferenceServiceMock"
+                            overrides="true" />
+    </extensions>
+
+</idea-plugin>

--- a/camel-idea-plugin/src/test/resources/log4j.properties
+++ b/camel-idea-plugin/src/test/resources/log4j.properties
@@ -16,11 +16,11 @@
 ## ---------------------------------------------------------------------------
 
 #
-# The logging properties used during tests..
+# The logging properties used during tests.
 #
 log4j.rootLogger=INFO, file
 
-#log4j.logger.org.apache.camel.idea=DEBUG
+#log4j.logger.com.github.cameltooling.idea=DEBUG
 
 # CONSOLE appender not used by default
 log4j.appender.out=org.apache.log4j.ConsoleAppender

--- a/camel-idea-plugin/src/test/resources/testData/completion/property/component-options.properties
+++ b/camel-idea-plugin/src/test/resources/testData/completion/property/component-options.properties
@@ -1,0 +1,1 @@
+camel.component.sql.<caret>

--- a/camel-idea-plugin/src/test/resources/testData/completion/property/data-format-options-with-old-name.properties
+++ b/camel-idea-plugin/src/test/resources/testData/completion/property/data-format-options-with-old-name.properties
@@ -1,0 +1,1 @@
+camel.dataformat.json-jackson.<caret>

--- a/camel-idea-plugin/src/test/resources/testData/completion/property/springboot-options.properties
+++ b/camel-idea-plugin/src/test/resources/testData/completion/property/springboot-options.properties
@@ -1,0 +1,1 @@
+camel.springboot.<caret>


### PR DESCRIPTION
fixes #700

## Motivation:

If we use a specific version of Camel that is not the same as the one included in the plugin and the Camel Runtime is not the default one, then the metadata are not properly loaded consequently the name of components, languages, data formats cannot be retrieved when using Spring Boot as Camel Runtime.

## Modifications:

* Add the ability to load also the runtime provider version
* Add a dynamic way to detect a runtime provider
* Add a dynamic way to find the catalog corresponding to a runtime provider
* Add the ability to support legacy runtime provider in case of Spring Boot
* Enable the cache of the catalog only when it is ready to use
* Clean up the class `CamelMavenVersionManager` by removing dead code, adding some log messages in case of errors and adding a utility method to avoid code duplication (not related to the initial issue)
* Make `CamelPreferenceService` non final to be able to extend it for testing purpose see the class `CamelPreferenceServiceMock`
* Rewrite `CamelService` in order to support properly the ability to download the catalog of specific runtime provider.
* Clean up  `CamelService` by fixing deprecated methods, using try-with-resource statement, avoiding to catch `Throwable`, simplifying over complicated tests and adding a utility method to parse the coordinates of an artifact represented by the new class `ArtifactCoordinates` (not related to the initial issue)
* Improve the base test class `CamelLightCodeInsightFixtureTestCaseIT` to properly add dependencies to a test project
* Define a new plugin for testing purpose only to override `CamelPreferenceService` with `CamelPreferenceServiceMock` in order to disable the preference "Download Catalog"
* Remove the exclusion of some tests in the Gradle configuration since they are already commented so it is useless (not related to the initial issue)
* Add some options commented by default for the tests for debugging purpose  (not related to the initial issue)
* Cleanup the code allowing to retrieve artifacts from maven (method `getMavenArtifacts`) by removing the code to catch `IOException` as it doesn't actually throw this type of exception.

## Result

It is now possible to use a different version of Camel even legacy ones