### PR TITLE
Ref #755: Adapt the debugger to Camel 3.19+

### DIFF
--- a/camel-idea-plugin/build.gradle
+++ b/camel-idea-plugin/build.gradle
@@ -90,3 +90,15 @@ test {
 // To enable the remote debug
 //    jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
 }
+
+runIde {
+// Start: To get Grape log messages
+//    systemProperty("groovy.grape.report.downloads", "true")
+//    systemProperty("ivy.message.logger.level", "4")
+//    testLogging {
+//        showStandardStreams = true
+//    }
+// End: To get Grape log messages
+// To enable the remote debug
+//    jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
+}

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,7 @@
       <ul>
         <li>Upgrade to Camel 3.19</li>
         <li>Set the body, Headers or Exchange properties from the context menu of the Debugger Window using the Camel simple language</li>
+        <li>Adapt the debugger to Camel 3.19+</li>
       </ul>
     ]]>
   </change-notes>


### PR DESCRIPTION
fixes #755 

## Motivation

Starting from 3.19, the source location received for java classes only contains the name of the file instead of the FQN, the code needs to be adapted consequently.

## Modifications:

* Use several locations for Java classes to support Camel versions before and after 3.19
* Fix violations
* Add the arguments as comments to launch `runIde` with the remote debugger and/or increase the verbosity of Grape (not related to the original issue)