### PR TITLE
Fix warnings in the debugger package

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerEditorsProvider.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerEditorsProvider.java
@@ -40,7 +40,6 @@ public class CamelDebuggerEditorsProvider extends XDebuggerEditorsProvider {
     @NotNull
     @Override
     public FileType getFileType() {
-        //return XmlFileType.INSTANCE;
         return PlainTextFileType.INSTANCE;
     }
 

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerIcons.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerIcons.java
@@ -21,8 +21,8 @@ import com.intellij.openapi.util.IconLoader;
 import javax.swing.Icon;
 
 public final class CamelDebuggerIcons {
-    public static final Icon EVALUATE_EXPRESSION_ICON = IconLoader.findIcon("/META-INF/evaluateCamelExpression.png");
-    public static final Icon SET_VALUE_ICON = IconLoader.findIcon("/META-INF/setValue.png");
+    public static final Icon EVALUATE_EXPRESSION_ICON = IconLoader.getIcon("/META-INF/evaluateCamelExpression.png", CamelDebuggerIcons.class);
+    public static final Icon SET_VALUE_ICON = IconLoader.getIcon("/META-INF/setValue.png", CamelDebuggerIcons.class);
 
     private CamelDebuggerIcons() {
     }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
@@ -16,8 +16,10 @@
  */
 package com.github.cameltooling.idea.runner.debugger;
 
-import com.github.cameltooling.idea.runner.debugger.stack.CamelMessageInfo;
-import com.github.cameltooling.idea.service.CamelCatalogService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
 import com.github.cameltooling.idea.service.CamelPreferenceService;
 import com.github.cameltooling.idea.service.CamelService;
 import com.intellij.debugger.DebuggerManagerEx;
@@ -37,31 +39,17 @@ import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
-import com.intellij.notification.NotificationGroupManager;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.LibraryOrderEntry;
-import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.OrderEntry;
-import com.intellij.openapi.ui.MessageType;
 import com.intellij.xdebugger.XDebugProcess;
 import com.intellij.xdebugger.XDebugProcessStarter;
 import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XDebuggerManager;
 import com.intellij.xdebugger.impl.XDebugSessionImpl;
-import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class CamelDebuggerRunner extends GenericDebuggerRunner {
 
@@ -69,13 +57,8 @@ public class CamelDebuggerRunner extends GenericDebuggerRunner {
     public static final String CAMEL_CONTEXT = "Camel";
 
     private static final Logger LOG = Logger.getInstance(CamelDebuggerRunner.class);
-    private static final String MIN_CAMEL_VERSION = "3.15.0";
     @NonNls
     private static final String ID = "CamelDebuggerRunner";
-
-    public CamelDebuggerRunner() {
-        super();
-    }
 
     @NotNull
     @Override
@@ -85,13 +68,13 @@ public class CamelDebuggerRunner extends GenericDebuggerRunner {
 
     @Override
     public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
-        CamelPreferenceService preferenceService = ServiceManager.getService(CamelPreferenceService.class);
+        CamelPreferenceService preferenceService = ApplicationManager.getApplication().getService(CamelPreferenceService.class);
         if (!preferenceService.isEnableCamelDebugger()) {
             return false;
         }
         if (profile instanceof RunConfigurationBase) {
             try {
-                final RunConfigurationBase base = (RunConfigurationBase) profile;
+                final RunConfigurationBase<?> base = (RunConfigurationBase<?>) profile;
                 final Project project = base.getProject();
                 final CamelService camelService = project.getService(CamelService.class);
                 if (camelService != null) {
@@ -135,123 +118,51 @@ public class CamelDebuggerRunner extends GenericDebuggerRunner {
         LOG.debug("Attaching VM...");
         DefaultDebugEnvironment environment = new DefaultDebugEnvironment(env, state, connection, pollConnection);
         final DebuggerSession debuggerSession = DebuggerManagerEx.getInstanceEx(env.getProject()).attachVirtualMachine(environment);
-        final CamelDebuggerSession camelDebuggerSession = new CamelDebuggerSession();
-
         if (debuggerSession == null) {
             return null;
-        } else {
-            final DebugProcessImpl debugProcess = debuggerSession.getProcess();
-            if (!debugProcess.isDetached() && !debugProcess.isDetaching()) {
-                if (environment.isRemote()) {
-                    debugProcess.putUserData(BatchEvaluator.REMOTE_SESSION_KEY, Boolean.TRUE);
-                }
+        }
+        final CamelDebuggerSession camelDebuggerSession = new CamelDebuggerSession();
+        final DebugProcessImpl debugProcess = debuggerSession.getProcess();
+        if (!debugProcess.isDetached() && !debugProcess.isDetaching()) {
+            if (environment.isRemote()) {
+                debugProcess.putUserData(BatchEvaluator.REMOTE_SESSION_KEY, Boolean.TRUE);
+            }
 
-                return XDebuggerManager.getInstance(env.getProject()).startSession(env, new XDebugProcessStarter() {
-                    @NotNull
-                    public XDebugProcess start(@NotNull XDebugSession session) {
+            return XDebuggerManager.getInstance(env.getProject()).startSession(env, new XDebugProcessStarter() {
+                @NotNull
+                public XDebugProcess start(@NotNull XDebugSession session) {
 
-                        final XDebugSessionImpl sessionImpl = (XDebugSessionImpl) session;
-                        final ExecutionResult executionResult = debugProcess.getExecutionResult();
-                        final Map<String, XDebugProcess> context = new HashMap<>();
-                        final ContextAwareDebugProcess contextAwareDebugProcess = new ContextAwareDebugProcess(session, executionResult.getProcessHandler(), context, JAVA_CONTEXT);
+                    final XDebugSessionImpl sessionImpl = (XDebugSessionImpl) session;
+                    final ExecutionResult executionResult = debugProcess.getExecutionResult();
+                    final Map<String, XDebugProcess> context = new HashMap<>();
+                    final ContextAwareDebugProcess contextAwareDebugProcess = new ContextAwareDebugProcess(session, executionResult.getProcessHandler(), context, JAVA_CONTEXT);
 
-                        camelDebuggerSession.addMessageReceivedListener(new MessageReceivedListener() {
-                            @Override
-                            public void onNewMessageReceived(CamelMessageInfo camelMessageInfo) {
-                                contextAwareDebugProcess.setContext(CAMEL_CONTEXT);
-                            }
-/*
-                            @Override
-                            public void onExceptionThrown(CamelMessageInfo camelMessageInfo, ObjectFieldDefinition exceptionThrown) {
-                                contextAwareDebugProcess.setContext(CAMEL_CONTEXT);
-                            }
+                    camelDebuggerSession.addMessageReceivedListener(camelMessageInfo -> contextAwareDebugProcess.setContext(CAMEL_CONTEXT));
 
-                            @Override
-                            public void onExecutionStopped(CamelMessageInfo camelMessageInfo, List<ObjectFieldDefinition> frame, String path, String internalPosition) {
-                                contextAwareDebugProcess.setContext(CAMEL_CONTEXT);
-                            }
-*/
-                        });
+                    debuggerSession.getContextManager().addListener((newContext, event) -> contextAwareDebugProcess.setContext(JAVA_CONTEXT));
 
-                        debuggerSession.getContextManager().addListener((newContext, event) -> contextAwareDebugProcess.setContext(JAVA_CONTEXT));
-
-                        //Init Java Debug Process
-                        sessionImpl.addExtraActions(executionResult.getActions());
-                        if (executionResult instanceof DefaultExecutionResult) {
-                            sessionImpl.addRestartActions(((DefaultExecutionResult) executionResult).getRestartActions());
-                            //sessionImpl.addExtraStopActions(((DefaultExecutionResult) executionResult).getAdditionalStopActions());
-                        }
-                        final JavaDebugProcess javaDebugProcess = JavaDebugProcess.create(session, debuggerSession);
-
-                        //Init Camel Debug Process
-                        final CamelDebugProcess camelDebugProcess = new CamelDebugProcess(session, camelDebuggerSession, javaDebugProcess.getProcessHandler());
-
-                        //Register All Processes
-                        context.put(JAVA_CONTEXT, javaDebugProcess);
-                        context.put(CAMEL_CONTEXT, camelDebugProcess);
-                        return contextAwareDebugProcess;
+                    //Init Java Debug Process
+                    sessionImpl.addExtraActions(executionResult.getActions());
+                    if (executionResult instanceof DefaultExecutionResult) {
+                        sessionImpl.addRestartActions(((DefaultExecutionResult) executionResult).getRestartActions());
                     }
-                }).getRunContentDescriptor();
-            } else {
-                debuggerSession.dispose();
-                camelDebuggerSession.dispose();
-                return null;
-            }
-        }
-    }
+                    final JavaDebugProcess javaDebugProcess = JavaDebugProcess.create(session, debuggerSession);
 
-    private void checkConfiguration(@NotNull Module module) {
-        String currentVersion = null;
-        CamelService camelService = module.getProject().getService(CamelService.class);
-        if (camelService != null) {
-            CamelCatalogService camelCatalogService = module.getProject().getService(CamelCatalogService.class);
-            if (camelCatalogService != null) {
-                currentVersion = camelCatalogService.get().getLoadedVersion();
-                ComparableVersion version = new ComparableVersion(currentVersion);
-                if (version.compareTo(new ComparableVersion(MIN_CAMEL_VERSION)) < 0) { //This is an older version of Camel, debugger is not supported
-                    NotificationGroupManager.getInstance()
-                            .getNotificationGroup("Debugger messages")
-                            .createNotification("Camel version is " + version + ". Minimum required version for debugger is 3.15.0",
-                                    MessageType.WARNING).notify(module.getProject());
+                    //Init Camel Debug Process
+                    final CamelDebugProcess camelDebugProcess = new CamelDebugProcess(
+                        session, camelDebuggerSession, javaDebugProcess.getProcessHandler()
+                    );
+
+                    //Register All Processes
+                    context.put(JAVA_CONTEXT, javaDebugProcess);
+                    context.put(CAMEL_CONTEXT, camelDebugProcess);
+                    return contextAwareDebugProcess;
                 }
-            }
+            }).getRunContentDescriptor();
+        } else {
+            debuggerSession.dispose();
+            camelDebuggerSession.dispose();
+            return null;
         }
-
-        List<OrderEntry> entries = Arrays.asList(ModuleRootManager.getInstance(module).getOrderEntries());
-        long debuggerDependenciesCount = entries.stream()
-                .filter(entry -> isDebuggerDependency(entry))
-                .count();
-        if (debuggerDependenciesCount <= 0) {
-            NotificationGroupManager.getInstance()
-                    .getNotificationGroup("Debugger messages")
-                    .createNotification("Camel Debugger is not found in classpath. \nPlease add camel-debug or camel-debug-starter"
-                                    + " JAR to your project dependencies.",
-                            MessageType.WARNING).notify(module.getProject());
-        }
-    }
-
-    private boolean isDebuggerDependency(OrderEntry entry) {
-        if (!(entry instanceof LibraryOrderEntry)) {
-            return false;
-        }
-        LibraryOrderEntry libraryOrderEntry = (LibraryOrderEntry) entry;
-
-        String name = libraryOrderEntry.getPresentableName().toLowerCase();
-
-        String[] split = name.split(":");
-        if (split.length < 3) {
-            return false;
-        }
-        int startIdx = 0;
-        if (split[0].equalsIgnoreCase("maven")
-                || split[0].equalsIgnoreCase("gradle")
-                || split[0].equalsIgnoreCase("sbt")) {
-            startIdx = 1;
-        }
-
-        String groupId = split[startIdx++].trim();
-        String artifactId = split[startIdx++].trim().toLowerCase();
-
-        return artifactId != null && ("camel-debug".equals(artifactId) || "camel-debug-starter".equals(artifactId));
     }
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelSuspendContext.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelSuspendContext.java
@@ -23,7 +23,7 @@ import com.intellij.xdebugger.frame.XSuspendContext;
 
 public class CamelSuspendContext extends XSuspendContext {
 
-    private CamelExecutionStack camelExecutionStack;
+    private final CamelExecutionStack camelExecutionStack;
 
     public CamelSuspendContext(XStackFrame... frame) {
         camelExecutionStack = new CamelExecutionStack("Camel Execution", frame);

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ContextAwareDebugProcess.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ContextAwareDebugProcess.java
@@ -41,12 +41,13 @@ import java.util.List;
 import java.util.Map;
 
 public class ContextAwareDebugProcess extends XDebugProcess {
-    private ProcessHandler processHandler;
-    private Map<String, XDebugProcess> debugProcesses;
+    private final ProcessHandler processHandler;
+    private final Map<String, XDebugProcess> debugProcesses;
     private String currentContext;
-    private String defaultContext;
+    private final String defaultContext;
 
-    public ContextAwareDebugProcess(@NotNull XDebugSession session, ProcessHandler processHandler, Map<String, XDebugProcess> debugProcesses, String defaultContext) {
+    public ContextAwareDebugProcess(@NotNull XDebugSession session, ProcessHandler processHandler,
+                                    Map<String, XDebugProcess> debugProcesses, String defaultContext) {
         super(session);
         this.processHandler = processHandler;
         this.debugProcesses = debugProcesses;
@@ -61,12 +62,12 @@ public class ContextAwareDebugProcess extends XDebugProcess {
     @Override
     @NotNull
     public XBreakpointHandler<?>[] getBreakpointHandlers() {
-        List<XBreakpointHandler> breakpointHandlers = new ArrayList<>();
+        List<XBreakpointHandler<?>> breakpointHandlers = new ArrayList<>();
         final Collection<XDebugProcess> values = debugProcesses.values();
         for (XDebugProcess value : values) {
             breakpointHandlers.addAll(Arrays.asList(value.getBreakpointHandlers()));
         }
-        return breakpointHandlers.toArray(new XBreakpointHandler[breakpointHandlers.size()]);
+        return breakpointHandlers.toArray(new XBreakpointHandler[0]);
     }
 
     @Override
@@ -121,9 +122,8 @@ public class ContextAwareDebugProcess extends XDebugProcess {
 
     @Override
     @NotNull
-    public Promise stopAsync() {
-        final Collection<XDebugProcess> values = debugProcesses.values();
-        for (XDebugProcess value : values) {
+    public Promise<Object> stopAsync() {
+        for (XDebugProcess value : debugProcesses.values()) {
             value.stopAsync();
         }
         return getDefaultDebugProcess().stopAsync();
@@ -168,9 +168,9 @@ public class ContextAwareDebugProcess extends XDebugProcess {
     }
 
     @Override
-    public void registerAdditionalActions(@NotNull DefaultActionGroup leftToolbar, @NotNull DefaultActionGroup topToolbar, @NotNull DefaultActionGroup settings) {
-        final Collection<XDebugProcess> values = debugProcesses.values();
-        for (XDebugProcess value : values) {
+    public void registerAdditionalActions(@NotNull DefaultActionGroup leftToolbar, @NotNull DefaultActionGroup topToolbar,
+                                          @NotNull DefaultActionGroup settings) {
+        for (XDebugProcess value : debugProcesses.values()) {
             value.registerAdditionalActions(leftToolbar, topToolbar, settings);
         }
     }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/MessageReceivedListener.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/MessageReceivedListener.java
@@ -22,7 +22,4 @@ public interface MessageReceivedListener {
 
     void onNewMessageReceived(CamelMessageInfo camelMessageInfo);
 
-//    void onExceptionThrown(CamelMessageInfo camelMessageInfo, ObjectFieldDefinition exceptionThrown);
-//
-//    void onExecutionStopped(CamelMessageInfo camelMessageInfo, List<ObjectFieldDefinition> frame, String path, String internalPosition);
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/actions/CamelEvaluateAction.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/actions/CamelEvaluateAction.java
@@ -25,7 +25,7 @@ import com.intellij.xdebugger.impl.actions.XDebuggerActionBase;
 import org.jetbrains.annotations.NotNull;
 
 public class CamelEvaluateAction extends XDebuggerActionBase {
-    private CamelEvaluateActionHandler evaluateActionHandler = new CamelEvaluateActionHandler();
+    private final CamelEvaluateActionHandler evaluateActionHandler = new CamelEvaluateActionHandler();
 
     public CamelEvaluateAction() {
         super(true);
@@ -42,6 +42,9 @@ public class CamelEvaluateAction extends XDebuggerActionBase {
         super.update(event);
         if (event.getPresentation().isEnabledAndVisible()) {
             final Project project = event.getProject();
+            if (project == null) {
+                return;
+            }
             final CamelService camelService = project.getService(CamelService.class);
             event.getPresentation().setEnabled(camelService.isCamelPresent());
             event.getPresentation().setVisible(camelService.isCamelPresent());

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/actions/CamelSetValueAction.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/actions/CamelSetValueAction.java
@@ -25,7 +25,7 @@ import com.intellij.xdebugger.impl.actions.XDebuggerActionBase;
 import org.jetbrains.annotations.NotNull;
 
 public class CamelSetValueAction extends XDebuggerActionBase {
-    private CamelSetValueActionHandler setValueActionHandler = new CamelSetValueActionHandler();
+    private final CamelSetValueActionHandler setValueActionHandler = new CamelSetValueActionHandler();
 
     public CamelSetValueAction() {
         super(true);
@@ -42,6 +42,9 @@ public class CamelSetValueAction extends XDebuggerActionBase {
         super.update(event);
         if (event.getPresentation().isEnabledAndVisible()) {
             final Project project = event.getProject();
+            if (project == null) {
+                return;
+            }
             final CamelService camelService = project.getService(CamelService.class);
             event.getPresentation().setEnabled(camelService.isCamelPresent());
             event.getPresentation().setVisible(camelService.isCamelPresent());

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/actions/CamelSetValueActionHandler.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/actions/CamelSetValueActionHandler.java
@@ -18,13 +18,11 @@ package com.github.cameltooling.idea.runner.debugger.actions;
 
 import com.github.cameltooling.idea.language.CamelLanguages;
 import com.github.cameltooling.idea.runner.debugger.ui.CamelSetValueDialog;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.lang.Language;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.AppUIUtil;
 import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XExpression;
-import com.intellij.xdebugger.XSourcePosition;
 import com.intellij.xdebugger.evaluation.XDebuggerEditorsProvider;
 import com.intellij.xdebugger.evaluation.XDebuggerEvaluator;
 import com.intellij.xdebugger.frame.XStackFrame;
@@ -44,9 +42,7 @@ public class CamelSetValueActionHandler extends XDebuggerActionHandler {
             return;
         }
 
-        final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(dataContext);
-
-        AppUIUtil.invokeOnEdt(() -> showDialog(session, file, editorsProvider, stackFrame, evaluator,
+        AppUIUtil.invokeOnEdt(() -> showDialog(session, editorsProvider, stackFrame, evaluator,
                 XExpressionImpl.EMPTY_EXPRESSION));
     }
 
@@ -56,13 +52,12 @@ public class CamelSetValueActionHandler extends XDebuggerActionHandler {
     }
 
     private static void showDialog(@NotNull XDebugSession session,
-                                   VirtualFile file,
                                    XDebuggerEditorsProvider editorsProvider,
                                    XStackFrame stackFrame,
                                    XDebuggerEvaluator evaluator,
                                    @Nullable XExpression expression) {
         //Hack to register languages before deserialization of stored expressions
-        CamelLanguages.ALL.stream().map(l -> l.getID());
+        CamelLanguages.ALL.stream().map(Language::getID);
 
         if (expression == null) {
             expression = XExpressionImpl.EMPTY_EXPRESSION;
@@ -71,7 +66,6 @@ public class CamelSetValueActionHandler extends XDebuggerActionHandler {
             //Assume Camel Constant by default
             expression = new XExpressionImpl(expression.getExpression(), CamelLanguages.CONSTANT_LANGUAGE, expression.getCustomInfo(), expression.getMode());
         }
-        XSourcePosition position = stackFrame == null ? null : stackFrame.getSourcePosition();
         new CamelSetValueDialog(session, editorsProvider, expression, evaluator.isCodeFragmentEvaluationSupported()).show();
     }
 

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/CamelBreakpoint.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/CamelBreakpoint.java
@@ -20,9 +20,9 @@ import com.intellij.psi.PsiElement;
 import com.intellij.xdebugger.XSourcePosition;
 
 public class CamelBreakpoint {
-    private String breakpointId;
-    private PsiElement breakpointTag;
-    private XSourcePosition position;
+    private final String breakpointId;
+    private final PsiElement breakpointTag;
+    private final XSourcePosition position;
 
     public CamelBreakpoint(String breakpointId, PsiElement breakpointTag, XSourcePosition position) {
         this.breakpointId = breakpointId;
@@ -34,23 +34,12 @@ public class CamelBreakpoint {
         return breakpointId;
     }
 
-    public void setBreakpointId(String breakpointId) {
-        this.breakpointId = breakpointId;
-    }
-
     public PsiElement getBreakpointTag() {
         return breakpointTag;
-    }
-
-    public void setBreakpointTag(PsiElement breakpointTag) {
-        this.breakpointTag = breakpointTag;
     }
 
     public XSourcePosition getXSourcePosition() {
         return position;
     }
 
-    public void setXSourcePosition(XSourcePosition position) {
-        this.position = position;
-    }
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/CamelBreakpointHandler.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/CamelBreakpointHandler.java
@@ -23,7 +23,7 @@ import com.intellij.xdebugger.breakpoints.XBreakpointProperties;
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint;
 import org.jetbrains.annotations.NotNull;
 
-public class CamelBreakpointHandler extends XBreakpointHandler<XLineBreakpoint<XBreakpointProperties>> {
+public class CamelBreakpointHandler extends XBreakpointHandler<XLineBreakpoint<XBreakpointProperties<?>>> {
     private final CamelDebuggerSession debuggerSession;
 
     public CamelBreakpointHandler(Project project, CamelDebuggerSession debuggerSession) {
@@ -33,12 +33,12 @@ public class CamelBreakpointHandler extends XBreakpointHandler<XLineBreakpoint<X
     }
 
     @Override
-    public void registerBreakpoint(@NotNull XLineBreakpoint<XBreakpointProperties> xBreakpoint) {
+    public void registerBreakpoint(@NotNull XLineBreakpoint<XBreakpointProperties<?>> xBreakpoint) {
         debuggerSession.addBreakpoint(xBreakpoint);
     }
 
     @Override
-    public void unregisterBreakpoint(@NotNull XLineBreakpoint<XBreakpointProperties> xBreakpoint, boolean temporary) {
+    public void unregisterBreakpoint(@NotNull XLineBreakpoint<XBreakpointProperties<?>> xBreakpoint, boolean temporary) {
         debuggerSession.removeBreakpoint(xBreakpoint);
     }
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/CamelBreakpointType.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/CamelBreakpointType.java
@@ -45,27 +45,24 @@ import org.jetbrains.yaml.psi.YAMLKeyValue;
 import java.util.Arrays;
 import java.util.List;
 
-public class CamelBreakpointType extends XLineBreakpointType<XBreakpointProperties> {
+public class CamelBreakpointType extends XLineBreakpointType<XBreakpointProperties<?>> {
 
     private static final List<String> NO_BREAKPOINTS_AT = Arrays.asList(
-            new String[]{
-                "routes",
-                "route",
-                "from",
-                "routeConfiguration",
-                "routeConfigurationId",
-                "exception",
-                "handled",
-                "simple",
-                "constant",
-                "datasonnet",
-                "groovy",
-                "steps",
-                "name",
-                "constant",
-                "uri"
-            }
-    );
+        "routes",
+        "route",
+        "from",
+        "routeConfiguration",
+        "routeConfigurationId",
+        "exception",
+        "handled",
+        "simple",
+        "constant",
+        "datasonnet",
+        "groovy",
+        "steps",
+        "name",
+        "constant",
+        "uri");
 
     protected CamelBreakpointType() {
         super("camel", "Camel Breakpoints");
@@ -81,7 +78,7 @@ public class CamelBreakpointType extends XLineBreakpointType<XBreakpointProperti
 
         switch (file.getFileType().getName()) {
         case "XML":
-            XmlTag tag = IdeaUtils.getService().getXmlTagAt(project, position);
+            XmlTag tag = IdeaUtils.getXmlTagAt(project, position);
             if (tag == null) {
                 return false;
             }
@@ -95,7 +92,7 @@ public class CamelBreakpointType extends XLineBreakpointType<XBreakpointProperti
             eipName = psiElement.getText();
             break;
         case "YAML":
-            YAMLKeyValue keyValue = IdeaUtils.getService().getYamlKeyValueAt(project, position);
+            YAMLKeyValue keyValue = IdeaUtils.getYamlKeyValueAt(project, position);
             if (keyValue != null) {
                 eipName = keyValue.getKeyText();
             }
@@ -112,7 +109,8 @@ public class CamelBreakpointType extends XLineBreakpointType<XBreakpointProperti
     }
 
     @Override
-    public XDebuggerEditorsProvider getEditorsProvider(@NotNull XLineBreakpoint<XBreakpointProperties> breakpoint, @NotNull Project project) {
+    public XDebuggerEditorsProvider getEditorsProvider(@NotNull XLineBreakpoint<XBreakpointProperties<?>> breakpoint,
+                                                       @NotNull Project project) {
         final XSourcePosition position = breakpoint.getSourcePosition();
         if (position == null) {
             return null;
@@ -128,11 +126,11 @@ public class CamelBreakpointType extends XLineBreakpointType<XBreakpointProperti
 
     @Nullable
     @Override
-    public XBreakpointProperties createBreakpointProperties(@NotNull VirtualFile virtualFile, int line) {
+    public XBreakpointProperties<?> createBreakpointProperties(@NotNull VirtualFile virtualFile, int line) {
         return new CamelBreakpointProperties(virtualFile.getFileType());
     }
 
-    class CamelBreakpointProperties extends XBreakpointProperties<CamelBreakpointProperties> {
+    static class CamelBreakpointProperties extends XBreakpointProperties<CamelBreakpointProperties> {
         private FileType myFileType;
 
         CamelBreakpointProperties(FileType fileType) {

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/evaluator/CamelExpressionEvaluator.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/evaluator/CamelExpressionEvaluator.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 public class CamelExpressionEvaluator extends XDebuggerEvaluator {
 
-    private CamelDebuggerSession session;
+    private final CamelDebuggerSession session;
 
     public CamelExpressionEvaluator(@NotNull CamelDebuggerSession session) {
         this.session = session;

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/CamelExecutionStack.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/CamelExecutionStack.java
@@ -27,7 +27,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class CamelExecutionStack extends XExecutionStack {
-    private List<XStackFrame> frames;
+    private final List<XStackFrame> frames;
 
     public CamelExecutionStack(@NotNull String displayName, XStackFrame... frame) {
         super(displayName, AllIcons.Debugger.ThreadSuspended);

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/CamelMessageInfo.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/CamelMessageInfo.java
@@ -45,12 +45,12 @@ public class CamelMessageInfo {
     private final String messageInfoAsXML;
     private final DocumentBuilder documentBuilder;
 
-    private XSourcePosition position;
-    private PsiElement tag;
+    private final XSourcePosition position;
+    private final PsiElement tag;
 
-    private String routeId;
-    private String processorId;
-    private String processor;
+    private final String routeId;
+    private final String processorId;
+    private final String processor;
 
     private List<CamelMessageInfo> stack;
 
@@ -173,8 +173,8 @@ public class CamelMessageInfo {
     }
 
     public static class Value {
-        private String type;
-        private Object value;
+        private final String type;
+        private final Object value;
 
         public Value(String type, Object value) {
             this.type = type;
@@ -189,6 +189,4 @@ public class CamelMessageInfo {
             return value;
         }
     }
-
-
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/CamelStackFrame.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/CamelStackFrame.java
@@ -33,30 +33,19 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class CamelStackFrame extends XStackFrame {
-    private final Project project;
 
-    private CamelDebuggerSession session;
-    private CamelMessageInfo camelMessageInfo;
-    //    @Nullable
-    //    private ObjectFieldDefinition exceptionThrown;
+    private final CamelDebuggerSession session;
+    private final CamelMessageInfo camelMessageInfo;
 
-    public CamelStackFrame(@NotNull Project project, @NotNull CamelDebuggerSession session, CamelMessageInfo camelMessageInfo) {
+
+    public CamelStackFrame(@NotNull CamelDebuggerSession session, CamelMessageInfo camelMessageInfo) {
         this.session = session;
         this.camelMessageInfo = camelMessageInfo;
-        this.project = project;
     }
 
     public CamelMessageInfo getCamelMessageInfo() {
         return camelMessageInfo;
     }
-
-    /*
-    public CamelStackFrame(@NotNull Project project, CamelDebuggerSession session, CamelMessageInfo camelMessageInfo, @Nullable ObjectFieldDefinition exceptionThrown)
-    {
-        this(project, session, camelMessageInfo);
-        this.exceptionThrown = exceptionThrown;
-    }
-*/
 
     @Nullable
     @Override
@@ -98,11 +87,6 @@ public class CamelStackFrame extends XStackFrame {
         } else {
             children.add("WARNING: ", JavaStackFrame.createMessageNode("Exchange Properties in Debugger are only available in Camel version 3.15 or later", AllIcons.Nodes.WarningMark));
         }
-/*
-        if (exceptionThrown != null) {
-            children.add("Exception", new ObjectFieldDefinitionValue(this.session, exceptionThrown, AllIcons.General.Error));
-        }
-*/
         node.addChildren(children, true);
     }
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/MapOfObjectFieldDefinitionValue.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/MapOfObjectFieldDefinitionValue.java
@@ -31,9 +31,9 @@ import java.util.Map;
 
 public class MapOfObjectFieldDefinitionValue extends XValue {
 
-    private CamelDebuggerSession session;
-    private Map<String, CamelMessageInfo.Value[]> values;
-    private Icon icon;
+    private final CamelDebuggerSession session;
+    private final Map<String, CamelMessageInfo.Value[]> values;
+    private final Icon icon;
 
     public MapOfObjectFieldDefinitionValue(CamelDebuggerSession session, Map<String, CamelMessageInfo.Value[]> values, Icon icon) {
         this.session = session;

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ui/CamelDebuggerEvaluationDialog.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ui/CamelDebuggerEvaluationDialog.java
@@ -98,8 +98,7 @@ public class CamelDebuggerEvaluationDialog extends DialogWrapper {
     private EvaluationMode myMode;
     private XSourcePosition mySourcePosition;
     private final SwitchModeAction mySwitchModeAction;
-    private final boolean myIsCodeFragmentEvaluationSupported;
-    private CamelExpressionParameters myCamelExpressionParameters;
+    private final CamelExpressionParameters myCamelExpressionParameters;
 
     public CamelDebuggerEvaluationDialog(@NotNull XDebugSession session,
                                          @NotNull XDebuggerEditorsProvider editorsProvider,
@@ -124,14 +123,13 @@ public class CamelDebuggerEvaluationDialog extends DialogWrapper {
                                           @NotNull XDebuggerEditorsProvider editorsProvider,
                                           @NotNull XExpression text,
                                           @Nullable XSourcePosition sourcePosition,
-                                          boolean isCodeFragmentEvaluationSupported) {
+                                          boolean myIsCodeFragmentEvaluationSupported) {
         super(project, true);
         mySession = session;
         myEvaluatorSupplier = evaluatorSupplier;
         myProject = project;
         myEditorsProvider = editorsProvider;
         mySourcePosition = sourcePosition;
-        myIsCodeFragmentEvaluationSupported = isCodeFragmentEvaluationSupported;
         setModal(false);
         setOKButtonText(XDebuggerBundle.message("xdebugger.button.evaluate"));
         setCancelButtonText(XDebuggerBundle.message("xdebugger.evaluate.dialog.close"));
@@ -321,26 +319,23 @@ public class CamelDebuggerEvaluationDialog extends DialogWrapper {
         text = XExpressionImpl.changeMode(text, mode);
         if (mode == EvaluationMode.EXPRESSION) {
             CamelExpressionInputComponent component =
-                    new CamelExpressionInputComponent(myProject, myEditorsProvider, "evaluateExpression", mySourcePosition, text, myDisposable,
+                    new CamelExpressionInputComponent(myProject, myEditorsProvider, "evaluateExpression", mySourcePosition, text,
                             mySession != null);
             component.setResultTypeCombo(myCamelExpressionParameters.getResultTypeCombo());
             component.setBodyMediaTypeCombo(myCamelExpressionParameters.getBodyMediaTypeCombo());
             component.setOutputMediaTypeCombo(myCamelExpressionParameters.getOutputMediaTypeCombo());
 
             component.getInputEditor().setExpandHandler(() -> mySwitchModeAction.actionPerformed(null));
-            component.getInputEditor().getLanguageChooser().addPropertyChangeListener(new PropertyChangeListener() {
-                @Override
-                public void propertyChange(PropertyChangeEvent evt) {
-                    Object newValueObj = evt.getNewValue();
-                    if (newValueObj != null) {
-                        String newValue = evt.getNewValue().toString();
-                        if ("DataSonnet".equals(newValue)) {
-                            myCamelExpressionParameters.getBodyMediaTypePanel().setVisible(true);
-                            myCamelExpressionParameters.getOutputMediaTypePanel().setVisible(true);
-                        } else if ("Simple".equals(newValue)) {
-                            myCamelExpressionParameters.getBodyMediaTypePanel().setVisible(false);
-                            myCamelExpressionParameters.getOutputMediaTypePanel().setVisible(false);
-                        }
+            component.getInputEditor().getLanguageChooser().addPropertyChangeListener(evt -> {
+                Object newValueObj = evt.getNewValue();
+                if (newValueObj != null) {
+                    String newValue = evt.getNewValue().toString();
+                    if ("DataSonnet".equals(newValue)) {
+                        myCamelExpressionParameters.getBodyMediaTypePanel().setVisible(true);
+                        myCamelExpressionParameters.getOutputMediaTypePanel().setVisible(true);
+                    } else if ("Simple".equals(newValue)) {
+                        myCamelExpressionParameters.getBodyMediaTypePanel().setVisible(false);
+                        myCamelExpressionParameters.getOutputMediaTypePanel().setVisible(false);
                     }
                 }
             });
@@ -349,15 +344,12 @@ public class CamelDebuggerEvaluationDialog extends DialogWrapper {
             CodeFragmentInputComponent component = new CodeFragmentInputComponent(myProject, myEditorsProvider, mySourcePosition, text,
                     getDimensionServiceKey() + ".splitter", myDisposable);
             component.getInputEditor().addCollapseButton(() -> mySwitchModeAction.actionPerformed(null));
-            component.getInputEditor().getLanguageChooser().addPropertyChangeListener(new PropertyChangeListener() {
-                @Override
-                public void propertyChange(PropertyChangeEvent evt) {
-                    Object newValueObj = evt.getNewValue();
-                    if (newValueObj != null) {
-                        String newValue = evt.getNewValue().toString();
-                        myCamelExpressionParameters.getBodyMediaTypePanel().setVisible("DataSonnet".equals(newValue));
-                        myCamelExpressionParameters.getOutputMediaTypePanel().setVisible("DataSonnet".equals(newValue));
-                    }
+            component.getInputEditor().getLanguageChooser().addPropertyChangeListener(evt -> {
+                Object newValueObj = evt.getNewValue();
+                if (newValueObj != null) {
+                    String newValue = evt.getNewValue().toString();
+                    myCamelExpressionParameters.getBodyMediaTypePanel().setVisible("DataSonnet".equals(newValue));
+                    myCamelExpressionParameters.getOutputMediaTypePanel().setVisible("DataSonnet".equals(newValue));
                 }
             });
             return component;

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ui/CamelExpressionInputComponent.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ui/CamelExpressionInputComponent.java
@@ -17,7 +17,6 @@
 package com.github.cameltooling.idea.runner.debugger.ui;
 
 import com.github.cameltooling.idea.language.CamelLanguages;
-import com.intellij.openapi.Disposable;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.editor.ex.util.EditorUtil;
 import com.intellij.openapi.keymap.KeymapUtil;
@@ -51,7 +50,7 @@ import java.util.stream.Collectors;
 public class CamelExpressionInputComponent extends EvaluationInputComponent {
     private final XDebuggerEditorBase myExpressionEditor;
     private final ExpressionInputForm myMainForm = new ExpressionInputForm();
-    private BorderLayoutPanel expressionPanel = JBUI.Panels.simplePanel();
+    private final BorderLayoutPanel expressionPanel = JBUI.Panels.simplePanel();
     private ComboBox<String> resultTypeCombo;
     private ComboBox<String> bodyMediaTypeCombo;
     private ComboBox<String> outputMediaTypeCombo;
@@ -61,7 +60,6 @@ public class CamelExpressionInputComponent extends EvaluationInputComponent {
                                          @Nullable String historyId,
                                          final @Nullable XSourcePosition sourcePosition,
                                          @Nullable XExpression expression,
-                                         @NotNull Disposable parentDisposable,
                                          boolean showHelp) {
         super(XDebuggerBundle.message("xdebugger.dialog.title.evaluate.expression"));
         myExpressionEditor = new XDebuggerExpressionComboBox(project, editorsProvider, historyId, sourcePosition, true, false) {

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ui/CamelExpressionParameters.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ui/CamelExpressionParameters.java
@@ -54,9 +54,9 @@ public class CamelExpressionParameters {
     }
 
     private void createUIComponents() {
-        resultTypeCombo = new ComboBox(new String[]{"java.lang.String", "java.lang.Boolean"});
-        bodyMediaTypeCombo = new ComboBox(new String[]{"application/json", "application/xml", "application/csv", "application/x-java-object", "text/plain"});
-        outputMediaTypeCombo = new ComboBox(new String[]{"application/json", "application/xml", "application/csv", "application/x-java-object", "text/plain"});
+        resultTypeCombo = new ComboBox<>(new String[]{"java.lang.String", "java.lang.Boolean"});
+        bodyMediaTypeCombo = new ComboBox<>(new String[]{"application/json", "application/xml", "application/csv", "application/x-java-object", "text/plain"});
+        outputMediaTypeCombo = new ComboBox<>(new String[]{"application/json", "application/xml", "application/csv", "application/x-java-object", "text/plain"});
     }
 
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ui/CamelSetValueDialog.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ui/CamelSetValueDialog.java
@@ -71,9 +71,8 @@ public class CamelSetValueDialog extends DialogWrapper {
     private final XDebuggerEditorsProvider myEditorsProvider;
     private EvaluationMode myMode;
     private final SwitchModeAction mySwitchModeAction;
-    private final boolean myIsCodeFragmentEvaluationSupported;
-    private CamelExpressionParameters myCamelExpressionParameters;
-    private CamelSetValueTargetPanel myCamelValueTargetPanel;
+    private final CamelExpressionParameters myCamelExpressionParameters;
+    private final CamelSetValueTargetPanel myCamelValueTargetPanel;
 
     public CamelSetValueDialog(@NotNull XDebugSession session,
                                @NotNull XDebuggerEditorsProvider editorsProvider,
@@ -86,12 +85,11 @@ public class CamelSetValueDialog extends DialogWrapper {
                                 @NotNull Project project,
                                 @NotNull XDebuggerEditorsProvider editorsProvider,
                                 @NotNull XExpression text,
-                                boolean isCodeFragmentEvaluationSupported) {
+                                boolean myIsCodeFragmentEvaluationSupported) {
         super(project, true);
         mySession = session;
         myProject = project;
         myEditorsProvider = editorsProvider;
-        myIsCodeFragmentEvaluationSupported = isCodeFragmentEvaluationSupported;
         setModal(false);
         setOKButtonText("Set Value");
         setCancelButtonText(XDebuggerBundle.message("xdebugger.evaluate.dialog.close"));
@@ -219,23 +217,19 @@ public class CamelSetValueDialog extends DialogWrapper {
         text = XExpressionImpl.changeMode(text, mode);
         if (mode == EvaluationMode.EXPRESSION) {
             CamelExpressionInputComponent component =
-                    new CamelExpressionInputComponent(myProject, myEditorsProvider, "setValueExpression", null, text, myDisposable,
-                            false);
+                    new CamelExpressionInputComponent(myProject, myEditorsProvider, "setValueExpression", null, text, false);
             component.addExpressionParametersComponent(myCamelExpressionParameters.getMainPanel());
             component.setResultTypeCombo(myCamelExpressionParameters.getResultTypeCombo());
             component.setBodyMediaTypeCombo(myCamelExpressionParameters.getBodyMediaTypeCombo());
             component.setOutputMediaTypeCombo(myCamelExpressionParameters.getOutputMediaTypeCombo());
 
             component.getInputEditor().setExpandHandler(() -> mySwitchModeAction.actionPerformed(null));
-            component.getInputEditor().getLanguageChooser().addPropertyChangeListener(new PropertyChangeListener() {
-                @Override
-                public void propertyChange(PropertyChangeEvent evt) {
-                    Object newValueObj = evt.getNewValue();
-                    if (newValueObj != null) {
-                        String newValue = evt.getNewValue().toString();
-                        myCamelExpressionParameters.getBodyMediaTypePanel().setVisible("DataSonnet".equals(newValue));
-                        myCamelExpressionParameters.getOutputMediaTypePanel().setVisible("DataSonnet".equals(newValue));
-                    }
+            component.getInputEditor().getLanguageChooser().addPropertyChangeListener(evt -> {
+                Object newValueObj = evt.getNewValue();
+                if (newValueObj != null) {
+                    String newValue = evt.getNewValue().toString();
+                    myCamelExpressionParameters.getBodyMediaTypePanel().setVisible("DataSonnet".equals(newValue));
+                    myCamelExpressionParameters.getOutputMediaTypePanel().setVisible("DataSonnet".equals(newValue));
                 }
             });
             return component;
@@ -243,15 +237,12 @@ public class CamelSetValueDialog extends DialogWrapper {
             CodeFragmentInputComponent component = new CodeFragmentInputComponent(myProject, myEditorsProvider, null, text,
                     getDimensionServiceKey() + ".splitter", myDisposable);
             component.getInputEditor().addCollapseButton(() -> mySwitchModeAction.actionPerformed(null));
-            component.getInputEditor().getLanguageChooser().addPropertyChangeListener(new PropertyChangeListener() {
-                @Override
-                public void propertyChange(PropertyChangeEvent evt) {
-                    Object newValueObj = evt.getNewValue();
-                    if (newValueObj != null) {
-                        String newValue = evt.getNewValue().toString();
-                        myCamelExpressionParameters.getBodyMediaTypePanel().setVisible("DataSonnet".equals(newValue));
-                        myCamelExpressionParameters.getOutputMediaTypePanel().setVisible("DataSonnet".equals(newValue));
-                    }
+            component.getInputEditor().getLanguageChooser().addPropertyChangeListener(evt -> {
+                Object newValueObj = evt.getNewValue();
+                if (newValueObj != null) {
+                    String newValue = evt.getNewValue().toString();
+                    myCamelExpressionParameters.getBodyMediaTypePanel().setVisible("DataSonnet".equals(newValue));
+                    myCamelExpressionParameters.getOutputMediaTypePanel().setVisible("DataSonnet".equals(newValue));
                 }
             });
             return component;

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ui/CamelSetValueTargetPanel.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/ui/CamelSetValueTargetPanel.java
@@ -20,8 +20,6 @@ import com.intellij.openapi.ui.ComboBox;
 
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 public class CamelSetValueTargetPanel {
     private ComboBox<String> targetComboBox;
@@ -29,13 +27,8 @@ public class CamelSetValueTargetPanel {
     private JPanel myPanel;
 
     private void createUIComponents() {
-        targetComboBox = new ComboBox(new String[]{"Message Header", "Exchange Property", "Body"});
-        targetComboBox.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                targetName.setVisible(!("Body".equals(targetComboBox.getItem())));
-            }
-        });
+        targetComboBox = new ComboBox<>(new String[]{"Message Header", "Exchange Property", "Body"});
+        targetComboBox.addActionListener(e -> targetName.setVisible(!("Body".equals(targetComboBox.getItem()))));
     }
 
     public String getTargetType() {


### PR DESCRIPTION
## Motivation

While investigating in how the recent improvements in the Debugger of Apache Camel can be leveraged in the IntelliJ plugin, I realized that many classes in the package `debugger` has warnings raised by IntelliJ. Moreover there are many line of codes that are commented which make the code very hard to read. To improve the maintainability of this package, it could be nice to address the warnings raised by IntelliJ.

## Modifications:

* Use the logger instead of calling `e.printStackTrace()`
* Use `final` keyword on fields that are not modified which prevents visibility issues
* Use lambda when possible to improve the readability of the code
* Avoid setting the size to the array when copying a collection into an array
* Remove commented code
* Replace deprecated code when possible
* Inline the code instead of creating a variable for a single usage
* Fix the generic related issues
* Add a log message in catch blocks for debugging purpose instead of keeping them empty which could hide bugs
* Always call `Thread.currentThread().interrupt()` when catching `InterruptedException`
* Improve the code calling `dumpTracedMessagesAsXml` by calling the old signature only as fallback instead of always calling it potentially for nothing
* Catch error also for pending breakpoints to remove
* Call `Thread.onSpinWait()` to improve the implementation of a busy wait
* Call static methods directly from the class `IdeaUtils` instead of through an instance.
* Remove unused variables, methods, fields and parameters
* Simplify the initialization of `NO_BREAKPOINTS_AT` by relying on the varargs parameter of the method `Arrays.asList`
* Avoid reading several times the `volatile` field `myDelegate` for the same call to ensure consistency.
* Implement the double-checked locking idiom to initialize the `volatile` field `myDelegate`
* Avoid adding a field when a local variable is good enough