### PR TITLE
Ref #719 - Simplify types in code assistance for better readability

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/endpoint/CamelSmartCompletionEndpointOptions.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/endpoint/CamelSmartCompletionEndpointOptions.java
@@ -28,6 +28,7 @@ import com.github.cameltooling.idea.completion.OptionSuggestion;
 import com.github.cameltooling.idea.service.CamelPreferenceService;
 import com.github.cameltooling.idea.util.CamelIdeaUtils;
 import com.github.cameltooling.idea.util.IdeaUtils;
+import com.github.cameltooling.idea.util.JavaClassUtils;
 import com.intellij.codeInsight.completion.PrioritizedLookupElement;
 import com.intellij.codeInsight.lookup.AutoCompletionPolicy;
 import com.intellij.codeInsight.lookup.Lookup;
@@ -125,7 +126,7 @@ public final class CamelSmartCompletionEndpointOptions {
                             .contains("advanced");
                     builder = builder.withBoldness(!advanced);
                     if (!option.getJavaType().isEmpty()) {
-                        builder = builder.withTypeText(option.getJavaType(), true);
+                        builder = builder.withTypeText(JavaClassUtils.getService().toSimpleType(option.getJavaType()), true);
                     }
                     if (option.isDeprecated()) {
                         // mark as deprecated

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/header/CamelHeaderNameCompletion.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/header/CamelHeaderNameCompletion.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.github.cameltooling.idea.service.CamelCatalogService;
 import com.github.cameltooling.idea.util.IdeaUtils;
+import com.github.cameltooling.idea.util.JavaClassUtils;
 import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionProvider;
 import com.intellij.codeInsight.completion.CompletionResultSet;
@@ -29,7 +30,7 @@ import com.intellij.codeInsight.lookup.AutoCompletionPolicy;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.icons.AllIcons;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.ProcessingContext;
@@ -91,11 +92,11 @@ abstract class CamelHeaderNameCompletion extends CompletionProvider<CompletionPa
     }
 
     private static CamelCatalog getCamelCatalog(Project project) {
-        return ServiceManager.getService(project, CamelCatalogService.class).get();
+        return project.getService(CamelCatalogService.class).get();
     }
 
     protected static IdeaUtils getIdeaUtils() {
-        return ServiceManager.getService(IdeaUtils.class);
+        return ApplicationManager.getApplication().getService(IdeaUtils.class);
     }
 
     /**
@@ -151,7 +152,7 @@ abstract class CamelHeaderNameCompletion extends CompletionProvider<CompletionPa
             .contains("advanced");
         builder = builder.withBoldness(!advanced);
         if (!header.getJavaType().isEmpty()) {
-            builder = builder.withTypeText(header.getJavaType(), true);
+            builder = builder.withTypeText(JavaClassUtils.getService().toSimpleType(header.getJavaType()), true);
         }
         if (header.isDeprecated()) {
             // mark as deprecated

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/property/CamelPropertyKeyCompletion.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/property/CamelPropertyKeyCompletion.java
@@ -28,6 +28,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import com.github.cameltooling.idea.service.CamelCatalogService;
+import com.github.cameltooling.idea.util.JavaClassUtils;
 import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionProvider;
 import com.intellij.codeInsight.completion.CompletionResultSet;
@@ -465,7 +466,7 @@ abstract class CamelPropertyKeyCompletion extends CompletionProvider<CompletionP
         final boolean advanced = group != null && group.contains("advanced");
         builder = builder.withBoldness(!advanced);
         if (!option.getJavaType().isEmpty()) {
-            builder = builder.withTypeText(option.getJavaType(), true);
+            builder = builder.withTypeText(JavaClassUtils.getService().toSimpleType(option.getJavaType()), true);
         }
         if (option.isDeprecated()) {
             // mark as deprecated

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/documentation/CamelDocumentationProvider.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/documentation/CamelDocumentationProvider.java
@@ -27,6 +27,7 @@ import com.github.cameltooling.idea.service.CamelCatalogService;
 import com.github.cameltooling.idea.service.CamelService;
 import com.github.cameltooling.idea.util.CamelIdeaUtils;
 import com.github.cameltooling.idea.util.IdeaUtils;
+import com.github.cameltooling.idea.util.JavaClassUtils;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.Language;
@@ -401,7 +402,7 @@ public class CamelDocumentationProvider extends DocumentationProviderEx implemen
             builder.append("<strong>").append(option.getName()).append("</strong><br/><br/>");
         }
         builder.append("<strong>Group: </strong>").append(Optional.ofNullable(option.getGroup()).orElse("NA")).append("<br/>");
-        builder.append("<strong>Type: </strong>").append("<tt>").append(option.getJavaType()).append("</tt>").append("<br/>");
+        builder.append("<strong>Type: </strong>").append("<tt>").append(JavaClassUtils.getService().toSimpleType(option.getJavaType())).append("</tt>").append("<br/>");
         boolean required = option.isRequired();
         builder.append("<strong>Required: </strong>").append(required).append("<br/>");
         if (option.getEnums() != null) {

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/JavaClassUtils.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/JavaClassUtils.java
@@ -16,8 +16,16 @@
  */
 package com.github.cameltooling.idea.util;
 
+import java.beans.Introspector;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiAnnotation;
@@ -41,19 +49,16 @@ import com.intellij.util.Query;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.beans.Introspector;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 
 public class JavaClassUtils implements Disposable {
 
+    /**
+     * The prefix of all the classes in the java lang package.
+     */
+    private static final String JAVA_LANG_PACKAGE = "java.lang.";
+
     public static JavaClassUtils getService() {
-        return ServiceManager.getService(JavaClassUtils.class);
+        return ApplicationManager.getApplication().getService(JavaClassUtils.class);
     }
 
     /**
@@ -159,6 +164,40 @@ public class JavaClassUtils implements Disposable {
             }
         }
         return null;
+    }
+
+    /**
+     * @param type the Java type to simplify if needed.
+     * @return the primitive type in case of wrapper classes. {@code string} in case of {@link String}. The given type
+     * otherwise.
+     */
+    @Nullable
+    public String toSimpleType(@Nullable String type) {
+        if (type == null) {
+            return null;
+        }
+        String result = type.toLowerCase();
+        if (result.startsWith(JAVA_LANG_PACKAGE)) {
+            result = result.substring(JAVA_LANG_PACKAGE.length());
+        }
+        switch (result) {
+        case "string":
+        case "long":
+        case "boolean":
+        case "double":
+        case "float":
+        case "short":
+        case "char":
+        case "byte":
+        case "int":
+            return result;
+        case "character":
+            return "char";
+        case "integer":
+            return "int";
+        default:
+            return type;
+        }
     }
 
     /**

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
   <change-notes><![CDATA[
       v.0.8.13
       <ul>
+        <li>Simplify types in code assistance for better readability</li>
         <li>Bug fixes</li>
       </ul>
     ]]>

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/util/JavaClassUtilsTest.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/util/JavaClassUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The test class for {@link JavaClassUtils}.
+ */
+public class JavaClassUtilsTest {
+
+    /**
+     * {@link JavaClassUtils#toSimpleType(String)} has no effect on specific types.
+     */
+    @Test
+    public void noEffectOnSpecificTypes() {
+        JavaClassUtils utils = new JavaClassUtils();
+        assertEquals("Foo", utils.toSimpleType("Foo"));
+        assertEquals("com.foo.Bar", utils.toSimpleType("com.foo.Bar"));
+        assertEquals("com.foo.bar.Integer", utils.toSimpleType("com.foo.bar.Integer"));
+    }
+
+    /**
+     * {@link JavaClassUtils#toSimpleType(String)} has no effect on primitive types.
+     */
+    @Test
+    public void noEffectOnPrimitiveTypes() {
+        JavaClassUtils utils = new JavaClassUtils();
+        assertEquals("byte", utils.toSimpleType("byte"));
+        assertEquals("short", utils.toSimpleType("short"));
+        assertEquals("int", utils.toSimpleType("int"));
+        assertEquals("long", utils.toSimpleType("long"));
+        assertEquals("float", utils.toSimpleType("float"));
+        assertEquals("double", utils.toSimpleType("double"));
+        assertEquals("boolean", utils.toSimpleType("boolean"));
+        assertEquals("char", utils.toSimpleType("char"));
+    }
+
+    /**
+     * {@link JavaClassUtils#toSimpleType(String)} can simplify wrapper types.
+     */
+    @Test
+    public void simplifyWrapperTypes() {
+        JavaClassUtils utils = new JavaClassUtils();
+        assertEquals("byte", utils.toSimpleType("Byte"));
+        assertEquals("short", utils.toSimpleType("Short"));
+        assertEquals("int", utils.toSimpleType("Integer"));
+        assertEquals("int", utils.toSimpleType("integer"));
+        assertEquals("long", utils.toSimpleType("Long"));
+        assertEquals("float", utils.toSimpleType("Float"));
+        assertEquals("double", utils.toSimpleType("Double"));
+        assertEquals("boolean", utils.toSimpleType("Boolean"));
+        assertEquals("char", utils.toSimpleType("Character"));
+        assertEquals("char", utils.toSimpleType("character"));
+        assertEquals("byte", utils.toSimpleType("java.lang.Byte"));
+        assertEquals("short", utils.toSimpleType("java.lang.Short"));
+        assertEquals("int", utils.toSimpleType("java.lang.Integer"));
+        assertEquals("long", utils.toSimpleType("java.lang.Long"));
+        assertEquals("float", utils.toSimpleType("java.lang.Float"));
+        assertEquals("double", utils.toSimpleType("java.lang.Double"));
+        assertEquals("boolean", utils.toSimpleType("java.lang.Boolean"));
+        assertEquals("char", utils.toSimpleType("java.lang.Character"));
+    }
+
+    /**
+     * {@link JavaClassUtils#toSimpleType(String)} can simplify {@code String}.
+     */
+    @Test
+    public void simplifyString() {
+        JavaClassUtils utils = new JavaClassUtils();
+        assertEquals("string", utils.toSimpleType("String"));
+        assertEquals("string", utils.toSimpleType("java.lang.String"));
+    }
+}


### PR DESCRIPTION
fixes #719 

## Motivation

The code assistance list of options is shown nicer as it uses `string` instead of `java.lang.String`. There is less noise.

## Modifications

* Add the method `toSimpleType` in `JavaClassUtils` to convert a Java type into a simplified type when it is possible
* Call the new method to get the type to display in the code assistance and the quick documentation everywhere is needed
* Fix warnings due to deprecations in modified classes (not related to the initial issue)