### PR TITLE
Ref #732 - Improve the multi-breakpoints support of the Camel Debugger

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
@@ -145,7 +145,7 @@ public class CamelDebuggerRunner extends GenericDebuggerRunner {
                     }
                     final JavaDebugProcess javaDebugProcess = JavaDebugProcess.create(session, debuggerSession);
                     final CamelDebuggerSession camelDebuggerSession = new CamelDebuggerSession(project, session, javaDebugProcess.getProcessHandler());
-                    camelDebuggerSession.addMessageReceivedListener(camelMessageInfo -> contextAwareDebugProcess.setContext(CAMEL_CONTEXT));
+                    camelDebuggerSession.addMessageReceivedListener(messages -> contextAwareDebugProcess.setContext(CAMEL_CONTEXT));
 
                     //Init Camel Debug Process
                     final CamelDebugProcess camelDebugProcess = new CamelDebugProcess(session, camelDebuggerSession);

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/MessageReceivedListener.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/MessageReceivedListener.java
@@ -16,10 +16,20 @@
  */
 package com.github.cameltooling.idea.runner.debugger;
 
+import java.util.List;
+
 import com.github.cameltooling.idea.runner.debugger.stack.CamelMessageInfo;
 
+/**
+ * {@code MessageReceivedListener} allows to be notified when suspended breakpoint node ids have been received.
+ */
 public interface MessageReceivedListener {
 
-    void onNewMessageReceived(CamelMessageInfo camelMessageInfo);
+    /**
+     * Calls when some suspended breakpoint node ids converted into {@link CamelMessageInfo} have been received.
+     *
+     * @param camelMessages the messages received are sorted by timestamp. It cannot be {@code null} or empty.
+     */
+    void onMessagesReceived(List<CamelMessageInfo> camelMessages);
 
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/CamelMessageInfo.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/CamelMessageInfo.java
@@ -41,7 +41,7 @@ public class CamelMessageInfo {
 
     private Value body;
     private String exchangeId;
-
+    private String timestamp;
     private final String messageInfoAsXML;
     private final DocumentBuilder documentBuilder;
 
@@ -99,6 +99,9 @@ public class CamelMessageInfo {
                 headers.put(key, new Value[]{newValue});
             }
         }
+        // Get the timestamp
+        Element timestampElement = (Element) (document.getElementsByTagName("timestamp").item(0));
+        timestamp = timestampElement.getTextContent();
         //Get Exchange ID
         Element exchangeElement = (Element) (document.getElementsByTagName("exchangeId").item(0));
         exchangeId = exchangeElement.getTextContent();
@@ -142,6 +145,14 @@ public class CamelMessageInfo {
 
     public String getExchangeId() {
         return exchangeId;
+    }
+
+    public Value exchangeIdAsValue() {
+        return new Value("java.lang.String", exchangeId);
+    }
+
+    public String getTimestamp() {
+        return timestamp;
     }
 
     public XSourcePosition getXSourcePosition() {

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/CamelStackFrame.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/stack/CamelStackFrame.java
@@ -21,7 +21,6 @@ import com.github.cameltooling.idea.runner.debugger.CamelDebuggerSession;
 import com.github.cameltooling.idea.runner.debugger.evaluator.CamelExpressionEvaluator;
 import com.intellij.debugger.engine.JavaStackFrame;
 import com.intellij.icons.AllIcons;
-import com.intellij.openapi.project.Project;
 import com.intellij.ui.ColoredTextContainer;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.xdebugger.XSourcePosition;
@@ -79,13 +78,14 @@ public class CamelStackFrame extends XStackFrame {
     @Override
     public void computeChildren(@NotNull XCompositeNode node) {
         final XValueChildrenList children = new XValueChildrenList();
+        children.add("ExchangeId", new ObjectFieldDefinitionValue(this.session, this.camelMessageInfo.exchangeIdAsValue(), AllIcons.Debugger.Value));
         children.add("Body", new ObjectFieldDefinitionValue(this.session, this.camelMessageInfo.getBody(), AllIcons.Debugger.Value));
         children.add("Headers", new MapOfObjectFieldDefinitionValue(this.session, this.camelMessageInfo.getHeaders(), AllIcons.Debugger.Value));
-
-        if (this.camelMessageInfo.getProperties() != null) {
-            children.add("Exchange Properties", new MapOfObjectFieldDefinitionValue(this.session, this.camelMessageInfo.getProperties(), AllIcons.Debugger.Value));
-        } else {
+        final var properties = this.camelMessageInfo.getProperties();
+        if (properties == null) {
             children.add("WARNING: ", JavaStackFrame.createMessageNode("Exchange Properties in Debugger are only available in Camel version 3.15 or later", AllIcons.Nodes.WarningMark));
+        } else {
+            children.add("Exchange Properties", new MapOfObjectFieldDefinitionValue(this.session, properties, AllIcons.Debugger.Value));
         }
         node.addChildren(children, true);
     }

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,7 @@
         <li>Allow to suggest only the Kamelet options (configurable)</li>
         <li>Auto setup of the Camel Debugger for different Camel runtimes (Standalone/Main, SpringBoot, Quarkus).</li>
         <li>Allow to define custom plugin parameters in the Camel Runners</li>
+        <li>Improve the multi-breakpoints support of the Camel Debugger</li>
         <li>Bug fixes</li>
       </ul>
     ]]>


### PR DESCRIPTION
fixes #732 

## Motivation

If we set several breakpoints or we set one breakpoint and we invoke `step over` command, in case we have a route with regular incoming messages, the debugger keeps on switching from different active breakpoints which makes the debugging hardly understandable.

## Modifications:

* Processes the suspended breakpoint node ids as batch
* Keeps only one Camel message per batch and ideally the one corresponding to the latest message processed
* Prevents getting `IndexNotReadyException` when collecting message info
* Sorts the messages by timestamp to get a more predictable behavior
* Adds the exchange Id as variables accessible from the debugger view

## Result

The debugger doesn't switch anymore from one breakpoint to another.
