### PR TITLE
Ref #720 - Allow to suggest only the Kamelet options

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/extension/CamelEndpointSmartCompletionExtension.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/extension/CamelEndpointSmartCompletionExtension.java
@@ -29,6 +29,7 @@ import javax.swing.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.cameltooling.idea.service.CamelCatalogService;
+import com.github.cameltooling.idea.service.CamelPreferenceService;
 import com.github.cameltooling.idea.service.KameletService;
 import com.github.cameltooling.idea.util.CamelIdeaUtils;
 import com.github.cameltooling.idea.util.IdeaUtils;
@@ -244,6 +245,9 @@ public class CamelEndpointSmartCompletionExtension implements CamelCompletionExt
                 }
                 final ComponentModel componentModel = JsonMapper.generateComponentModel(json);
                 final KameletService service = project.getService(KameletService.class);
+                if (CamelPreferenceService.getService().isOnlyShowKameletOptions()) {
+                    componentModel.getEndpointOptions().clear();
+                }
                 // Add the list of name of Kamelets available according to the type of endpoint
                 componentModel.getEndpointOptions().addAll(createKameletNameOptions(service, consumer));
                 final String name = getKameletName(uri);
@@ -256,9 +260,9 @@ public class CamelEndpointSmartCompletionExtension implements CamelCompletionExt
                             final ComponentModel.EndpointOptionModel option = new ComponentModel.EndpointOptionModel();
                             final JSONSchemaProps schemaProps = entry.getValue();
                             option.setKind("parameter");
-                            option.setGroup("common");
                             String nameProperty = entry.getKey();
                             option.setName(nameProperty);
+                            option.setGroup(required.contains(nameProperty) ? "common" : "advanced");
                             option.setRequired(required.contains(nameProperty));
                             option.setDisplayName(schemaProps.getTitle());
                             option.setJavaType(schemaProps.getType());

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/preference/editorsettings/CamelEditorSettingsPage.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/preference/editorsettings/CamelEditorSettingsPage.java
@@ -16,9 +16,13 @@
  */
 package com.github.cameltooling.idea.preference.editorsettings;
 
+import java.awt.*;
+
+import javax.swing.*;
+
 import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
 import com.github.cameltooling.idea.service.CamelPreferenceService;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.options.BaseConfigurable;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurationException;
