### PR TITLE
Ref #590 - Re-add tests easy to fix

### DIFF
--- a/camel-idea-plugin/build.gradle
+++ b/camel-idea-plugin/build.gradle
@@ -70,14 +70,6 @@ dependencies {
 
 description = 'Apache Camel IDE :: IDEA Plugin'
 
-tasks.register('prepareTest') {
-    doFirst {
-        project.file('build/mockJDK-11').mkdirs()
-    }
-}
-
-tasks.test.dependsOn("prepareTest")
-
 test {
 // Start: To get Grape log messages
 //    systemProperty("groovy.grape.report.downloads", "true")

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/BeanReferenceTypeAnnotator.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/BeanReferenceTypeAnnotator.java
@@ -91,7 +91,7 @@ public class BeanReferenceTypeAnnotator extends AbstractCamelAnnotator {
     }
 
     private boolean isBeanReference(PsiElement element) {
-        return Arrays.stream(element.getReferences()).anyMatch(ref -> ref instanceof BeanReference);
+        return Arrays.stream(element.getReferences()).anyMatch(BeanReference.class::isInstance);
     }
 
     private boolean isBeanPropertyReference(PsiElement element) {

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/annotator/CamelSimpleAnnotatorTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/annotator/CamelSimpleAnnotatorTestIT.java
@@ -17,6 +17,7 @@
 package com.github.cameltooling.idea.annotator;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Test Camel simple validation and the expected value is highlighted
@@ -30,6 +31,12 @@ import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
  */
 public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{CAMEL_CORE_MODEL_MAVEN_ARTIFACT};
+    }
+
     @Override
     protected String getTestDataPath() {
         return "src/test/resources/testData/annotator";
@@ -41,11 +48,10 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
 //        myFixture.checkHighlighting(false, false, true, true);
 //    }
 
-//    @Ignore
-//    public void testAnnotatorLogValidation() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaWithLog());
-//        myFixture.checkHighlighting(false, false, true, true);
-//    }
+    public void testAnnotatorLogValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaWithLog());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
 
     public void testAnnotatorLogValidation2() {
         myFixture.configureByText("AnnotatorTestData.java", getJavaWithFilterAndLog());
@@ -64,17 +70,15 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
 //        myFixture.checkHighlighting(false, false, true, true);
 //    }
 
-//    @Ignore
-//    public void testAnnotatorCamelPredicateValidation() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaWithCamelPredicate());
-//        myFixture.checkHighlighting(false, false, false, true);
-//    }
+    public void testAnnotatorCamelPredicateValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaWithCamelPredicate());
+        myFixture.checkHighlighting(false, false, false, true);
+    }
 
-//    @Ignore
-//    public void testAnnotatorJavaMultilinePredicateValidation() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaMultilinePredicate());
-//        myFixture.checkHighlighting(false, false, false, true);
-//    }
+    public void testAnnotatorJavaMultilinePredicateValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaMultilinePredicate());
+        myFixture.checkHighlighting(false, false, false, true);
+    }
 
 //    @Ignore
 //    public void testAnnotatorCamelPredicateValidation2() {
@@ -82,11 +86,10 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
 //        myFixture.checkHighlighting(false, false, false, true);
 //    }
 
-//    @Ignore
-//    public void testXmlAnnotatorSimpleValidation2() {
-//        myFixture.configureByText("AnnotatorTestData.xml", getXmlWithSimple());
-//        myFixture.checkHighlighting(false, false, false, true);
-//    }
+    public void testXmlAnnotatorSimpleValidation2() {
+        myFixture.configureByText("AnnotatorTestData.xml", getXmlWithSimple());
+        myFixture.checkHighlighting(false, false, false, true);
+    }
 
 //    @Ignore
 //    public void testXmlAnnotatorPredicateValidation2() {
@@ -96,15 +99,15 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
 //    }
 
 //    @Ignore
