### PR TITLE
Ref #711 - Fixes the NPE preventing to create a new Camel endpoint

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/intention/CamelAddEndpointIntention.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/intention/CamelAddEndpointIntention.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+
 import javax.swing.*;
 
 import com.github.cameltooling.idea.service.CamelCatalogService;
@@ -29,8 +30,9 @@ import com.github.cameltooling.idea.util.CamelIdeaUtils;
 import com.github.cameltooling.idea.util.IdeaUtils;
 import com.intellij.codeInsight.intention.LowPriorityAction;
 import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.IPopupChooserBuilder;
@@ -56,14 +58,19 @@ import org.jetbrains.annotations.NotNull;
  */
 public class CamelAddEndpointIntention extends PsiElementBaseIntentionAction implements Iconable, LowPriorityAction {
 
+    /**
+     * The logger.
+     */
+    private static final Logger LOG = Logger.getInstance(CamelAddEndpointIntention.class);
+
     public IdeaUtils getIdeaUtils() {
-        return ServiceManager.getService(IdeaUtils.class);
+        return ApplicationManager.getApplication().getService(IdeaUtils.class);
     }
 
     @Override
     public void invoke(@NotNull Project project, Editor editor, @NotNull PsiElement element) throws IncorrectOperationException {
          // filter libraries to only be Camel libraries
-        Set<String> artifacts = ServiceManager.getService(project, CamelService.class).getLibraries();
+        Set<String> artifacts = project.getService(CamelService.class).getLibraries();
 
         // find the camel component from those libraries
         boolean consumerOnly = getCamelIdeaUtils().isConsumerEndpoint(element);
@@ -96,7 +103,7 @@ public class CamelAddEndpointIntention extends PsiElementBaseIntentionAction imp
 
     @Override
     public boolean isAvailable(@NotNull Project project, Editor editor, @NotNull PsiElement element) {
-        if (ServiceManager.getService(project, CamelService.class).isCamelPresent()) {
+        if (project.getService(CamelService.class).isCamelPresent()) {
             // special for xml
             XmlTag xml = PsiTreeUtil.getParentOfType(element, XmlTag.class);
             if (xml != null) {
@@ -148,20 +155,20 @@ public class CamelAddEndpointIntention extends PsiElementBaseIntentionAction imp
     private static List<String> findCamelComponentNamesInArtifact(Set<String> artifactIds, boolean consumerOnly, Project project) {
         List<String> names = new ArrayList<>();
 
-        CamelCatalog camelCatalog = ServiceManager.getService(project, CamelCatalogService.class).get();
+        CamelCatalog camelCatalog = project.getService(CamelCatalogService.class).get();
         for (String name : camelCatalog.findComponentNames()) {
             String json = camelCatalog.componentJSonSchema(name);
+            if (json == null) {
+                LOG.debug(String.format("The JSon schema metadata of the component %s could not be found", name));
+                continue;
+            }
             ComponentModel model = JsonMapper.generateComponentModel(json);
             if (artifactIds.contains(model.getArtifactId())) {
                 boolean onlyConsume = model.isConsumerOnly();
                 boolean onlyProduce = model.isProducerOnly();
                 boolean both = !onlyConsume && !onlyProduce;
 
-                if (both) {
-                    names.add(name);
-                } else if (consumerOnly && onlyConsume) {
-                    names.add(name);
-                } else if (!consumerOnly && onlyProduce) {
+                if (both || (consumerOnly && onlyConsume) || (!consumerOnly && onlyProduce)) {
                     names.add(name);
                 }
             }
@@ -174,11 +181,11 @@ public class CamelAddEndpointIntention extends PsiElementBaseIntentionAction imp
     }
 
     private CamelPreferenceService getCamelPreferenceService() {
-        return ServiceManager.getService(CamelPreferenceService.class);
+        return ApplicationManager.getApplication().getService(CamelPreferenceService.class);
     }
 
     private CamelIdeaUtils getCamelIdeaUtils() {
-        return ServiceManager.getService(CamelIdeaUtils.class);
+        return ApplicationManager.getApplication().getService(CamelIdeaUtils.class);
     }
 
 }


### PR DESCRIPTION
fixes #711 

## Motivation

The feature allowing to create a new endpoint fails with a NPE and should be fixed.

## Modifications

* Prevent the plugin from failing when a JSon schema metadata cannot be found
* Fixes the deprecation warnings (not related to the initial issue) 