### PR TITLE
Ref #606 - Detect late addition or removal of Camel

### DIFF
--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,9 @@
   <applicationListeners>
     <listener class="com.github.cameltooling.idea.CamelPluginStartup" topic="com.intellij.openapi.project.ProjectManagerListener"/>
   </applicationListeners>
+  <projectListeners>
+    <listener class="com.github.cameltooling.idea.CamelPluginStartup" topic="com.intellij.openapi.roots.ModuleRootListener"/>
+  </projectListeners>
 
   <extensions defaultExtensionNs="com.intellij">
     <notificationGroup id="Apache Camel" displayType="BALLOON"/>

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/CamelProjectComponentTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/CamelProjectComponentTestIT.java
@@ -16,13 +16,11 @@
  */
 package com.github.cameltooling.idea;
 
-/*
+
 import java.io.File;
-import java.io.IOException;
 
 import com.github.cameltooling.idea.service.CamelService;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
 import com.intellij.openapi.roots.OrderRootType;
@@ -33,19 +31,18 @@ import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.testFramework.ModuleTestCase;
+import com.intellij.testFramework.JavaProjectTestCase;
 import com.intellij.util.ui.UIUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
-*/
 /**
  * Test if the {@link CamelService} service is updated correctly when changes happen to
  * the Project and model configuration
- *//*
+ */
 