-//    public void testXmlAnnotatorWithLogValidation() {
-//        myFixture.configureByText("AnnotatorTestData.xml", getXmlWithLog());
-//        myFixture.checkHighlighting(false, false, false, true);
-//    }
+    public void testXmlAnnotatorWithLogValidation() {
+        myFixture.configureByText("AnnotatorTestData.xml", getXmlWithLog());
+        myFixture.checkHighlighting(false, false, false, true);
+    }
 
     private String getJavaWithSimple() {
         return "import org.apache.camel.builder.RouteBuilder;\n"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
-            + "        public void configure() throws Exception {\n"
+            + "        public void configure() {\n"
             + "            from(\"netty-http:http://localhost/cdi?matchOnUriPrefix=true&nettySharedHttpServer=#httpServer\")\n"
             + "            .id(\"http-route-cdi\")\n"
             + "            .transform()\n"
@@ -116,7 +119,7 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
     private String getJavaWithLog() {
         return "import org.apache.camel.builder.RouteBuilder;"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
-            + "    public void configure() throws Exception {\n"
+            + "    public void configure() {\n"
             + "      from(\"timer:stream?repeatCount=1\")\n"
             + "           .log(\"Result from query <error descr=\"Unknown function: xbody\">${xbody}</error>\")\n"
             + "           .process(exchange -> {\n"
@@ -129,7 +132,7 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
     private String getJavaWithFilterAndLog() {
         return "import org.apache.camel.builder.RouteBuilder;\n"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
-            + "    public void configure() throws Exception {\n"
+            + "    public void configure() {\n"
             + "      from(\"direct:foo\")\n"
             + "         .filter(header(Exchange.REDELIVERED))\n"
             + "           .log(LoggingLevel.WARN, \"Processed ${body} after ${header.CamelRedeliveryCount} retries\")\n"
@@ -141,7 +144,7 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
     private String getJavaOpenBracketWithSimple() {
         return "import org.apache.camel.builder.RouteBuilder;\n"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
-            + "        public void configure() throws Exception {\n"
+            + "        public void configure() {\n"
             + "            from(\"netty-http:http://localhost/cdi?matchOnUriPrefix=true&nettySharedHttpServer=#httpServer\")\n"
             + "            .id(\"http-route-cdi\")\n"
             + "            .transform()\n"
@@ -153,7 +156,7 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
     private String getJavaMutlipleOpenBracketWithSimple() {
         return "import org.apache.camel.builder.RouteBuilder;\n"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
-            + "        public void configure() throws Exception {\n"
+            + "        public void configure() {\n"
             + "            from(\"netty-http:http://localhost/cdi?matchOnUriPrefix=true&nettySharedHttpServer=#httpServer\")\n"
             + "            .id(\"http-route-cdi\")\n"
             + "            .transform()\n"
@@ -165,7 +168,7 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
     private String getJavaWithCamelPredicate() {
         return "import org.apache.camel.builder.RouteBuilder;\n"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
-            + "        public void configure() throws Exception {\n"
+            + "        public void configure() {\n"
             + "              from(\"direct:start\")\n"
             + "                .loopDoWhile(simple(\"${body.length} <error descr=\"Unexpected token =\">=!=</error> 12\"))\n"
             + "                .to(\"mock:loop\")\n"
@@ -178,7 +181,7 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
     private String getJavaWithCamelPredicate2() {
         return "import org.apache.camel.builder.RouteBuilder;\n"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
-            + "        public void configure() throws Exception {\n"
+            + "        public void configure() {\n"
             + "              from(\"direct:start\")\n"
             + "                .loopDoWhile(simple(\"${body.length} != 12\"))\n"
             + "                .filter().simple(<error descr=\"Unknown function: xxxx\">\"${xxxx}\"</error>)\n"
@@ -194,7 +197,7 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
     private String getJavaMultilinePredicate() {
         return "import org.apache.camel.builder.RouteBuilder;\n"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
-            + "        public void configure() throws Exception {\n"
+            + "        public void configure() {\n"
             + " from(\"timer:trigger\")\n"
             + "            .choice()\n"
             + "                .when(xpath(\"/person/city = 'London'\"))\n"

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
@@ -16,14 +16,12 @@
  */
 package com.github.cameltooling.idea.completion;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.codeInsight.completion.CompletionType;
-import com.intellij.testFramework.PsiTestUtil;
 import org.hamcrest.Matchers;
+import org.jetbrains.annotations.Nullable;
 
 import static org.junit.Assert.assertThat;
 
@@ -33,8 +31,6 @@ import static org.junit.Assert.assertThat;
 public class JavaCamelBeanReferenceSmartCompletionTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
     private static final String SPRING_CONTEXT_MAVEN_ARTIFACT = "org.springframework:spring-context:5.1.6.RELEASE";
-
-    private static final File[] springMavenArtifacts = getMavenArtifacts(SPRING_CONTEXT_MAVEN_ARTIFACT);
 
     @Override
     protected String getTestDataPath() {
@@ -121,10 +117,10 @@ public class JavaCamelBeanReferenceSmartCompletionTestIT extends CamelLightCodeI
             + "   private void thisIsVeryPrivate() {}\n"
             + "}";
 
+    @Nullable
     @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), getModule(), "Maven: " + SPRING_CONTEXT_MAVEN_ARTIFACT, springMavenArtifacts[0].getParent(), springMavenArtifacts[0].getName());
+    protected String[] getMavenDependencies() {
+        return new String[]{SPRING_CONTEXT_MAVEN_ARTIFACT};
     }
 
     public void testJavaBeanTestDataCompletionWithIncorrectBeanRef() {

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaEndpointSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaEndpointSmartCompletionTestIT.java
@@ -63,7 +63,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         assertThat(strings, Matchers.not(Matchers.contains("timer:trigger?repeatCount=10")));
         assertThat(strings, Matchers.contains("timer:trigger?repeatCount=10&exceptionHandler",
             "timer:trigger?repeatCount=10&exchangePattern"));
-        assertTrue("There is less options", strings.size() == 2);
+        assertEquals("There is less options", 2, strings.size());
     }
 
     private String getJavaInTheMiddleOfResolvedOptionsData() {
@@ -80,7 +80,8 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         myFixture.configureByText("JavaCaretInMiddleOptionsTestData.java", getJavaInTheMiddleOfResolvedOptionsData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertTrue("Expect 0 options", strings.size() == 0);
+        assertNotNull(strings);
+        assertEquals("Expect 0 options", 0, strings.size());
     }
 
     private String getJavaAfterAmpOptionsTestData() {
@@ -92,27 +93,25 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
             + "        }\n"
             + "    }";
     }
-//    @Ignore
-//    public void testJavaAfterAmbeCompletion() {
-//        myFixture.configureByText("JavaCaretInMiddleOptionsTestData.java", getJavaAfterAmpOptionsTestData());
-//        myFixture.complete(CompletionType.BASIC, 1);
-//        List<String> strings = myFixture.getLookupElementStrings();
-//        assertThat(strings, Matchers.not(Matchers.contains("timer:trigger?repeatCount=10")));
-//        assertThat(strings, Matchers.contains("timer:trigger?repeatCount=10&bridgeErrorHandler",
-//            "timer:trigger?repeatCount=10&daemon",
-//            "timer:trigger?repeatCount=10&delay",
-//            "timer:trigger?repeatCount=10&exceptionHandler",
-//            "timer:trigger?repeatCount=10&exchangePattern",
-//            "timer:trigger?repeatCount=10&fixedRate",
-//            "timer:trigger?repeatCount=10&pattern",
-//            "timer:trigger?repeatCount=10&period",
-//            "timer:trigger?repeatCount=10&synchronous",
-//            "timer:trigger?repeatCount=10&time",
-//            "timer:trigger?repeatCount=10&timer"));
-//        assertTrue("There is less options", strings.size() < 13);
-//    }
-
-
+    public void testJavaAfterAmpOptionsCompletion() {
+        myFixture.configureByText("JavaCaretInMiddleOptionsTestData.java", getJavaAfterAmpOptionsTestData());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertDoesntContain(strings, "timer:trigger?repeatCount=10");
+        assertContainsElements(strings, "timer:trigger?repeatCount=10&bridgeErrorHandler",
+            "timer:trigger?repeatCount=10&daemon",
+            "timer:trigger?repeatCount=10&delay",
+            "timer:trigger?repeatCount=10&exceptionHandler",
+            "timer:trigger?repeatCount=10&exchangePattern",
+            "timer:trigger?repeatCount=10&fixedRate",
+            "timer:trigger?repeatCount=10&pattern",
+            "timer:trigger?repeatCount=10&period",
+            "timer:trigger?repeatCount=10&synchronous",
+            "timer:trigger?repeatCount=10&time",
+            "timer:trigger?repeatCount=10&timer");
+        assertTrue("There is less options", strings.size() < 13);
+    }
 
     private String getJavaCaretAfterQuestionMarkWithPreDataOptionsTestData() {
         return "import org.apache.camel.builder.RouteBuilder;\n"
@@ -143,6 +142,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         myFixture.configureByText("JavaCaretInMiddleOptionsTestData.java", getJavaEndOfLineTestData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertTrue("There is many options", strings.size() > 9);
     }
 
@@ -162,7 +162,8 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         myFixture.configureByText("JavaCaretInMiddleOptionsTestData.java", javaInsertAfterQuestionMarkTestData);
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertTrue("There is many options", strings.size() == 1);
+        assertNotNull(strings);
+        assertEquals("There is many options", 1, strings.size());
         assertThat(strings, Matchers.contains("timer:trigger?period"));
         myFixture.type('\n');
         javaInsertAfterQuestionMarkTestData = javaInsertAfterQuestionMarkTestData.replace("<caret>", "iod=");
@@ -184,6 +185,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         myFixture.configureByText("CamelRoute.java", getJavaMultilineTestData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertTrue("There is many options", strings.size() > 1);
         assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
             "timer:trigger?repeatCount=10&",
@@ -210,6 +212,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         myFixture.configureByText("CamelRoute.java", getJavaMultilineTest2Data());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertTrue("There is many options", strings.size() > 1);
         assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
             "timer:trigger?repeatCount=10",
@@ -236,6 +239,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         myFixture.configureByText("CamelRoute.java", getJavaMultilineTest3Data());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertTrue("There is many options", strings.size() > 1);
         assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
             "timer:trigger?repeatCount=10",
@@ -262,6 +266,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         myFixture.configureByText("CamelRoute.java", getJavaMultilineInFixSearchData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertTrue("There is many options", strings.size() > 1);
         assertThat(strings, Matchers.containsInAnyOrder("&exceptionHandler", "&exchangePattern"));
         assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
@@ -289,6 +294,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         myFixture.configureByText("CamelRoute.java", getJavaMultilineTest4SearchData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertTrue("There is many options", strings.size() > 1);
         assertThat(strings, Matchers.not(Matchers.containsInAnyOrder(
             "timer:trigger?repeatCount=10",

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaEndpointSmartCompletionValueTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaEndpointSmartCompletionValueTestIT.java
@@ -16,7 +16,6 @@
  */
 package com.github.cameltooling.idea.completion;
 
-import java.util.Collections;
 import java.util.List;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
@@ -34,6 +33,7 @@ public class JavaEndpointSmartCompletionValueTestIT extends CamelLightCodeInsigh
         myFixture.configureByFiles("CompleteJavaEndpointValueEnumTestData.java");
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertEquals(8, strings.size());
         assertThat(strings, Matchers.contains("file:inbox?readLock=changed", "file:inbox?readLock=fileLock", "file:inbox?readLock=idempotent",
             "file:inbox?readLock=idempotent-changed", "file:inbox?readLock=idempotent-rename", "file:inbox?readLock=markerFile",
@@ -44,6 +44,7 @@ public class JavaEndpointSmartCompletionValueTestIT extends CamelLightCodeInsigh
         myFixture.configureByFiles("CompleteJavaEndpointValueDefaultTestData.java");
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertEquals(1, strings.size());
         assertThat(strings, Matchers.contains("file:inbox?delay=500"));
     }
@@ -52,6 +53,7 @@ public class JavaEndpointSmartCompletionValueTestIT extends CamelLightCodeInsigh
         myFixture.configureByFiles("CompleteJavaEndpointValueBooleanTestData.java");
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertEquals(2, strings.size());
         assertThat(strings, Matchers.contains("file:inbox?delay=1000&recursive=false", "file:inbox?delay=1000&recursive=true"));
     }
@@ -69,7 +71,8 @@ public class JavaEndpointSmartCompletionValueTestIT extends CamelLightCodeInsigh
         myFixture.configureByText("JavaCaretInMiddleOptionsTestData.java", getJavaInTheMiddleUnresolvedValueTestData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertFalse(strings.containsAll(Collections.singletonList("timer:trigger?repeatCount=10")));
+        assertNotNull(strings);
+        assertDoesntContain(strings, "timer:trigger?repeatCount=10");
         assertThat(strings, Matchers.contains("timer:trigger?repeatCount=10&fixedRate=false", "timer:trigger?repeatCount=10&fixedRate=true"));
         assertEquals(2, strings.size());
     }
@@ -83,20 +86,17 @@ public class JavaEndpointSmartCompletionValueTestIT extends CamelLightCodeInsigh
             + "        }\n"
             + "    }";
     }
-//    @Ignore
-//    public void testUnresolvedValueWithPreTestCompletion() {
-//        myFixture.configureByText("JavaCaretInMiddleOptionsTestData.java", getJavaUnresolvedValueWithPreTestData());
-//        myFixture.complete(CompletionType.BASIC, 1);
-//        List<String> strings = myFixture.getLookupElementStrings();
-//        assertFalse(strings.containsAll(Collections.singletonList("timer:trigger?repeatCount=10")));
-//        assertThat(strings, Matchers.containsInAnyOrder(
-//            "timer:trigger?exchangePattern=InOut",
-//            "timer:trigger?exchangePattern=InOnly",
-//            "timer:trigger?exchangePattern=InOptionalOut",
-//            "timer:trigger?exchangePattern=OutIn",
-//            "timer:trigger?exchangePattern=RobustInOnly",
-//            "timer:trigger?exchangePattern=OutOptionalIn"));
-//        assertEquals(6, strings.size());
-//    }
+    public void testUnresolvedValueWithPreTestCompletion() {
+        myFixture.configureByText("JavaCaretInMiddleOptionsTestData.java", getJavaUnresolvedValueWithPreTestData());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertDoesntContain(strings, "timer:trigger?repeatCount=10");
+        assertContainsElements(strings,
+            "timer:trigger?exchangePattern=InOut",
+            "timer:trigger?exchangePattern=InOnly",
+            "timer:trigger?exchangePattern=InOptionalOut");
+        assertEquals(3, strings.size());
+    }
 
 }

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaHeaderNameCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaHeaderNameCompletionTestIT.java
@@ -16,15 +16,13 @@
  */
 package com.github.cameltooling.idea.completion;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.codeInsight.lookup.LookupElement;
-import com.intellij.testFramework.PsiTestUtil;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Testing the completion of the header names based on the headers defined in the metadata of a component.
@@ -34,12 +32,10 @@ public class JavaHeaderNameCompletionTestIT extends CamelLightCodeInsightFixture
     private static final String CAMEL_CORE_MODEL_MAVEN_ARTIFACT = String.format("org.apache.camel:camel-core-model:%s", CAMEL_VERSION);
     private static final String CAMEL_FILE_MAVEN_ARTIFACT = String.format("org.apache.camel:camel-file:%s", CAMEL_VERSION);
 
-    private static final File[] mavenArtifacts = getMavenArtifacts(CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_FILE_MAVEN_ARTIFACT);
-
-    protected void setUp() throws Exception {
-        super.setUp();
-        PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), myFixture.getModule(), "Maven: " + CAMEL_CORE_MODEL_MAVEN_ARTIFACT, mavenArtifacts[0].getParent(), mavenArtifacts[0].getName());
-        PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), myFixture.getModule(), "Maven: " + CAMEL_FILE_MAVEN_ARTIFACT, mavenArtifacts[1].getParent(), mavenArtifacts[1].getName());
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_FILE_MAVEN_ARTIFACT};
     }
 
     @Override

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaHeaderValueCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaHeaderValueCompletionTestIT.java
@@ -16,14 +16,12 @@
  */
 package com.github.cameltooling.idea.completion;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.codeInsight.lookup.LookupElement;
-import com.intellij.testFramework.PsiTestUtil;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Testing the completion of the header values based on the headers defined in the metadata of a component.
@@ -33,13 +31,10 @@ public class JavaHeaderValueCompletionTestIT extends CamelLightCodeInsightFixtur
     private static final String CAMEL_CORE_MODEL_MAVEN_ARTIFACT = String.format("org.apache.camel:camel-core-model:%s", CAMEL_VERSION);
     private static final String CAMEL_ATHENA_MAVEN_ARTIFACT = String.format("org.apache.camel:camel-aws2-athena:%s", CAMEL_VERSION);
 
-    private static final File[] mavenArtifacts = getMavenArtifacts(CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_ATHENA_MAVEN_ARTIFACT);
-
-
-    protected void setUp() throws Exception {
-        super.setUp();
-        PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), myFixture.getModule(), "Maven: " + CAMEL_CORE_MODEL_MAVEN_ARTIFACT, mavenArtifacts[0].getParent(), mavenArtifacts[0].getName());
-        PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), myFixture.getModule(), "Maven: " + CAMEL_ATHENA_MAVEN_ARTIFACT, mavenArtifacts[1].getParent(), mavenArtifacts[1].getName());
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_ATHENA_MAVEN_ARTIFACT};
     }
 
     @Override

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertyEndpointSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertyEndpointSmartCompletionTestIT.java
@@ -38,7 +38,8 @@ public class PropertyEndpointSmartCompletionTestIT extends CamelLightCodeInsight
         myFixture.configureByText("TestData.properties", insertAfterQuestionMarkTestData);
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertTrue("There is many options", strings.size() == 1);
+        assertNotNull(strings);
+        assertEquals("There is many options", 1, strings.size());
         assertThat(strings, Matchers.contains("timer:trigger?period"));
         myFixture.type('\n');
         insertAfterQuestionMarkTestData = insertAfterQuestionMarkTestData.replace("<caret>", "iod=");
@@ -53,6 +54,7 @@ public class PropertyEndpointSmartCompletionTestIT extends CamelLightCodeInsight
         myFixture.configureByText("TestData.properties", getEndOfLineTestData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertTrue("There is many options", strings.size() > 9);
     }
 
@@ -67,29 +69,29 @@ public class PropertyEndpointSmartCompletionTestIT extends CamelLightCodeInsight
         assertNull("Don't except any elements, because it the 're' is unique and return the repeatCount", strings);
     }
 
-    private String getfterAmpOptionsTestData() {
+    private String getAfterAmpOptionsTestData() {
         return "TIME=timer:trigger?repeatCount=10&<caret>";
     }
 
-//    @Ignore
-//    public void testAfterAmpCompletion() {
-//        myFixture.configureByText("TestData.properties", getfterAmpOptionsTestData());
-//        myFixture.complete(CompletionType.BASIC, 1);
-//        List<String> strings = myFixture.getLookupElementStrings();
-//        assertThat(strings, Matchers.not(Matchers.contains("timer:trigger?repeatCount=10")));
-//        assertThat(strings, Matchers.contains("timer:trigger?repeatCount=10&bridgeErrorHandler",
-//            "timer:trigger?repeatCount=10&daemon",
-//            "timer:trigger?repeatCount=10&delay",
-//            "timer:trigger?repeatCount=10&exceptionHandler",
-//            "timer:trigger?repeatCount=10&exchangePattern",
-//            "timer:trigger?repeatCount=10&fixedRate",
-//            "timer:trigger?repeatCount=10&pattern",
-//            "timer:trigger?repeatCount=10&period",
-//            "timer:trigger?repeatCount=10&synchronous",
-//            "timer:trigger?repeatCount=10&time",
-//            "timer:trigger?repeatCount=10&timer"));
-//        assertTrue("There is less options", strings.size() < 13);
-//    }
+    public void testAfterAmpCompletion() {
+        myFixture.configureByText("TestData.properties", getAfterAmpOptionsTestData());
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertDoesntContain(strings, "timer:trigger?repeatCount=10");
+        assertContainsElements(strings, "timer:trigger?repeatCount=10&bridgeErrorHandler",
+            "timer:trigger?repeatCount=10&daemon",
+            "timer:trigger?repeatCount=10&delay",
+            "timer:trigger?repeatCount=10&exceptionHandler",
+            "timer:trigger?repeatCount=10&exchangePattern",
+            "timer:trigger?repeatCount=10&fixedRate",
+            "timer:trigger?repeatCount=10&pattern",
+            "timer:trigger?repeatCount=10&period",
+            "timer:trigger?repeatCount=10&synchronous",
+            "timer:trigger?repeatCount=10&time",
+            "timer:trigger?repeatCount=10&timer");
+        assertTrue("There is less options", strings.size() < 13);
+    }
 
     private String getInTheMiddleOfResolvedOptionsData() {
         return "TIMER=timer:trigger?repeatCount=10&fixed<caret>Rate=false";
@@ -99,7 +101,8 @@ public class PropertyEndpointSmartCompletionTestIT extends CamelLightCodeInsight
         myFixture.configureByText("TestData.properties", getInTheMiddleOfResolvedOptionsData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
-        assertTrue("Expect 0 options", strings.size() == 0);
+        assertNotNull(strings);
+        assertEquals("Expect 0 options", 0, strings.size());
     }
 
     private String getInTheMiddleUnresolvedOptionsTestData() {
@@ -113,7 +116,7 @@ public class PropertyEndpointSmartCompletionTestIT extends CamelLightCodeInsight
         assertThat(strings, Matchers.not(Matchers.contains("timer:trigger?repeatCount=10")));
         assertThat(strings, Matchers.contains("timer:trigger?repeatCount=10&exceptionHandler",
             "timer:trigger?repeatCount=10&exchangePattern"));
-        assertTrue("Expect exactly 2 options", strings.size() == 2);
+        assertEquals("Expect exactly 2 options", 2, strings.size());
         myFixture.type('\n');
         String result = getInTheMiddleUnresolvedOptionsTestData().replace("<caret>", "ceptionHandler=");
         myFixture.checkResult(result);
@@ -127,6 +130,7 @@ public class PropertyEndpointSmartCompletionTestIT extends CamelLightCodeInsight
         myFixture.configureByText("TestData.properties", getAfterValueWithOutAmpTestData());
         myFixture.complete(CompletionType.BASIC, 1);
         List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
         assertTrue("There is less options", strings.size() > 10);
         myFixture.type('\n');
         String result = getAfterValueWithOutAmpTestData().replace("<caret>", "&bridgeErrorHandler=");

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/documentation/CamelDocumentationProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/documentation/CamelDocumentationProviderTestIT.java
@@ -87,7 +87,6 @@ public class CamelDocumentationProviderTestIT extends CamelLightCodeInsightFixtu
         return "src/test/resources/testData/documentation/";
     }
 
-//    @Ignore
     public void testJavaClassQuickNavigateInfo() throws Exception {
         myFixture.configureByText(JavaFileType.INSTANCE, getJavaTestWithCursorBeforeCamelComponent());
 

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/documentation/CamelSmartCompletionDocumentationTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/documentation/CamelSmartCompletionDocumentationTestIT.java
@@ -54,27 +54,26 @@ public class CamelSmartCompletionDocumentationTestIT extends CamelLightCodeInsig
         PsiElement docInfo = new CamelDocumentationProvider().getDocumentationElementForLookupItem(manager, lookup, element);
 
         CamelDocumentationProvider.DocumentationElement de = (CamelDocumentationProvider.DocumentationElement) docInfo;
+        assertNotNull(de);
         assertEquals(componentName, de.getComponentName());
         assertEquals("delete", de.getText());
         assertEquals("delete", de.getEndpointOption());
     }
 
-//    @Ignore
-//    public void testXMLQuickDocCaretOnAmpersand() throws Exception {
-//        myFixture.configureByFile("XmlCamelRouteQuickDocCaretOnAmpTestData.xml");
-//        PsiElement element = getElementAtCaret();
-//        assertNotNull(element);
-//        CamelDocumentationProvider camelDocumentationProvider = new CamelDocumentationProvider();
-//        assertEquals(element.getParent(), camelDocumentationProvider.getCustomDocumentationElement(myFixture.getEditor(), myFixture.getFile(), element));
-//    }
-//
-//    @Ingore
-//    public void testXMLQuickDocCaretAtTheEndOfTheRoute() throws Exception {
-//        myFixture.configureByFile("XmlCamelRouteQuickDocCaretAtTheEndTestData.xml");
-//        PsiElement element = getElementAtCaret();
-//        assertNotNull(element);
-//        CamelDocumentationProvider camelDocumentationProvider = new CamelDocumentationProvider();
-//        assertEquals(element.getParent(), camelDocumentationProvider.getCustomDocumentationElement(myFixture.getEditor(), myFixture.getFile(), element));
-//    }
+    public void testXMLQuickDocCaretOnAmpersand() {
+        myFixture.configureByFile("XmlCamelRouteQuickDocCaretOnAmpTestData.xml");
+        PsiElement element = getElementAtCaret();
+        assertNotNull(element);
+        CamelDocumentationProvider camelDocumentationProvider = new CamelDocumentationProvider();
+        assertEquals(element.getParent(), camelDocumentationProvider.getCustomDocumentationElement(myFixture.getEditor(), myFixture.getFile(), element, 0));
+    }
+
+    public void testXMLQuickDocCaretAtTheEndOfTheRoute() {
+        myFixture.configureByFile("XmlCamelRouteQuickDocCaretAtTheEndTestData.xml");
+        PsiElement element = getElementAtCaret();
+        assertNotNull(element);
+        CamelDocumentationProvider camelDocumentationProvider = new CamelDocumentationProvider();
+        assertEquals(element.getParent(), camelDocumentationProvider.getCustomDocumentationElement(myFixture.getEditor(), myFixture.getFile(), element, 0));
+    }
 
 }

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectJavaEndpointTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectJavaEndpointTestIT.java
@@ -16,8 +16,10 @@
  */
 package com.github.cameltooling.idea.inspection;
 
-/*
-public class CamelInspectJavaEndpointTestIT extends InspectionTestCase {
+import com.intellij.codeInspection.ex.LocalInspectionToolWrapper;
+import com.intellij.testFramework.JavaInspectionTestCase;
+
+public class CamelInspectJavaEndpointTestIT extends JavaInspectionTestCase {
 
     @Override
     protected String getTestDataPath() {
@@ -32,4 +34,3 @@ public class CamelInspectJavaEndpointTestIT extends InspectionTestCase {
     }
 
 }
-*/

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectJavaSimpleTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectJavaSimpleTestIT.java
@@ -16,23 +16,16 @@
  */
 package com.github.cameltooling.idea.inspection;
 
-/*
 import com.intellij.codeInspection.ex.LocalInspectionToolWrapper;
-import com.intellij.testFramework.JavaInspectionTestCase;
-import com.intellij.testFramework.PsiTestUtil;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
-
-import java.io.File;
+import org.jetbrains.annotations.Nullable;
 
 
-public class CamelInspectJavaSimpleTestIT extends JavaInspectionTestCase {
-    public static final String CAMEL_CORE_MAVEN_ARTIFACT = "org.apache.camel:camel-core:2.22.0";
+public class CamelInspectJavaSimpleTestIT extends CamelInspectionTestHelper {
 
+    @Nullable
     @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        File[] mavenArtifacts =  Maven.resolver().resolve(CAMEL_CORE_MAVEN_ARTIFACT).withoutTransitivity().asFile();
-        PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), myFixture.getModule(), "Maven: " + CAMEL_CORE_MAVEN_ARTIFACT, mavenArtifacts[0].getParent(), mavenArtifacts[0].getName());
+    protected String[] getMavenDependencies() {
+        return new String[]{CAMEL_CORE_MAVEN_ARTIFACT};
     }
 
     @Override
@@ -47,6 +40,4 @@ public class CamelInspectJavaSimpleTestIT extends JavaInspectionTestCase {
         // must be called fooroute as inspectionsimplejava fails for some odd reason
         doTest("testData/fooroute/", new LocalInspectionToolWrapper(inspection));
     }
-
 }
-*/

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectXmlSimpleTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectXmlSimpleTestIT.java
@@ -16,21 +16,10 @@
  */
 package com.github.cameltooling.idea.inspection;
 
-/*
 import com.intellij.codeInspection.ex.LocalInspectionToolWrapper;
-import com.intellij.testFramework.PsiTestUtil;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
-
-import java.io.File;
+import org.jetbrains.annotations.Nullable;
 
 public class CamelInspectXmlSimpleTestIT extends CamelInspectionTestHelper {
-
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        File[] mavenArtifacts =  Maven.resolver().resolve(CAMEL_CORE_MAVEN_ARTIFACT).withoutTransitivity().asFile();
-        PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), myFixture.getModule(), "Maven: " + CAMEL_CORE_MAVEN_ARTIFACT, mavenArtifacts[0].getParent(), mavenArtifacts[0].getName());
-    }
 
     public void testSimpleInspection() {
         // force Camel enabled so the inspection test can run
@@ -38,5 +27,9 @@ public class CamelInspectXmlSimpleTestIT extends CamelInspectionTestHelper {
         doTest("testData/inspectionsimplexml/", new LocalInspectionToolWrapper(inspection));
     }
 
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{CAMEL_CORE_MAVEN_ARTIFACT};
+    }
 }
-*/

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectionTestHelper.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectionTestHelper.java
@@ -1,50 +1,88 @@
 
 package com.github.cameltooling.idea.inspection;
 
-/*
+
+import java.io.File;
+
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.projectRoots.JavaSdk;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.LanguageLevelModuleExtension;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.pom.java.LanguageLevel;
-import com.intellij.testFramework.InspectionTestCase;
+import com.intellij.testFramework.IdeaTestUtil;
+import com.intellij.testFramework.JavaInspectionTestCase;
 import com.intellij.testFramework.LightProjectDescriptor;
+import com.intellij.testFramework.PsiTestUtil;
 import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.jps.model.java.JpsJavaSdkType;
+import org.jetbrains.annotations.Nullable;
 
-*/
+
 /**
  * Test helper for setup test case to test inspection code. The class create a new {@link LightProjectDescriptor} for
- * each test to make sure it start with a clean state and all previous added libraries is removed
+ * each test to make sure it starts with a clean state and all previous added libraries is removed
  *
- *//*
-
-
-public abstract class CamelInspectionTestHelper extends InspectionTestCase {
-
-    private static final String BUILD_MOCK_JDK_DIRECTORY = "build/mockJDK-";
+ */
+public abstract class CamelInspectionTestHelper extends JavaInspectionTestCase {
 
     public static final String CAMEL_CORE_MAVEN_ARTIFACT = "org.apache.camel:camel-core:2.22.0";
 
     @NotNull
     @Override
     protected LightProjectDescriptor getProjectDescriptor() {
-        LanguageLevel languageLevel = LanguageLevel.JDK_1_8;
         return new DefaultLightProjectDescriptor() {
             @Override
             public Sdk getSdk() {
-                String compilerOption = JpsJavaSdkType.complianceOption(languageLevel.toJavaVersion());
-                return JavaSdk.getInstance().createJdk( "java " + compilerOption, BUILD_MOCK_JDK_DIRECTORY + compilerOption, false );
+                return IdeaTestUtil.getMockJdk11();
             }
 
             @Override
             public void configureModule(@NotNull Module module, @NotNull ModifiableRootModel model, @NotNull ContentEntry contentEntry) {
-                model.getModuleExtension( LanguageLevelModuleExtension.class ).setLanguageLevel( languageLevel );
+                loadDependencies(model);
+                model.getModuleExtension( LanguageLevelModuleExtension.class ).setLanguageLevel( LanguageLevel.JDK_11 );
             }
         };
+    }
+
+    /**
+     * @return an array of the dependencies to add to the module in the following format
+     * {@code group-id:artifact-id:version}. No additional dependencies by default.
+     */
+    @Nullable
+    protected String[] getMavenDependencies() {
+        return null;
+    }
+
+    /**
+     * Loads the maven dependencies into the given model.
+     * @param model the model into which the dependencies are added.
+     */
+    protected void loadDependencies(@NotNull ModifiableRootModel model) {
+        String[] dependencies = getMavenDependencies();
+        if (dependencies != null && dependencies.length > 0) {
+            File[] artifacts = getMavenArtifacts(dependencies);
+            for (int i = 0; i < artifacts.length; i++) {
+                File artifact = artifacts[i];
+                PsiTestUtil.addLibrary(model, dependencies[i], artifact.getParent(), artifact.getName());
+            }
+        }
+    }
+
+    /**
+     * Get a list of artifact declared as dependencies in the pom.xml file.
+     * <p>
+     *   The method take a String arrays off "G:A:P:C:?" "org.apache.camel:camel-core:2.22.0"
+     * </p>
+     * @param mavenArtifact - Array of maven artifact to resolve
+     * @return Array of artifact files
+     */
+    protected static File[] getMavenArtifacts(String... mavenArtifact) {
+        return Maven.configureResolver()
+            .withRemoteRepo("snapshot", "https://repository.apache.org/snapshots/", "default")
+            .resolve(mavenArtifact)
+            .withoutTransitivity().asFile();
     }
 
     @Override
@@ -52,4 +90,4 @@ public abstract class CamelInspectionTestHelper extends InspectionTestCase {
         return "src/test/resources/";
     }
 }
-*/
+

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/preference/annotator/CamelAnnotatorPageTest.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/preference/annotator/CamelAnnotatorPageTest.java
@@ -1,168 +1,159 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *      http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package com.github.cameltooling.idea.preference.annotator;
-//
-//import java.io.File;
-//import java.io.IOException;
-//import java.nio.charset.StandardCharsets;
-//import java.nio.file.Files;
-//import java.nio.file.Paths;
-//import java.util.List;
-//import java.util.stream.Collectors;
-//
-//import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
-//import com.intellij.openapi.options.ConfigurationException;
-//import com.intellij.ui.components.JBCheckBox;
-//import org.junit.Ignore;
-//
-//public class CamelAnnotatorPageTest extends CamelLightCodeInsightFixtureTestCaseIT {
-//
-//    private CamelAnnotatorPage annotatorPage;
-//
-//    @Override
-//    protected void setUp() throws Exception {
-//        super.setUp();
-//        annotatorPage = new CamelAnnotatorPage();
-//        annotatorPage.createComponent();
-//        super.initCamelPreferencesService();
-//    }
-//
-//    @Override
-//    public void tearDown() throws Exception {
-//        super.tearDown();
-//        annotatorPage.disposeUIResources();
-//        annotatorPage = null;
-//    }
-//    @Ignore
-//    public void testPluginXmlShouldContainAnnotatorPreferencesPage() {
-//        File pluginXml = new File("src/main/resources/META-INF/plugin.xml");
-//        assertNotNull(pluginXml);
-//
-//        try {
-//            List<String> lines = Files.readAllLines(Paths.get("src/main/resources/META-INF/plugin.xml"), StandardCharsets.UTF_8);
-//            List<String> trimmedStrings =
-//                    lines.stream().map(String::trim).collect(Collectors.toList());
-//            int indexOfApplicationConfigurable = trimmedStrings.indexOf("<applicationConfigurable parentId=\"camel\" id=\"camel.annotator\" "
-//                    + "groupId=\"language\" displayName=\"Validation\" "
-//                    + "instance=\"com.github.cameltooling.idea.preference.annotator.CamelAnnotatorPage\"/>");
-//            assertTrue(indexOfApplicationConfigurable > 0);
-//        } catch (IOException e) {
-//            e.printStackTrace();
-//        }
-//    }
-//
-//    @Ignore
-//    public void testShouldContainRealTimeEndpointValidationCatalogCheckBox() {
-//        JBCheckBox checkBox = annotatorPage.getRealTimeEndpointValidationCatalogCheckBox();
-//        assertEquals("Real time validation of Camel endpoints in editor", checkBox.getText());
-//        assertTrue(checkBox.isSelected());
-//    }
-//
-//    @Ignore
-//    public void testShouldContainRealTimeSimpleValidationCatalogCheckBox() {
-//        JBCheckBox checkBox = annotatorPage.getRealTimeSimpleValidationCatalogCheckBox();
-//        assertEquals("Real time validation of Camel simple language in editor", checkBox.getText());
-//        assertTrue(checkBox.isSelected());
-//    }
-//
-//    @Ignore
-//    public void testShouldContainHighlightCustomOptionsCheckBox() {
-//        JBCheckBox checkBox = annotatorPage.getHighlightCustomOptionsCheckBox();
-//        assertEquals("Highlight custom endpoint options as warnings in editor", checkBox.getText());
-//        assertTrue(checkBox.isSelected());
-//    }
-//
-//    @Ignore
-//    public void testShouldChangeStateOfRealTimeEndpointValidationCatalogCheckBox() throws ConfigurationException {
-//        JBCheckBox checkBox = annotatorPage.getRealTimeEndpointValidationCatalogCheckBox();
-//        assertEquals(true, checkBox.isSelected());
-//        assertEquals(true, annotatorPage.getCamelPreferenceService().isRealTimeEndpointValidation());
-//        checkBox.setSelected(false);
-//        annotatorPage.apply();
-//        assertEquals(false, checkBox.isSelected());
-//        assertEquals(false, annotatorPage.getCamelPreferenceService().isRealTimeEndpointValidation());
-//    }
-//
-//    @Ignore
-//    public void testShouldChangeStateOfRealTimeSimpleValidationCatalogCheckBox() throws ConfigurationException {
-//        JBCheckBox checkBox = annotatorPage.getRealTimeSimpleValidationCatalogCheckBox();
-//        assertEquals(true, checkBox.isSelected());
-//        assertEquals(true, annotatorPage.getCamelPreferenceService().isRealTimeSimpleValidation());
-//        checkBox.setSelected(false);
-//        annotatorPage.apply();
-//        assertEquals(false, checkBox.isSelected());
-//        assertEquals(false, annotatorPage.getCamelPreferenceService().isRealTimeSimpleValidation());
-//    }
-//
-//    @Ignore
-//    public void testShouldChangeStateOfHighlightCustomOptionsCheckBox() throws ConfigurationException {
-//        JBCheckBox checkBox = annotatorPage.getHighlightCustomOptionsCheckBox();
-//        assertEquals(true, checkBox.isSelected());
-//        assertEquals(true, annotatorPage.getCamelPreferenceService().isHighlightCustomOptions());
-//        checkBox.setSelected(false);
-//        annotatorPage.apply();
-//        assertEquals(false, checkBox.isSelected());
-//        assertEquals(false, annotatorPage.getCamelPreferenceService().isHighlightCustomOptions());
-//    }
-//
-//    @Ignore
-//    public void testShouldResetRealTimeEndpointValidationCatalogCheckBox() {
-//        JBCheckBox checkBox = annotatorPage.getRealTimeEndpointValidationCatalogCheckBox();
-//        checkBox.setSelected(false);
-//        annotatorPage.reset();
-//        assertTrue(checkBox.isSelected());
-//    }
-//
-//    @Ignore
-//    public void testShouldRestRealTimeSimpleValidationCatalogCheckBox() {
-//        JBCheckBox checkBox = annotatorPage.getRealTimeSimpleValidationCatalogCheckBox();
-//        boolean status = checkBox.isSelected();
-//        checkBox.setSelected(!status);
-//        annotatorPage.reset();
-//        assertEquals(status, checkBox.isSelected());
-//    }
-//
-//    @Ignore
-//    public void testShouldResetHighlightCustomOptionsCheckBox() {
-//        JBCheckBox checkBox = annotatorPage.getHighlightCustomOptionsCheckBox();
-//        boolean status = checkBox.isSelected();
-//        checkBox.setSelected(!status);
-//        annotatorPage.reset();
-//        assertEquals(status, checkBox.isSelected());
-//    }
-//
-//    public void testShouldChangeStateOfRealTimeJSonPathValidationCatalogCheckBox() {
-//        JBCheckBox checkBox = annotatorPage.getRealTimeJSonPathValidationCatalogCheckBox();
-//        assertEquals(true, checkBox.isSelected());
-//        assertEquals(true, annotatorPage.getCamelPreferenceService().isRealTimeJSonPathValidation());
-//        checkBox.setSelected(false);
-//        annotatorPage.apply();
-//        assertEquals(false, checkBox.isSelected());
-//        assertEquals(false, annotatorPage.getCamelPreferenceService().isRealTimeJSonPathValidation());
-//    }
-//
-//    public void testShouldChangeStateOfRealTimeBeanMethodValidationCheckBox() {
-//        JBCheckBox checkBox = annotatorPage.getRealTimeBeanMethodValidationCheckBox();
-//        assertEquals(true, checkBox.isSelected());
-//        assertEquals(true, annotatorPage.getCamelPreferenceService().isRealTimeBeanMethodValidationCheckBox());
-//        checkBox.setSelected(false);
-//        annotatorPage.apply();
-//        assertEquals(false, checkBox.isSelected());
-//        assertEquals(false, annotatorPage.getCamelPreferenceService().isRealTimeBeanMethodValidationCheckBox());
-//    }
-//
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.preference.annotator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.intellij.ui.components.JBCheckBox;
+
+public class CamelAnnotatorPageTest extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    private CamelAnnotatorPage annotatorPage;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        annotatorPage = new CamelAnnotatorPage();
+        annotatorPage.createComponent();
+        super.initCamelPreferencesService();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            annotatorPage.disposeUIResources();
+            annotatorPage = null;
+        } finally {
+            super.tearDown();
+        }
+    }
+    public void testPluginXmlShouldContainAnnotatorPreferencesPage() {
+        File pluginXml = new File("src/main/resources/META-INF/plugin.xml");
+        assertNotNull(pluginXml);
+
+        try {
+            List<String> lines = Files.readAllLines(Paths.get("src/main/resources/META-INF/plugin.xml"), StandardCharsets.UTF_8);
+            List<String> trimmedStrings =
+                    lines.stream().map(String::trim).collect(Collectors.toList());
+            int indexOfApplicationConfigurable = trimmedStrings.indexOf("<applicationConfigurable parentId=\"camel\" id=\"camel.annotator\" "
+                    + "groupId=\"language\" displayName=\"Validation\" "
+                    + "instance=\"com.github.cameltooling.idea.preference.annotator.CamelAnnotatorPage\"/>");
+            assertTrue(indexOfApplicationConfigurable > 0);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void testShouldContainRealTimeEndpointValidationCatalogCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getRealTimeEndpointValidationCatalogCheckBox();
+        assertEquals("Real time validation of Camel endpoints in editor", checkBox.getText());
+        assertTrue(checkBox.isSelected());
+    }
+
+    public void testShouldContainRealTimeSimpleValidationCatalogCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getRealTimeSimpleValidationCatalogCheckBox();
+        assertEquals("Real time validation of Camel simple language in editor", checkBox.getText());
+        assertTrue(checkBox.isSelected());
+    }
+
+    public void testShouldContainHighlightCustomOptionsCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getHighlightCustomOptionsCheckBox();
+        assertEquals("Highlight custom endpoint options as warnings in editor", checkBox.getText());
+        assertTrue(checkBox.isSelected());
+    }
+
+    public void testShouldChangeStateOfRealTimeEndpointValidationCatalogCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getRealTimeEndpointValidationCatalogCheckBox();
+        assertTrue(checkBox.isSelected());
+        assertTrue(annotatorPage.getCamelPreferenceService().isRealTimeEndpointValidation());
+        checkBox.setSelected(false);
+        annotatorPage.apply();
+        assertFalse(checkBox.isSelected());
+        assertFalse(annotatorPage.getCamelPreferenceService().isRealTimeEndpointValidation());
+    }
+
+    public void testShouldChangeStateOfRealTimeSimpleValidationCatalogCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getRealTimeSimpleValidationCatalogCheckBox();
+        assertTrue(checkBox.isSelected());
+        assertTrue(annotatorPage.getCamelPreferenceService().isRealTimeSimpleValidation());
+        checkBox.setSelected(false);
+        annotatorPage.apply();
+        assertFalse(checkBox.isSelected());
+        assertFalse(annotatorPage.getCamelPreferenceService().isRealTimeSimpleValidation());
+    }
+
+    public void testShouldChangeStateOfHighlightCustomOptionsCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getHighlightCustomOptionsCheckBox();
+        assertTrue(checkBox.isSelected());
+        assertTrue(annotatorPage.getCamelPreferenceService().isHighlightCustomOptions());
+        checkBox.setSelected(false);
+        annotatorPage.apply();
+        assertFalse(checkBox.isSelected());
+        assertFalse(annotatorPage.getCamelPreferenceService().isHighlightCustomOptions());
+    }
+
+    public void testShouldResetRealTimeEndpointValidationCatalogCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getRealTimeEndpointValidationCatalogCheckBox();
+        checkBox.setSelected(false);
+        annotatorPage.reset();
+        assertTrue(checkBox.isSelected());
+    }
+
+    public void testShouldRestRealTimeSimpleValidationCatalogCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getRealTimeSimpleValidationCatalogCheckBox();
+        boolean status = checkBox.isSelected();
+        checkBox.setSelected(!status);
+        annotatorPage.reset();
+        assertEquals(status, checkBox.isSelected());
+    }
+
+    public void testShouldResetHighlightCustomOptionsCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getHighlightCustomOptionsCheckBox();
+        boolean status = checkBox.isSelected();
+        checkBox.setSelected(!status);
+        annotatorPage.reset();
+        assertEquals(status, checkBox.isSelected());
+    }
+
+    public void testShouldChangeStateOfRealTimeJSonPathValidationCatalogCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getRealTimeJSonPathValidationCatalogCheckBox();
+        assertTrue(checkBox.isSelected());
+        assertTrue(annotatorPage.getCamelPreferenceService().isRealTimeJSonPathValidation());
+        checkBox.setSelected(false);
+        annotatorPage.apply();
+        assertFalse(checkBox.isSelected());
+        assertFalse(annotatorPage.getCamelPreferenceService().isRealTimeJSonPathValidation());
+    }
+
+    public void testShouldChangeStateOfRealTimeBeanMethodValidationCheckBox() {
+        JBCheckBox checkBox = annotatorPage.getRealTimeBeanMethodValidationCheckBox();
+        assertTrue(checkBox.isSelected());
+        assertTrue(annotatorPage.getCamelPreferenceService().isRealTimeBeanMethodValidationCheckBox());
+        checkBox.setSelected(false);
+        annotatorPage.apply();
+        assertFalse(checkBox.isSelected());
+        assertFalse(annotatorPage.getCamelPreferenceService().isRealTimeBeanMethodValidationCheckBox());
+    }
+
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/preference/editorsettings/CamelEditorSettingsPageTest.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/preference/editorsettings/CamelEditorSettingsPageTest.java
@@ -39,13 +39,6 @@ public class CamelEditorSettingsPageTest extends CamelLightCodeInsightFixtureTes
         super.initCamelPreferencesService();
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-        editorSettingsPage = null;
-        super.initCamelPreferencesService();
-    }
-
     public void testPluginXmlShouldContainEditorPreferencesPage() {
         File pluginXml = new File("src/main/resources/META-INF/plugin.xml");
         assertNotNull(pluginXml);
@@ -68,12 +61,11 @@ public class CamelEditorSettingsPageTest extends CamelLightCodeInsightFixtureTes
         assertTrue(checkBox.isSelected());
     }
 