@@ -31,15 +35,13 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
-import java.awt.*;
-
 public class CamelEditorSettingsPage extends BaseConfigurable implements SearchableConfigurable, Configurable.NoScroll {
 
     private JBCheckBox downloadCatalogCheckBox;
     private JBCheckBox scanThirdPartyComponentsCatalogCheckBox;
     private JBCheckBox camelIconInGutterCheckBox;
     private JBCheckBox enableDebuggerCheckBox;
+    private JBCheckBox onlyShowKameletOptionsCheckBox;
     private JComboBox<CamelCatalogProvider> camelRuntimeProviderComboBox;
 
     @Nullable
@@ -49,6 +51,7 @@ public class CamelEditorSettingsPage extends BaseConfigurable implements Searcha
         scanThirdPartyComponentsCatalogCheckBox = new JBCheckBox("Scan classpath for third party Camel components");
         camelIconInGutterCheckBox = new JBCheckBox("Show Camel icon in gutter");
         enableDebuggerCheckBox = new JBCheckBox("Enable Camel Debugger");
+        onlyShowKameletOptionsCheckBox = new JBCheckBox("Only show Kamelet's own options");
         camelRuntimeProviderComboBox = new ComboBox<>(CamelCatalogProvider.values());
         camelRuntimeProviderComboBox.setRenderer(
             new SimpleListCellRenderer<>() {
@@ -64,10 +67,12 @@ public class CamelEditorSettingsPage extends BaseConfigurable implements Searcha
         JPanel panel = new JPanel(new MigLayout("fillx,wrap 2", "[left]rel[grow,fill]"));
         panel.setOpaque(false);
 
-        panel.add(downloadCatalogCheckBox, "span 2");
-        panel.add(scanThirdPartyComponentsCatalogCheckBox, "span 2");
-        panel.add(camelIconInGutterCheckBox, "span 2");
-        panel.add(enableDebuggerCheckBox, "span 2");
+        final String constraintsForCheckBox = "span 2";
+        panel.add(downloadCatalogCheckBox, constraintsForCheckBox);
+        panel.add(scanThirdPartyComponentsCatalogCheckBox, constraintsForCheckBox);
+        panel.add(camelIconInGutterCheckBox, constraintsForCheckBox);
+        panel.add(enableDebuggerCheckBox, constraintsForCheckBox);
+        panel.add(onlyShowKameletOptionsCheckBox, constraintsForCheckBox);
 
         panel.add(new JLabel("Camel Runtime Provider"));
         panel.add(camelRuntimeProviderComboBox);
@@ -80,30 +85,36 @@ public class CamelEditorSettingsPage extends BaseConfigurable implements Searcha
 
     @Override
     public void apply() throws ConfigurationException {
-        getCamelPreferenceService().setDownloadCatalog(downloadCatalogCheckBox.isSelected());
-        getCamelPreferenceService().setScanThirdPartyComponents(scanThirdPartyComponentsCatalogCheckBox.isSelected());
-        getCamelPreferenceService().setShowCamelIconInGutter(camelIconInGutterCheckBox.isSelected());
-        getCamelPreferenceService().setEnableCamelDebugger(enableDebuggerCheckBox.isSelected());
-        getCamelPreferenceService().setCamelCatalogProvider((CamelCatalogProvider) camelRuntimeProviderComboBox.getSelectedItem());
+        final CamelPreferenceService preferenceService = getCamelPreferenceService();
+        preferenceService.setDownloadCatalog(downloadCatalogCheckBox.isSelected());
+        preferenceService.setScanThirdPartyComponents(scanThirdPartyComponentsCatalogCheckBox.isSelected());
+        preferenceService.setShowCamelIconInGutter(camelIconInGutterCheckBox.isSelected());
+        preferenceService.setEnableCamelDebugger(enableDebuggerCheckBox.isSelected());
+        preferenceService.setOnlyShowKameletOptions(onlyShowKameletOptionsCheckBox.isSelected());
+        preferenceService.setCamelCatalogProvider((CamelCatalogProvider) camelRuntimeProviderComboBox.getSelectedItem());
     }
 
     @Override
     public boolean isModified() {
         // check boxes
-        return getCamelPreferenceService().isDownloadCatalog() != downloadCatalogCheckBox.isSelected()
-                || getCamelPreferenceService().isScanThirdPartyComponents() != scanThirdPartyComponentsCatalogCheckBox.isSelected()
-                || getCamelPreferenceService().isShowCamelIconInGutter() != camelIconInGutterCheckBox.isSelected()
-                || getCamelPreferenceService().isEnableCamelDebugger() != enableDebuggerCheckBox.isSelected()
-                || getCamelPreferenceService().getCamelCatalogProvider() != camelRuntimeProviderComboBox.getSelectedItem();
+        final CamelPreferenceService preferenceService = getCamelPreferenceService();
+        return preferenceService.isDownloadCatalog() != downloadCatalogCheckBox.isSelected()
+                || preferenceService.isScanThirdPartyComponents() != scanThirdPartyComponentsCatalogCheckBox.isSelected()
+                || preferenceService.isShowCamelIconInGutter() != camelIconInGutterCheckBox.isSelected()
+                || preferenceService.isEnableCamelDebugger() != enableDebuggerCheckBox.isSelected()
+                || preferenceService.isOnlyShowKameletOptions() != onlyShowKameletOptionsCheckBox.isSelected()
+                || preferenceService.getCamelCatalogProvider() != camelRuntimeProviderComboBox.getSelectedItem();
     }
 
     @Override
     public void reset() {
-        downloadCatalogCheckBox.setSelected(getCamelPreferenceService().isDownloadCatalog());
-        scanThirdPartyComponentsCatalogCheckBox.setSelected(getCamelPreferenceService().isScanThirdPartyComponents());
-        camelIconInGutterCheckBox.setSelected(getCamelPreferenceService().isShowCamelIconInGutter());
-        enableDebuggerCheckBox.setSelected(getCamelPreferenceService().isEnableCamelDebugger());
-        camelRuntimeProviderComboBox.setSelectedItem(getCamelPreferenceService().getCamelCatalogProvider());
+        final CamelPreferenceService preferenceService = getCamelPreferenceService();
+        downloadCatalogCheckBox.setSelected(preferenceService.isDownloadCatalog());
+        scanThirdPartyComponentsCatalogCheckBox.setSelected(preferenceService.isScanThirdPartyComponents());
+        camelIconInGutterCheckBox.setSelected(preferenceService.isShowCamelIconInGutter());
+        enableDebuggerCheckBox.setSelected(preferenceService.isEnableCamelDebugger());
+        onlyShowKameletOptionsCheckBox.setSelected(preferenceService.isOnlyShowKameletOptions());
+        camelRuntimeProviderComboBox.setSelectedItem(preferenceService.getCamelCatalogProvider());
     }
 
     @NotNull
@@ -119,7 +130,7 @@ public class CamelEditorSettingsPage extends BaseConfigurable implements Searcha
     }
 
     CamelPreferenceService getCamelPreferenceService() {
-        return ServiceManager.getService(CamelPreferenceService.class);
+        return ApplicationManager.getApplication().getService(CamelPreferenceService.class);
     }
 
     JBCheckBox getDownloadCatalogCheckBox() {

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelPreferenceService.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelPreferenceService.java
@@ -71,6 +71,10 @@ public class CamelPreferenceService implements PersistentStateComponent<CamelPre
     private boolean showCamelIconInGutter = true;
     private boolean enableCamelDebugger = true;
     /**
+     * Flag indicating whether only the options of the Kamelet should be proposed.
+     */
+    private boolean onlyShowKameletOptions = true;
+    /**
      * The {@link CamelCatalogProvider} set in the preferences.
      */
     private CamelCatalogProvider camelCatalogProvider;
@@ -153,6 +157,14 @@ public class CamelPreferenceService implements PersistentStateComponent<CamelPre
 
     public void setEnableCamelDebugger(boolean enableCamelDebugger) {
         this.enableCamelDebugger = enableCamelDebugger;
+    }
+
+    public boolean isOnlyShowKameletOptions() {
+        return onlyShowKameletOptions;
+    }
+
+    public void setOnlyShowKameletOptions(boolean onlyShowKameletOptions) {
+        this.onlyShowKameletOptions = onlyShowKameletOptions;
     }
 
     public List<String> getIgnorePropertyList() {
@@ -246,6 +258,7 @@ public class CamelPreferenceService implements PersistentStateComponent<CamelPre
             && scanThirdPartyComponents == that.scanThirdPartyComponents
             && showCamelIconInGutter == that.showCamelIconInGutter
             && camelCatalogProvider == that.camelCatalogProvider
+            && onlyShowKameletOptions == that.onlyShowKameletOptions
             && Objects.equals(ignorePropertyList, that.ignorePropertyList)
             && Objects.equals(excludePropertyFiles, that.excludePropertyFiles);
     }
@@ -254,7 +267,7 @@ public class CamelPreferenceService implements PersistentStateComponent<CamelPre
     public int hashCode() {
         return Objects.hash(realTimeEndpointValidation, realTimeSimpleValidation, realTimeJSonPathValidation,
             realTimeIdReferenceTypeValidation, downloadCatalog, scanThirdPartyComponents, camelCatalogProvider,
-            ignorePropertyList, excludePropertyFiles);
+            onlyShowKameletOptions, ignorePropertyList, excludePropertyFiles);
     }
 
     public boolean isRealTimeBeanMethodValidationCheckBox() {

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,7 @@
       v.0.8.13
       <ul>
         <li>Simplify types in code assistance for better readability</li>
+        <li>Allow to suggest only the Kamelet options (configurable)</li>
         <li>Bug fixes</li>
       </ul>
     ]]>

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/YamlEndpointSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/YamlEndpointSmartCompletionTestIT.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.github.cameltooling.idea.service.CamelPreferenceService;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -31,6 +32,14 @@ import static org.junit.Assert.assertThat;
  * Testing smart completion with Camel YAML DSL
  */
 public class YamlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    protected void tearDown() throws Exception {
+        try {
+            CamelPreferenceService.getService().setOnlyShowKameletOptions(true);
+        } finally {
+            super.tearDown();
+        }
+    }
 
     public void testConsumerCompletion() {
         myFixture.configureByFiles("CompleteYamlEndpointConsumerTestData.yaml");
@@ -347,9 +356,10 @@ public class YamlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
     }
 
     /**
-     * Ensure that the configuration option of a given Kamelet can be suggested
+     * Ensure that the configuration option of a given Kamelet can be suggested with other options.
      */
     public void testYamlKameletOptionSuggestions() {
+        CamelPreferenceService.getService().setOnlyShowKameletOptions(false);
         myFixture.configureByText("CamelRoute.yaml", getYamlKameletOptionSuggestionsData());
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
@@ -357,6 +367,22 @@ public class YamlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
         assertContainsElements(strings, "kamelet:ftp-source?connectionHost", "kamelet:ftp-source?connectionPort", "kamelet:ftp-source?bridgeErrorHandler");
         myFixture.type("user\n");
         String javaMarkTestData = getYamlKameletOptionSuggestionsData().replace("<caret>", "username=");
+        myFixture.checkResult(javaMarkTestData);
+    }
+
+    /**
+     * Ensure that the configuration option of a given Kamelet can be suggested without other options.
+     */
+    public void testYamlKameletOptionAloneSuggestions() {
+        CamelPreferenceService.getService().setOnlyShowKameletOptions(true);
+        myFixture.configureByText("CamelRoute.yaml", getYamlKameletOptionSuggestionsData());
+        myFixture.completeBasic();
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertDoesntContain(strings, "kamelet:ftp-source?bridgeErrorHandler");
+        assertContainsElements(strings, "kamelet:ftp-source?connectionHost", "kamelet:ftp-source?connectionPort");
+        myFixture.type("connectionH\n");
+        String javaMarkTestData = getYamlKameletOptionSuggestionsData().replace("<caret>", "connectionHost=");
         myFixture.checkResult(javaMarkTestData);
     }
 


### PR DESCRIPTION
fixes #720 

## Motivation

For a better user experience, only the Kamelet options should be proposed by default.

## Modifications:

* Add a new checkbox in the configuration of Camel to decide whether the Kamelet options should be suggested alone or not.
* Add a new boolean to store in the preferences of the project if the Kamelet options should be suggested alone or not.
* Ensure that only the required options are proposed in bold
* Adapt the code consequently
* Fixes warnings on modified classes (not related to the initial issue)

## Result

![image](https://user-images.githubusercontent.com/1618116/174562107-f38b5cce-c384-49ed-8d85-c7c98783dac8.png)
