### PR TITLE
Ref #749: Don't add Camel debugger when disabled

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
@@ -121,6 +121,8 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
         final CamelService service = project.getService(CamelService.class);
         if (!service.isCamelPresent()) {
             LOG.debug("The project is not a camel project so no need to patch the parameters");
+        } else if (!CamelPreferenceService.getService().isEnableCamelDebugger()) {
+            LOG.debug("The Camel Debugger has been disabled so no need to patch the parameters");
         } else if (CamelPreferenceService.getService().isCamelDebuggerAutoSetup()) {
             if (service.containsLibrary("camel-debug", false)) {
                 LOG.debug("The component camel-debug has been detected in the dependencies of the project");


### PR DESCRIPTION
fixes #749 

## Motivation

If the debugger is disabled, it is still added automatically which is not expected.

## Modification

* Add the missing test to skip the addition of the debugger when it is disabled