-//    @Ignore
-//    public void testShouldContainScanThirdPartyComponentsCatalogCheckBox() {
-//        JBCheckBox checkBox = editorSettingsPage.getScanThirdPartyComponentsCatalogCheckBox();
-//        assertEquals("Scan classpath for third party Camel components using modern component packaging", checkBox.getText());
-//        assertTrue(checkBox.isSelected());
-//    }
+    public void testShouldContainScanThirdPartyComponentsCatalogCheckBox() {
+        JBCheckBox checkBox = editorSettingsPage.getScanThirdPartyComponentsCatalogCheckBox();
+        assertEquals("Scan classpath for third party Camel components", checkBox.getText());
+        assertTrue(checkBox.isSelected());
+    }
 
     public void testShouldContainCamelIconInGutterCheckBox() {
         JBCheckBox checkBox = editorSettingsPage.getCamelIconInGutterCheckBox();

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/reference/CamelBeanMethodReferenceTest.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/reference/CamelBeanMethodReferenceTest.java
@@ -16,20 +16,10 @@
  */
 package com.github.cameltooling.idea.reference;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Collection;
-
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiLiteralExpression;
 import com.intellij.psi.PsiPolyVariantReference;
-import com.intellij.psi.ResolveResult;
-import com.intellij.testFramework.PsiTestUtil;
-import com.intellij.usageView.UsageInfo;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Test method reference link between the Java Camel DSL bean reference method @{code bean(MyClass.class,"myMethodName")}
@@ -37,12 +27,10 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 public class CamelBeanMethodReferenceTest extends CamelLightCodeInsightFixtureTestCaseIT {
     private static final String SPRING_CONTEXT_MAVEN_ARTIFACT = "org.springframework:spring-context:5.1.6.RELEASE";
 
-    private static final File[] springMavenArtifacts = getMavenArtifacts(SPRING_CONTEXT_MAVEN_ARTIFACT);
-
+    @Nullable
     @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        PsiTestUtil.addLibrary(myFixture.getProjectDisposable(), myFixture.getModule(), "Maven: " + SPRING_CONTEXT_MAVEN_ARTIFACT, springMavenArtifacts[0].getParent(), springMavenArtifacts[0].getName());
+    protected String[] getMavenDependencies() {
+        return new String[]{SPRING_CONTEXT_MAVEN_ARTIFACT};
     }
 
     @Override


### PR DESCRIPTION
## Motivation

Fix commented/ignored tests after upgrade to Camel 3 & Intellij 2021.1

## Modifications:

* Improve the way to define a `LightProjectDescriptor` to get rid of the directory `mockJDK`
* Re-add tests that are easy to fix
* Simplify asserts when possible