### PR TITLE
Ref #754: Make the tests pass on Windows OS

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -39,7 +39,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/build-all.sh
+++ b/build-all.sh
@@ -2,7 +2,7 @@
 
 for v in "2022.1.4" "2022.2.3"; do
     echo "## Building with version $v..."
-    ./gradlew -PideaVersion="$v" clean build
+    ./gradlew --no-daemon -PideaVersion="$v" clean build
 
     status=$?
     if [[ $status -ne 0 ]]; then

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/header/CamelYamlHeaderValueCompletion.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/header/CamelYamlHeaderValueCompletion.java
@@ -43,7 +43,7 @@ public class CamelYamlHeaderValueCompletion extends CamelHeaderValueCompletion {
     protected LookupElementBuilder createLookupElementBuilder(final PsiElement element,
                                                               final EndpointHeaderModel header,
                                                               final String suggestion) {
-        return LookupElementBuilder.create(new OptionSuggestion(header, String.format("%nconstant: %s", suggestion)))
+        return LookupElementBuilder.create(new OptionSuggestion(header, String.format("\nconstant: %s", suggestion)))
             .withLookupString(suggestion)
             .withPresentableText(suggestion)
             .withInsertHandler(

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/property/CamelYamlPropertyKeyCompletion.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/property/CamelYamlPropertyKeyCompletion.java
@@ -97,7 +97,7 @@ public class CamelYamlPropertyKeyCompletion extends CamelPropertyKeyCompletion {
             // The suggestion doesn't match, so it is replaced by an empty proposal
             return LookupElementBuilder.create("");
         }
-        return LookupElementBuilder.create(String.format("%s:%n", subpartOfSuggestion))
+        return LookupElementBuilder.create(String.format("%s:\n", subpartOfSuggestion))
             .withLookupString(subpartOfSuggestion)
             .withPresentableText(subpartOfSuggestion)
             .withInsertHandler((ctx, item) -> indentSuggestion(ctx));
@@ -114,14 +114,14 @@ public class CamelYamlPropertyKeyCompletion extends CamelPropertyKeyCompletion {
         } else if (suggestion.endsWith(subpartOfSuggestion)) {
             // The current subpart of the suggestion is the last part of the key, so the description can be supplied
             return LookupElementBuilder.create(
-                new SimpleSuggestion(suggestion, descriptionSupplier, String.format("%s:%n", subpartOfSuggestion))
+                new SimpleSuggestion(suggestion, descriptionSupplier, String.format("%s:\n", subpartOfSuggestion))
             )
                 .withLookupString(subpartOfSuggestion)
                 .withPresentableText(subpartOfSuggestion)
                 .withInsertHandler((ctx, item) -> indentSuggestion(ctx));
         }
         // The current subpart of the suggestion is an intermediate part of the key, so no description is supplied
-        return LookupElementBuilder.create(String.format("%s:%n", subpartOfSuggestion))
+        return LookupElementBuilder.create(String.format("%s:\n", subpartOfSuggestion))
             .withLookupString(subpartOfSuggestion)
             .withPresentableText(subpartOfSuggestion)
             .withInsertHandler((ctx, item) -> indentSuggestion(ctx));
@@ -147,7 +147,7 @@ public class CamelYamlPropertyKeyCompletion extends CamelPropertyKeyCompletion {
                 .withPresentableText(subpartOfSuggestionInKebabCase);
         }
         // The current subpart of the suggestion is an intermediate part of the key, so no description is supplied
-        return LookupElementBuilder.create(String.format("%s:%n", subpartOfSuggestionInKebabCase))
+        return LookupElementBuilder.create(String.format("%s:\n", subpartOfSuggestionInKebabCase))
             .withLookupString(subpartOfSuggestion)
             .withLookupString(subpartOfSuggestionInKebabCase)
             .withPresentableText(subpartOfSuggestionInKebabCase)

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/CamelLightCodeInsightFixtureTestCaseIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/CamelLightCodeInsightFixtureTestCaseIT.java
@@ -64,7 +64,7 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightJavaCo
 
 
     static {
-        final String projectRoot = System.getProperty("user.dir").substring(0, System.getProperty("user.dir").lastIndexOf('/'));
+        final String projectRoot = new File(System.getProperty("user.dir")).getParent();
         try (InputStream is = new FileInputStream(projectRoot +"/gradle.properties")) {
             Properties gradleProperties = new Properties();
             gradleProperties.load(is);

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/YamlPropertyKeyCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/YamlPropertyKeyCompletionTestIT.java
@@ -30,7 +30,6 @@ import com.intellij.codeInsight.lookup.LookupElement;
  */
 public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
-    private static final String SUFFIX = String.format("%n");
     @Override
     protected String getTestDataPath() {
         return "src/test/resources/testData/completion/property";
@@ -108,7 +107,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.type("cam");
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "camel:" + SUFFIX);
+        assertContainsElements(strings, "camel:\n");
     }
 
     /**
@@ -121,7 +120,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.type("camel");
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "camel:" + SUFFIX);
+        assertContainsElements(strings, "camel:\n");
     }
 
     /**
@@ -133,7 +132,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "main:" + SUFFIX, "component:" + SUFFIX, "language:" + SUFFIX, "dataformat:" + SUFFIX);
+        assertContainsElements(strings, "main:\n", "component:\n", "language:\n", "dataformat:\n");
     }
 
     /**
@@ -186,8 +185,8 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.type(type);
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "main:" + SUFFIX);
-        assertDoesntContain(strings, "component:" + SUFFIX, "language:" + SUFFIX, "dataformat:" + SUFFIX);
+        assertContainsElements(strings, "main:\n");
+        assertDoesntContain(strings, "component:\n", "language:\n", "dataformat:\n");
     }
 
     /**
@@ -251,7 +250,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "ftp:" + SUFFIX, "bean:" + SUFFIX, "cql:" + SUFFIX);
+        assertContainsElements(strings, "ftp:\n", "bean:\n", "cql:\n");
     }
 
     /**
@@ -276,8 +275,8 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "ftp:" +  SUFFIX);
-        assertDoesntContain(strings, "bean:" +  SUFFIX, "cql:" +  SUFFIX);
+        assertContainsElements(strings, "ftp:\n");
+        assertDoesntContain(strings, "bean:\n", "cql:\n");
     }
 
     /**
@@ -325,7 +324,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "jsonpath:" + SUFFIX, "bean:" + SUFFIX, "xpath:" + SUFFIX);
+        assertContainsElements(strings, "jsonpath:\n", "bean:\n", "xpath:\n");
     }
 
     /**
@@ -351,8 +350,8 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.type("be");
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "bean:" + SUFFIX);
-        assertDoesntContain(strings, "jsonpath:" + SUFFIX, "xpath:" + SUFFIX);
+        assertContainsElements(strings, "bean:\n");
+        assertDoesntContain(strings, "jsonpath:\n", "xpath:\n");
     }
 
     /**
@@ -402,7 +401,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "jackson:" + SUFFIX, "csv:" + SUFFIX, "bindyCsv:" + SUFFIX);
+        assertContainsElements(strings, "jackson:\n", "csv:\n", "bindyCsv:\n");
     }
 
     /**
@@ -428,8 +427,8 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.type("cs");
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "csv:" + SUFFIX);
-        assertDoesntContain(strings, "jackson:" + SUFFIX, "xpath:" + SUFFIX);
+        assertContainsElements(strings, "csv:\n");
+        assertDoesntContain(strings, "jackson:\n", "xpath:\n");
     }
 
     /**
@@ -502,7 +501,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertContainsElements(strings, "camel:" + SUFFIX);
+        assertContainsElements(strings, "camel:\n");
     }
 
     /**


### PR DESCRIPTION
fixes #754 

## Motivation

Some tests are failing on Windows OS.

## Modifications:

* Add windows as OS to be tested by the CI
* Use `\n` as line separator since IntelliJ [manages it automatically](https://intellij-support.jetbrains.com/hc/en-us/community/posts/206125949/comments/206718299)
* Fix the way to retrieve `gradle.properties` to make it OS independent
* Add more flexibility to the hack that removes the jaxb libs to avoid failures
* Skip the tests that fail when the jaxb libs are not removed properly