### PR TITLE
Ref #729 - Support custom plugin parameters in the Camel Runners

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
@@ -354,7 +354,7 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
 
             @Override
             void addRequiredParameters(JavaParameters parameters) {
-                super.addPluginGoal(parameters);
+                super.addRequiredMavenGoals(parameters);
             }
 
             @Override
@@ -373,7 +373,7 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
 
             @Override
             void addRequiredParameters(JavaParameters parameters) {
-                super.addPluginGoal(parameters);
+                super.addRequiredMavenGoals(parameters);
                 // Added as required parameters for backward compatibility reasons
                 parameters.getProgramParametersList().addProperty("spring-boot.run.fork", "false");
             }
@@ -394,7 +394,7 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
 
             @Override
             void addRequiredParameters(JavaParameters parameters) {
-                super.addPluginGoal(parameters);
+                super.addRequiredMavenGoals(parameters);
             }
 
             @Override
@@ -563,12 +563,14 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
         }
 
         /**
-         * Adds the pair {@code maven-plugin-name:goal-name} to the given parameters.
+         * Adds the required maven goals to the given parameters.
          *
          * @param parameters the parameters to patch.
          */
-        private void addPluginGoal(JavaParameters parameters) {
-            parameters.getProgramParametersList().add(runtime.getPluginGoal());
+        private void addRequiredMavenGoals(JavaParameters parameters) {
+            parameters.getProgramParametersList().addAt(0, "clean");
+            parameters.getProgramParametersList().addAt(1, "compile");
+            parameters.getProgramParametersList().addAt(2, runtime.getPluginGoal());
         }
     }
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/ui/CamelRunnerConfPanel.form
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/ui/CamelRunnerConfPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.github.cameltooling.idea.runner.ui.CamelRunnerConfPanel">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -10,13 +10,13 @@
     <children>
       <vspacer id="3a9c4">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <grid id="1fdf9" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="0">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -73,6 +73,26 @@
             <constraints border-constraint="East"/>
             <properties>
               <toolTipText resource-bundle="messages/MavenConfigurableBundle" key="maven.settings.working.directory.tooltip"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="b8995" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="81e70" class="com.intellij.openapi.ui.LabeledComponent" binding="additionalPluginParamsComponent">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <componentClass value="com.intellij.ui.EditorTextField"/>
+              <labelLocation value="West"/>
+              <text value="Additional plugin parameters"/>
             </properties>
           </component>
         </children>

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/ui/CamelRunnerConfPanel.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/ui/CamelRunnerConfPanel.java
@@ -54,6 +54,7 @@ public class CamelRunnerConfPanel implements PanelWithAnchor, MavenSettingsObser
     protected LabeledComponent<EditorTextField> profilesComponent;
     protected JBLabel myFakeLabel;
     protected FixedSizeButton showProjectTreeButton;
+    protected LabeledComponent<EditorTextField> additionalPluginParamsComponent;
     protected JComponent anchor;
 
     public CamelRunnerConfPanel(@NotNull Project project) {
@@ -100,12 +101,13 @@ public class CamelRunnerConfPanel implements PanelWithAnchor, MavenSettingsObser
                 workingDirComponent.getComponent());
 
         setAnchor(profilesComponent.getLabel());
+        setAnchor(additionalPluginParamsComponent.getLabel());
     }
 
     protected void setData(final MavenRunnerParameters data) {
         data.setWorkingDirPath(workingDirComponent.getComponent().getText());
 
-        data.setGoals(List.of("clean", "compile"));
+        data.setGoals(ParametersListUtil.parse(additionalPluginParamsComponent.getComponent().getText(), true));
 
         Map<String, Boolean> profilesMap = new LinkedHashMap<>();
 
@@ -129,7 +131,7 @@ public class CamelRunnerConfPanel implements PanelWithAnchor, MavenSettingsObser
 
     protected void getData(final MavenRunnerParameters data) {
         workingDirComponent.getComponent().setText(data.getWorkingDirPath());
-
+        additionalPluginParamsComponent.getComponent().setText(String.join(" ", data.getGoals()));
         ParametersList parametersList = new ParametersList();
 
         for (Map.Entry<String, Boolean> entry : data.getProfilesMap().entrySet()) {
@@ -163,11 +165,13 @@ public class CamelRunnerConfPanel implements PanelWithAnchor, MavenSettingsObser
         this.anchor = anchor;
         workingDirComponent.setAnchor(anchor);
         profilesComponent.setAnchor(anchor);
+        additionalPluginParamsComponent.setAnchor(anchor);
     }
 
     @Override
     public void registerSettingsWatcher(@NotNull MavenRCSettingsWatcher watcher) {
         watcher.registerComponent("workingDir", workingDirComponent);
         watcher.registerComponent("profiles", profilesComponent);
+        watcher.registerComponent("additionalPluginParams", additionalPluginParamsComponent);
     }
 }

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
         <li>Simplify types in code assistance for better readability</li>
         <li>Allow to suggest only the Kamelet options (configurable)</li>
         <li>Auto setup of the Camel Debugger for different Camel runtimes (Standalone/Main, SpringBoot, Quarkus).</li>
+        <li>Allow to define custom plugin parameters in the Camel Runners</li>
         <li>Bug fixes</li>
       </ul>
     ]]>


### PR DESCRIPTION
fixes #729 

## Motivation 

For now, the Camel runner has only fixed parameters which could be an issue, especially with the Quarkus runtime as the Camel runner is the only way to launch the application with the Camel Debugger automatically added and set up.

## Modifications:

* Adds a new text field in the UI to provide additional plugin parameters 
* Registers the additional plugin parameters  as `MavenRunnerParameters`'s goals
* Injects the maven goals `clean`, `compile` and the plugin goal as first program parameters 