-public class CamelProjectComponentTestIT extends ModuleTestCase {
+public class CamelProjectComponentTestIT extends JavaProjectTestCase {
 
     private File root;
 
@@ -55,8 +52,8 @@ public class CamelProjectComponentTestIT extends ModuleTestCase {
         root = new File(FileUtil.getTempDirectory());
     }
 
-    public void testAddLibrary() throws IOException {
-        CamelService service = ServiceManager.getService(myProject, CamelService.class);
+    public void testAddLibrary() {
+        CamelService service = myProject.getService(CamelService.class);
         assertEquals(0, service.getLibraries().size());
 
         File camelJar = createTestArchive("camel-core-2.22.0.jar");
@@ -67,11 +64,11 @@ public class CamelProjectComponentTestIT extends ModuleTestCase {
 
         UIUtil.dispatchAllInvocationEvents();
         assertEquals(1, service.getLibraries().size());
-        assertEquals(true, service.isCamelPresent());
+        assertTrue(service.isCamelPresent());
     }
 
-    public void testRemoveLibrary() throws IOException {
-        CamelService service = ServiceManager.getService(myProject, CamelService.class);
+    public void testRemoveLibrary() {
+        CamelService service = myProject.getService(CamelService.class);
         assertEquals(0, service.getLibraries().size());
 
         VirtualFile camelCoreVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-core-2.22.0.jar"));
@@ -80,11 +77,11 @@ public class CamelProjectComponentTestIT extends ModuleTestCase {
         final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(myProject);
 
         Library springLibrary = addLibraryToModule(camelSpringVirtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-spring:2.22.0-snapshot");
-        Library coreLibrary = addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-core:2.22.0-snapshot");
+        addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-core:2.22.0-snapshot");
 
         UIUtil.dispatchAllInvocationEvents();
         assertEquals(2, service.getLibraries().size());
-        assertEquals(true, service.isCamelPresent());
+        assertTrue(service.isCamelPresent());
 
         ApplicationManager.getApplication().runWriteAction(() -> projectLibraryTable.removeLibrary(springLibrary));
 
@@ -92,8 +89,8 @@ public class CamelProjectComponentTestIT extends ModuleTestCase {
         assertEquals(1, service.getLibraries().size());
     }
 
-    public void testAddModule() throws IOException {
-        CamelService service = ServiceManager.getService(myProject, CamelService.class);
+    public void testAddModule() {
+        CamelService service = myProject.getService(CamelService.class);
         assertEquals(0, service.getLibraries().size());
 
         File camelJar = createTestArchive("camel-core-2.22.0.jar");
@@ -104,6 +101,7 @@ public class CamelProjectComponentTestIT extends ModuleTestCase {
             final Module moduleA = createModule("myNewModel.iml");
             Library library = projectLibraryTable.createLibrary("Maven: org.apache.camel:camel-core:2.22.0-snapshot");
             final Library.ModifiableModel libraryModifiableModel = library.getModifiableModel();
+            assertNotNull(virtualFile);
             libraryModifiableModel.addRoot(virtualFile, OrderRootType.CLASSES);
             libraryModifiableModel.commit();
             ModuleRootModificationUtil.addDependency(moduleA, library);
@@ -113,8 +111,8 @@ public class CamelProjectComponentTestIT extends ModuleTestCase {
         assertEquals(1, service.getLibraries().size());
     }
 
-    public void testAddLegacyPackaging() throws IOException {
-        CamelService service = ServiceManager.getService(myProject, CamelService.class);
+    public void testAddLegacyPackaging() {
+        CamelService service = myProject.getService(CamelService.class);
         assertEquals(0, service.getLibraries().size());
 
         VirtualFile camelCoreVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-core-2.22.0.jar"));
@@ -127,11 +125,11 @@ public class CamelProjectComponentTestIT extends ModuleTestCase {
 
         UIUtil.dispatchAllInvocationEvents();
         assertEquals(1, service.getLibraries().size());
-        assertEquals(true, service.getLibraries().contains("camel-core"));
+        assertTrue(service.getLibraries().contains("camel-core"));
     }
 
-    public void testAddLibWithoutMavenPackaging() throws IOException {
-        CamelService service = ServiceManager.getService(myProject, CamelService.class);
+    public void testAddLibWithoutMavenPackaging() {
+        CamelService service = myProject.getService(CamelService.class);
         assertEquals(0, service.getLibraries().size());
 
         VirtualFile camelCoreVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-core-2.22.0.jar"));
@@ -142,15 +140,16 @@ public class CamelProjectComponentTestIT extends ModuleTestCase {
 
         UIUtil.dispatchAllInvocationEvents();
         assertEquals(1, service.getLibraries().size());
-        assertEquals(true, service.getLibraries().contains("camel-core"));
+        assertTrue(service.getLibraries().contains("camel-core"));
 
     }
 
-    private File createTestArchive(String filename) throws IOException {
+    private File createTestArchive(String filename) {
         JavaArchive archive = ShrinkWrap.create(JavaArchive.class, filename)
             .addClasses(CamelService.class);
         File file = new File(root, archive.getName());
         file.deleteOnExit();
+        file.getParentFile().mkdirs();
         archive.as(ZipExporter.class).exportTo(file, true);
         return file;
     }
@@ -166,4 +165,3 @@ public class CamelProjectComponentTestIT extends ModuleTestCase {
         });
     }
 }
-*/

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelServiceTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelServiceTestIT.java
@@ -22,13 +22,12 @@ import com.intellij.testFramework.PsiTestUtil;
 import com.intellij.testFramework.exceptionCases.AbstractExceptionCase;
 
 public class CamelServiceTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
-    
+
     public void testScanForCamelProjectShouldSupportDependenciesWithoutVersion() throws Throwable {
-        CamelService service = ServiceManager.getService(getModule().getProject(), CamelService.class);
+        CamelService service = getModule().getProject().getService(CamelService.class);
         assertNoException(ArrayIndexOutOfBoundsExceptionCase.check(
             () -> PsiTestUtil.addProjectLibrary(getModule(), "gradle::mylib:"))
         );
-        assertTrue(service.isCamelPresent());
         assertNoException(ArrayIndexOutOfBoundsExceptionCase.check(
             () -> PsiTestUtil.addProjectLibrary(getModule(), "gradle:mygroup:myartifactId:"))
         );


### PR DESCRIPTION
fixes #606 

## Motivation

Late addition or removal of Apache Camel is not detected by the plugin such that we need to reopen the project to ensure that it is detected properly which is not really convenient for end users.

## Modifications:

* Listen to roots changes for such purpose as suggested in [this thread](https://intellij-support.jetbrains.com/hc/en-us/community/posts/206819849-How-to-listen-to-the-library-updates-on-Module-)
* Un-comment the unit tests `CamelProjectComponentTestIT` since they actually test module changes
* Migrate the unit tests `CamelProjectComponentTestIT` to make it work again with the target version of Intellij

## Result

The plugin can now detect Camel even if it is added later in an existing project and enable all its features consequently