### PR TITLE
Ref #590: Re-add the gutter tests

### DIFF
--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/JavaCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/JavaCamelRouteLineMarkerProviderTestIT.java
@@ -1,169 +1,154 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *      http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package com.github.cameltooling.idea.gutter;
-//
-//import java.util.List;
-//import javax.swing.*;
-//
-//import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
-//import com.github.cameltooling.idea.service.CamelPreferenceService;
-//import com.intellij.codeInsight.daemon.GutterMark;
-//import com.intellij.codeInsight.daemon.LineMarkerInfo;
-//import com.intellij.navigation.GotoRelatedItem;
-//import com.intellij.openapi.components.ServiceManager;
-//import com.intellij.psi.PsiIdentifier;
-//import com.intellij.psi.PsiJavaToken;
-//import org.junit.Ignore;
-//
-///**
-// * Testing the Camel icon is shown in the gutter where a Camel route starts in Java DSL and the route navigation
-// */
-//public class JavaCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
-//
-//    @Ignore
-//    public void testCamelGutter() {
-//        myFixture.configureByFiles("JavaCamelRouteLineMarkerProviderTestData.java");
-//        List<GutterMark> gutters = myFixture.findAllGutters();
-//        assertNotNull(gutters);
-//
-//        //remove first element since it is navigate to super implementation gutter icon
-//        gutters.remove(0);
-//
-//        assertEquals("Should contain 3 Camel gutters", 3, gutters.size());
-//
-//        assertGuttersHasCamelIcon(gutters);
-//
-//        LineMarkerInfo.LineMarkerGutterIconRenderer firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(1);
-//
-//        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
-//        assertEquals("The navigation start element doesn't match", "\"file:inbox\"",
-//            firstGutter.getLineMarkerInfo().getElement().getText());
-//
-//
-//        List<GotoRelatedItem> firstGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstGutter);
-//        assertEquals("Navigation should have one target", 1, firstGutterTargets.size());
-//        assertEquals("The navigation target element doesn't match", "from(\"file:outbox\")",
-//            GutterTestUtil.getGuttersWithJavaTarget(firstGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
-//
-//
-//        LineMarkerInfo.LineMarkerGutterIconRenderer secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(2);
-//
-//        assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
-//        assertEquals("The navigation start element doesn't match", "\"file:outbox\"",
-//            secondGutter.getLineMarkerInfo().getElement().getText());
-//
-//        List<GotoRelatedItem> secondGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(secondGutter);
-//        assertEquals("Navigation should have one target", 1, secondGutterTargets.size());
-//        assertEquals("The navigation target element doesn't match", "from(\"file:inbox\")",
-//            GutterTestUtil.getGuttersWithJavaTarget(secondGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
-//    }
-//
-//    @Ignore
-//    public void testCamelGutterForToDAndToF() {
-//        myFixture.configureByFiles("JavaCamelRouteLineMarkerProviderAlternateToTestData.java");
-//        List<GutterMark> gutters = myFixture.findAllGutters();
-//        assertNotNull(gutters);
-//
-//        //remove first element since it is navigate to super implementation gutter icon
-//        gutters.remove(0);
-//
-//        assertEquals("Should contain 2 Camel gutters", 2, gutters.size());
-//
-//        assertGuttersHasCamelIcon(gutters);
-//
-//        LineMarkerInfo.LineMarkerGutterIconRenderer firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(0);
-//
-//        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
-//        assertEquals("The navigation start element doesn't match", "\"file:test\"",
-//            firstGutter.getLineMarkerInfo().getElement().getText());
-//
-//
-//        List<GotoRelatedItem> firstGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstGutter);
-//        assertEquals("Navigation should have one target", 1, firstGutterTargets.size());
-//        assertEquals("The navigation target element doesn't match", "from(\"file:test\")",
-//            GutterTestUtil.getGuttersWithJavaTarget(firstGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
-//
-//
-//        LineMarkerInfo.LineMarkerGutterIconRenderer secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(1);
-//
-//        assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
-//        assertEquals("The navigation start element doesn't match", "\"file:test\"",
-//            secondGutter.getLineMarkerInfo().getElement().getText());
-//
-//        List<GotoRelatedItem> secondGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(secondGutter);
-//        assertEquals("Navigation should have one target", 1, secondGutterTargets.size());
-//        assertEquals("The navigation target element doesn't match", "from(\"file:test\")",
-//            GutterTestUtil.getGuttersWithJavaTarget(secondGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
-//    }
-//
-//    @Ignore
-//    public void testCamelGutterForVariableAndConstant() {
-//        myFixture.configureByFiles("JavaCamelRouteLineMarkerProviderFromVariableTestData.java");
-//        List<GutterMark> gutters = myFixture.findAllGutters();
-//        assertNotNull(gutters);
-//
-//        //remove first element since it is navigate to super implementation gutter icon
-//        gutters.remove(0);
-//
-//        assertEquals("Should contain 2 Camel gutters", 2, gutters.size());
-//
-//        assertGuttersHasCamelIcon(gutters);
-//
-//        LineMarkerInfo.LineMarkerGutterIconRenderer firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(0);
-//        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiIdentifier);
-//        assertEquals("The navigation start element doesn't match", "uriVar",
-//            firstGutter.getLineMarkerInfo().getElement().getText());
-//
-//        List<GotoRelatedItem> firstGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstGutter);
-//        assertEquals("Navigation should have two targets", 2, firstGutterTargets.size());
-//    }
-//
-//    @Ignore
-//    public void testCamelGutterForMethodCallFrom() {
-//        myFixture.configureByFiles("JavaCamelRouteLineMarkerProviderFromMethodCallTestData.java");
-//        List<GutterMark> gutters = myFixture.findAllGutters();
-//        assertNotNull(gutters);
-//
-//        //remove first element since it is navigate to super implementation gutter icon
-//        gutters.remove(0);
-//        // remove last element since it is from method returning route uri
-//        gutters.remove(gutters.size() - 1);
-//
-//        assertEquals("Should contain 1 Camel gutters", 1, gutters.size());
-//
-//        assertGuttersHasCamelIcon(gutters);
-//
-//        LineMarkerInfo.LineMarkerGutterIconRenderer firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(0);
-//        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiIdentifier);
-//        assertEquals("The navigation start element doesn't match", "calcEndpoint",
-//            firstGutter.getLineMarkerInfo().getElement().getText());
-//
-//        List<GotoRelatedItem> firstGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstGutter);
-//        assertEquals("Navigation should have two targets", 2, firstGutterTargets.size());
-//        assertEquals("The navigation variable target element doesn't match", "calcEndpoint",
-//            GutterTestUtil.getGuttersWithMethodTarget(firstGutterTargets).get(0).getName());
-//    }
-//
-//    private void assertGuttersHasCamelIcon(List<GutterMark> gutters) {
-//        Icon defaultIcon = ServiceManager.getService(CamelPreferenceService.class).getCamelIcon();
-//        gutters.forEach(gutterMark -> {
-//            assertSame("Gutter should have the Camel icon", defaultIcon, gutterMark.getIcon());
-//            assertEquals("Camel route", gutterMark.getTooltipText());
-//        });
-//    }
-//
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.gutter;
+
+import java.util.List;
+
+import javax.swing.Icon;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.intellij.codeInsight.daemon.GutterMark;
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.navigation.GotoRelatedItem;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.psi.PsiIdentifier;
+import com.intellij.psi.PsiJavaToken;
+
+/**
+ * Testing the Camel icon is shown in the gutter where a Camel route starts in Java DSL and the route navigation
+ */
+public class JavaCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    public void testCamelGutter() {
+        myFixture.configureByFiles("JavaCamelRouteLineMarkerProviderTestData.java");
+        List<GutterMark> gutters = myFixture.findAllGutters();
+        assertNotNull(gutters);
+
+        assertEquals("Should contain 3 Camel gutters", 3, gutters.size());
+
+        assertGuttersHasCamelIcon(gutters);
+
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(1);
+
+        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"file:inbox\"",
+            firstGutter.getLineMarkerInfo().getElement().getText());
+
+
+        List<GotoRelatedItem> firstGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstGutter);
+        assertEquals("Navigation should have one target", 1, firstGutterTargets.size());
+        assertEquals("The navigation target element doesn't match", "from(\"file:outbox\")",
+            GutterTestUtil.getGuttersWithJavaTarget(firstGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
+
+
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(2);
+
+        assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"file:outbox\"",
+            secondGutter.getLineMarkerInfo().getElement().getText());
+
+        List<GotoRelatedItem> secondGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(secondGutter);
+        assertEquals("Navigation should have one target", 1, secondGutterTargets.size());
+        assertEquals("The navigation target element doesn't match", "from(\"file:inbox\")",
+            GutterTestUtil.getGuttersWithJavaTarget(secondGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
+    }
+
+    public void testCamelGutterForToDAndToF() {
+        myFixture.configureByFiles("JavaCamelRouteLineMarkerProviderAlternateToTestData.java");
+        List<GutterMark> gutters = myFixture.findAllGutters();
+        assertNotNull(gutters);
+
+        assertEquals("Should contain 2 Camel gutters", 2, gutters.size());
+
+        assertGuttersHasCamelIcon(gutters);
+
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(0);
+
+        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"file:test\"",
+            firstGutter.getLineMarkerInfo().getElement().getText());
+
+
+        List<GotoRelatedItem> firstGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstGutter);
+        assertEquals("Navigation should have one target", 1, firstGutterTargets.size());
+        assertEquals("The navigation target element doesn't match", "from(\"file:test\")",
+            GutterTestUtil.getGuttersWithJavaTarget(firstGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
+
+
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(1);
+
+        assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"file:test\"",
+            secondGutter.getLineMarkerInfo().getElement().getText());
+
+        List<GotoRelatedItem> secondGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(secondGutter);
+        assertEquals("Navigation should have one target", 1, secondGutterTargets.size());
+        assertEquals("The navigation target element doesn't match", "from(\"file:test\")",
+            GutterTestUtil.getGuttersWithJavaTarget(secondGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
+    }
+
+    public void testCamelGutterForVariableAndConstant() {
+        myFixture.configureByFiles("JavaCamelRouteLineMarkerProviderFromVariableTestData.java");
+        List<GutterMark> gutters = myFixture.findAllGutters();
+        assertNotNull(gutters);
+
+        assertEquals("Should contain 2 Camel gutters", 2, gutters.size());
+
+        assertGuttersHasCamelIcon(gutters);
+
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(0);
+        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiIdentifier);
+        assertEquals("The navigation start element doesn't match", "uriVar",
+            firstGutter.getLineMarkerInfo().getElement().getText());
+
+        List<GotoRelatedItem> firstGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstGutter);
+        assertEquals("Navigation should have two targets", 2, firstGutterTargets.size());
+    }
+
+    public void testCamelGutterForMethodCallFrom() {
+        myFixture.configureByFiles("JavaCamelRouteLineMarkerProviderFromMethodCallTestData.java");
+        List<GutterMark> gutters = myFixture.findAllGutters();
+        assertNotNull(gutters);
+
+        // remove last element since it is from method returning route uri
+        gutters.remove(gutters.size() - 1);
+
+        assertEquals("Should contain 1 Camel gutters", 1, gutters.size());
+
+        assertGuttersHasCamelIcon(gutters);
+
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(0);
+        assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof PsiIdentifier);
+        assertEquals("The navigation start element doesn't match", "calcEndpoint",
+            firstGutter.getLineMarkerInfo().getElement().getText());
+
+        List<GotoRelatedItem> firstGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstGutter);
+        assertEquals("Navigation should have two targets", 2, firstGutterTargets.size());
+        assertEquals("The navigation variable target element doesn't match", "calcEndpoint",
+            GutterTestUtil.getGuttersWithMethodTarget(firstGutterTargets).get(0).getName());
+    }
+
+    private void assertGuttersHasCamelIcon(List<GutterMark> gutters) {
+        Icon defaultIcon = ApplicationManager.getApplication().getService(CamelPreferenceService.class).getCamelIcon();
+        gutters.forEach(gutterMark -> {
+            assertSame("Gutter should have the Camel icon", defaultIcon, gutterMark.getIcon());
+            assertEquals("Camel route", gutterMark.getTooltipText());
+        });
+    }
+
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/MultiLanguageCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/MultiLanguageCamelRouteLineMarkerProviderTestIT.java
@@ -1,79 +1,74 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *      http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package com.github.cameltooling.idea.gutter;
-//
-//import java.util.List;
-//
-//import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
-//import com.intellij.codeInsight.daemon.GutterMark;
-//import com.intellij.codeInsight.daemon.LineMarkerInfo;
-//import com.intellij.navigation.GotoRelatedItem;
-//import com.intellij.psi.PsiJavaToken;
-//import com.intellij.psi.xml.XmlToken;
-//import org.junit.Ignore;
-//
-//import static com.github.cameltooling.idea.gutter.GutterTestUtil.getGuttersWithJavaTarget;
-//import static com.github.cameltooling.idea.gutter.GutterTestUtil.getGuttersWithXMLTarget;
-//
-///**
-// * Testing the Camel icon is shown in the gutter where a Camel route starts in XML DSL and the route navigation
-// */
-//public class MultiLanguageCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
-//
-//    @Ignore
-//    public void testCamelGutterForJavaAndXMLRoutes() {
-//        myFixture.configureByFiles("XmlCamelRouteLineMarkerProviderTestData.xml", "JavaCamelRouteLineMarkerProviderTestData.java");
-//        List<GutterMark> javaGutters = myFixture.findAllGutters("JavaCamelRouteLineMarkerProviderTestData.java");
-//        assertNotNull(javaGutters);
-//
-//        List<GutterMark> xmlGutters = myFixture.findAllGutters("XmlCamelRouteLineMarkerProviderTestData.xml");
-//        assertNotNull(xmlGutters);
-//
-//        //remove first element since it is navigate to super implementation gutter icon
-//        javaGutters.remove(0);
-//
-//        assertEquals("Should contain 3 Java Camel gutters", 3, javaGutters.size());
-//        assertEquals("Should contain 2 XML Camel gutters", 3, xmlGutters.size());
-//
-//        //from Java to XML
-//        LineMarkerInfo.LineMarkerGutterIconRenderer firstJavaGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) javaGutters.get(1);
-//        assertTrue(firstJavaGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
-//        assertEquals("The navigation start element doesn't match", "\"file:inbox\"",
-//            firstJavaGutter.getLineMarkerInfo().getElement().getText());
-//
-//
-//        List<GotoRelatedItem> firstJavaGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstJavaGutter);
-//        assertEquals("Navigation should have two targets", 2, firstJavaGutterTargets.size());
-//        assertEquals("The navigation target XML tag name doesn't match", "to", getGuttersWithXMLTarget(firstJavaGutterTargets).get(0).getLocalName());
-//        assertEquals("The navigation Java target element doesn't match", "from(\"file:outbox\")",
-//                getGuttersWithJavaTarget(firstJavaGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
-//
-//        //from XML to Java
-//        LineMarkerInfo.LineMarkerGutterIconRenderer firstXmlGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) xmlGutters.get(1);
-//        assertTrue(firstXmlGutter.getLineMarkerInfo().getElement() instanceof XmlToken);
-//        assertEquals("The navigation start element doesn't match", "\"file:inbox\"",
-//                (firstJavaGutter.getLineMarkerInfo().getElement()).getText());
-//
-//
-//        List<GotoRelatedItem> firstXmlGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstXmlGutter);
-//        assertEquals("Navigation should have two targets", 2, firstXmlGutterTargets.size());
-//        assertEquals("The navigation target XML tag name doesn't match", "to", getGuttersWithXMLTarget(firstXmlGutterTargets).get(0).getLocalName());
-//        assertEquals("The navigation Java target element doesn't match", "from(\"file:outbox\")",
-//                getGuttersWithJavaTarget(firstXmlGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
-//    }
-//
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.gutter;
+
+import java.util.List;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.intellij.codeInsight.daemon.GutterMark;
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.navigation.GotoRelatedItem;
+import com.intellij.psi.PsiJavaToken;
+import com.intellij.psi.xml.XmlToken;
+
+import static com.github.cameltooling.idea.gutter.GutterTestUtil.getGuttersWithJavaTarget;
+import static com.github.cameltooling.idea.gutter.GutterTestUtil.getGuttersWithXMLTarget;
+
+/**
+ * Testing the Camel icon is shown in the gutter where a Camel route starts in XML DSL and the route navigation
+ */
+public class MultiLanguageCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    public void testCamelGutterForJavaAndXMLRoutes() {
+        myFixture.configureByFiles("XmlCamelRouteLineMarkerProviderTestData.xml", "JavaCamelRouteLineMarkerProviderTestData.java");
+        List<GutterMark> javaGutters = myFixture.findAllGutters("JavaCamelRouteLineMarkerProviderTestData.java");
+        assertNotNull(javaGutters);
+
+        List<GutterMark> xmlGutters = myFixture.findAllGutters("XmlCamelRouteLineMarkerProviderTestData.xml");
+        assertNotNull(xmlGutters);
+
+        assertEquals("Should contain 3 Java Camel gutters", 3, javaGutters.size());
+        assertEquals("Should contain 3 XML Camel gutters", 3, xmlGutters.size());
+
+        //from Java to XML
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstJavaGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) javaGutters.get(1);
+        assertTrue(firstJavaGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"file:inbox\"",
+            firstJavaGutter.getLineMarkerInfo().getElement().getText());
+
+
+        List<GotoRelatedItem> firstJavaGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstJavaGutter);
+        assertEquals("Navigation should have two targets", 2, firstJavaGutterTargets.size());
+        assertEquals("The navigation target XML tag name doesn't match", "to", getGuttersWithXMLTarget(firstJavaGutterTargets).get(0).getLocalName());
+        assertEquals("The navigation Java target element doesn't match", "from(\"file:outbox\")",
+                getGuttersWithJavaTarget(firstJavaGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
+
+        //from XML to Java
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstXmlGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) xmlGutters.get(1);
+        assertTrue(firstXmlGutter.getLineMarkerInfo().getElement() instanceof XmlToken);
+        assertEquals("The navigation start element doesn't match", "\"file:inbox\"",
+                (firstJavaGutter.getLineMarkerInfo().getElement()).getText());
+
+
+        List<GotoRelatedItem> firstXmlGutterTargets = GutterTestUtil.getGutterNavigationDestinationElements(firstXmlGutter);
+        assertEquals("Navigation should have two targets", 2, firstXmlGutterTargets.size());
+        assertEquals("The navigation target XML tag name doesn't match", "to", getGuttersWithXMLTarget(firstXmlGutterTargets).get(0).getLocalName());
+        assertEquals("The navigation Java target element doesn't match", "from(\"file:outbox\")",
+                getGuttersWithJavaTarget(firstXmlGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
+    }
+
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/XmlCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/XmlCamelRouteLineMarkerProviderTestIT.java
@@ -23,6 +23,7 @@ import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.codeInsight.daemon.GutterMark;
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
 import com.intellij.navigation.GotoRelatedItem;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.xml.XmlTag;
@@ -41,13 +42,13 @@ public class XmlCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsight
 
         assertEquals("Does not contain the expected amount of Camel gutters", 3, gutters.size());
 
-        Icon defaultIcon = ServiceManager.getService(CamelPreferenceService.class).getCamelIcon();
+        Icon defaultIcon = ApplicationManager.getApplication().getService(CamelPreferenceService.class).getCamelIcon();
         gutters.forEach(gutterMark -> {
             assertSame("Gutter should have the Camel icon", defaultIcon, gutterMark.getIcon());
             assertEquals("Camel route", gutterMark.getTooltipText());
         });
 
-        LineMarkerInfo.LineMarkerGutterIconRenderer firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(1);
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(1);
 
         assertTrue(firstGutter.getLineMarkerInfo().getElement() instanceof XmlToken);
         assertEquals("The navigation start element doesn't match", "file:inbox",
@@ -59,7 +60,7 @@ public class XmlCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsight
         assertEquals("The navigation target tag name doesn't match", "to",
                 GutterTestUtil.getGuttersWithXMLTarget(firstGutterTargets).get(0).getLocalName());
 
-        LineMarkerInfo.LineMarkerGutterIconRenderer secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(2);
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(2);
 
         assertTrue(secondGutter.getLineMarkerInfo().getElement() instanceof XmlToken);
         assertEquals("The navigation start element doesn't match", "file:outbox",
@@ -79,10 +80,10 @@ public class XmlCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsight
 
         assertEquals("Should contain 1 Camel gutter", 1, gutters.size());
 
-        assertSame("Gutter should have the Camel icon", ServiceManager.getService(CamelPreferenceService.class).getCamelIcon(), gutters.get(0).getIcon());
+        assertSame("Gutter should have the Camel icon", ApplicationManager.getApplication().getService(CamelPreferenceService.class).getCamelIcon(), gutters.get(0).getIcon());
         assertEquals("Camel route", gutters.get(0).getTooltipText());
 
-        LineMarkerInfo.LineMarkerGutterIconRenderer gutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(0);
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> gutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(0);
 
         assertTrue(gutter.getLineMarkerInfo().getElement() instanceof XmlToken);
         assertEquals("The navigation start element doesn't match", "file:inbox",

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/YamlCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/YamlCamelRouteLineMarkerProviderTestIT.java
@@ -25,6 +25,7 @@ import com.github.cameltooling.idea.service.CamelPreferenceService;
 import com.intellij.codeInsight.daemon.GutterMark;
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
 import com.intellij.navigation.GotoRelatedItem;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.xml.XmlTag;
@@ -44,13 +45,13 @@ public class YamlCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsigh
 
         assertEquals("Does not contain the expected amount of Camel gutters", 3, gutters.size());
 
-        Icon defaultIcon = ServiceManager.getService(CamelPreferenceService.class).getCamelIcon();
+        Icon defaultIcon = ApplicationManager.getApplication().getService(CamelPreferenceService.class).getCamelIcon();
         gutters.forEach(gutterMark -> {
             assertSame("Gutter should have the Camel icon", defaultIcon, gutterMark.getIcon());
             assertEquals("Camel route", gutterMark.getTooltipText());
         });
 
-        LineMarkerInfo.LineMarkerGutterIconRenderer firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(1);
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(1);
 
         assertSame(YAMLTokenTypes.SCALAR_KEY, firstGutter.getLineMarkerInfo().getElement().getNode().getElementType());
         assertEquals("from", firstGutter.getLineMarkerInfo().getElement().getText());
@@ -61,7 +62,7 @@ public class YamlCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsigh
         assertEquals("Navigation should have one target", 1, firstGutterTargets.size());
         assertEquals("The navigation target route doesn't match", "to: file:inbox", firstGutterTargets.get(0).getElement().getText());
 
-        LineMarkerInfo.LineMarkerGutterIconRenderer secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(2);
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(2);
 
         assertSame(YAMLTokenTypes.SCALAR_KEY, secondGutter.getLineMarkerInfo().getElement().getNode().getElementType());
         assertEquals("from", secondGutter.getLineMarkerInfo().getElement().getText());
@@ -81,10 +82,10 @@ public class YamlCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsigh
 
         assertEquals("Should contain 1 Camel gutter", 1, gutters.size());
 
-        assertSame("Gutter should have the Camel icon", ServiceManager.getService(CamelPreferenceService.class).getCamelIcon(), gutters.get(0).getIcon());
+        assertSame("Gutter should have the Camel icon", ApplicationManager.getApplication().getService(CamelPreferenceService.class).getCamelIcon(), gutters.get(0).getIcon());
         assertEquals("Camel route", gutters.get(0).getTooltipText());
 
-        LineMarkerInfo.LineMarkerGutterIconRenderer gutter = (LineMarkerInfo.LineMarkerGutterIconRenderer) gutters.get(0);
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> gutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(0);
 
         assertSame(YAMLTokenTypes.SCALAR_KEY, gutter.getLineMarkerInfo().getElement().getNode().getElementType());
         assertEquals("from", gutter.getLineMarkerInfo().getElement().getText());


### PR DESCRIPTION
Related to #590

## Motivation

Some tests are commented because they don't pass since the migration to Camel 3 & Intellij 2021.1.

## Modifications:

* Re-add the tests
* Adapt the tests to make them pass
* Fix some violations