### PR TITLE
Ref #413: Show Camel gutter for rest()

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/extension/CamelIdeaUtilsExtension.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/extension/CamelIdeaUtilsExtension.java
@@ -48,6 +48,13 @@ public interface CamelIdeaUtilsExtension {
     boolean isInsideCamelRoute(PsiElement element, boolean excludeRouteStart);
 
     /**
+     * Indicates whether the given element can be marked with a line marker.
+     * @param element the element to check.
+     * @return {@code true} if it can be marked, {@code false} otherwise.
+     */
+    boolean isCamelLineMarker(PsiElement element);
+
+    /**
      * Is the given element a language of a Camel route
      *
      * @param element the element

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/extension/camel/YamlCamelIdeaUtils.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/extension/camel/YamlCamelIdeaUtils.java
@@ -27,7 +27,8 @@ import com.github.cameltooling.idea.util.IdeaUtils;
 import com.github.cameltooling.idea.util.YamlPatternConditions;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.module.Module;
 import com.intellij.patterns.ElementPattern;
@@ -51,12 +52,10 @@ import org.jetbrains.yaml.psi.YAMLValue;
 public class YamlCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtilsExtension {
 
     private static final List<String> YAML_ROUTES = Arrays.asList(
-        new String[] {
-            "routes",
-            "routeConfigurations",
-            "route",
-            "routeConfiguration"
-        });
+        "routes",
+        "routeConfigurations",
+        "route",
+        "routeConfiguration");
     /**
      * All keys representing the potential producers.
      */
@@ -310,6 +309,16 @@ public class YamlCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
         return false;
     }
 
+    /**
+     * @param element the element to test.
+     * @return {@code true} if the given element is a scalar key, {@code false} otherwise.
+     */
+    @Override
+    public boolean isCamelLineMarker(PsiElement element) {
+        final ASTNode node = element.getNode();
+        return node != null && node.getElementType() == YAMLTokenTypes.SCALAR_KEY;
+    }
+
     @Override
     public boolean skipEndpointValidation(PsiElement element) {
         return false;
@@ -378,12 +387,12 @@ public class YamlCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
         if (keyValue == null) {
             return false;
         }
-        final String key = keyValue.getKeyText();
-        return Arrays.asList(PLACE_FOR_ENDPOINT_URI).contains(key) && isInsideCamelRoute(location, false);
+        return Arrays.asList(PLACE_FOR_ENDPOINT_URI).contains(keyValue.getKeyText())
+            && isInsideCamelRoute(location, false);
     }
 
     private IdeaUtils getIdeaUtils() {
-        return ServiceManager.getService(IdeaUtils.class);
+        return ApplicationManager.getApplication().getService(IdeaUtils.class);
     }
 
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/CamelIdeaUtils.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/CamelIdeaUtils.java
@@ -82,6 +82,16 @@ public final class CamelIdeaUtils implements Disposable {
             .anyMatch(extension -> extension.isCamelRouteStartExpression(element));
     }
 
+    /**
+     * Indicates whether the given element can be marked with a line marker.
+     * @param element the element to check.
+     * @return {@code true} if it can be marked, {@code false} otherwise.
+     */
+    public boolean isCamelLineMarker(PsiElement element) {
+        return enabledExtensions.stream()
+            .anyMatch(extension -> extension.isCamelLineMarker(element));
+    }
+
     public boolean isInsideCamelRoute(PsiElement element, boolean excludeRouteStart) {
         return enabledExtensions.stream()
             .anyMatch(extension -> extension.isInsideCamelRoute(element, excludeRouteStart));

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/JavaCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/JavaCamelRouteLineMarkerProviderTestIT.java
@@ -39,9 +39,21 @@ public class JavaCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsigh
         List<GutterMark> gutters = myFixture.findAllGutters();
         assertNotNull(gutters);
 
-        assertEquals("Should contain 3 Camel gutters", 3, gutters.size());
+        assertEquals("Should contain 4 Camel gutters", 4, gutters.size());
 
         assertGuttersHasCamelIcon(gutters);
+
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstRestGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(0);
+
+        assertTrue(firstRestGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "\"/say\"",
+            firstRestGutter.getLineMarkerInfo().getElement().getText());
+
+        LineMarkerInfo.LineMarkerGutterIconRenderer<?> secondRestGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(3);
+
+        assertTrue(secondRestGutter.getLineMarkerInfo().getElement() instanceof PsiJavaToken);
+        assertEquals("The navigation start element doesn't match", "rest",
+            secondRestGutter.getLineMarkerInfo().getElement().getText());
 
         LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(1);
 
@@ -54,7 +66,6 @@ public class JavaCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsigh
         assertEquals("Navigation should have one target", 1, firstGutterTargets.size());
         assertEquals("The navigation target element doesn't match", "from(\"file:outbox\")",
             GutterTestUtil.getGuttersWithJavaTarget(firstGutterTargets).get(0).getMethodExpression().getQualifierExpression().getText());
-
 
         LineMarkerInfo.LineMarkerGutterIconRenderer<?> secondGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) gutters.get(2);
 

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/MultiLanguageCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/MultiLanguageCamelRouteLineMarkerProviderTestIT.java
@@ -41,8 +41,8 @@ public class MultiLanguageCamelRouteLineMarkerProviderTestIT extends CamelLightC
         List<GutterMark> xmlGutters = myFixture.findAllGutters("XmlCamelRouteLineMarkerProviderTestData.xml");
         assertNotNull(xmlGutters);
 
-        assertEquals("Should contain 3 Java Camel gutters", 3, javaGutters.size());
-        assertEquals("Should contain 3 XML Camel gutters", 3, xmlGutters.size());
+        assertEquals("Should contain 4 Java Camel gutters", 4, javaGutters.size());
+        assertEquals("Should contain 4 XML Camel gutters", 4, xmlGutters.size());
 
         //from Java to XML
         LineMarkerInfo.LineMarkerGutterIconRenderer<?> firstJavaGutter = (LineMarkerInfo.LineMarkerGutterIconRenderer<?>) javaGutters.get(1);

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/XmlCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/XmlCamelRouteLineMarkerProviderTestIT.java
@@ -17,14 +17,14 @@
 package com.github.cameltooling.idea.gutter;
 
 import java.util.List;
-import javax.swing.*;
+
+import javax.swing.Icon;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.codeInsight.daemon.GutterMark;
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
 import com.intellij.navigation.GotoRelatedItem;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.psi.xml.XmlToken;
@@ -40,7 +40,7 @@ public class XmlCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsight
         List<GutterMark> gutters = myFixture.findAllGutters();
         assertNotNull(gutters);
 
-        assertEquals("Does not contain the expected amount of Camel gutters", 3, gutters.size());
+        assertEquals("Does not contain the expected amount of Camel gutters", 4, gutters.size());
 
         Icon defaultIcon = ApplicationManager.getApplication().getService(CamelPreferenceService.class).getCamelIcon();
         gutters.forEach(gutterMark -> {

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/YamlCamelRouteLineMarkerProviderTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/gutter/YamlCamelRouteLineMarkerProviderTestIT.java
@@ -18,7 +18,7 @@ package com.github.cameltooling.idea.gutter;
 
 import java.util.List;
 
-import javax.swing.*;
+import javax.swing.Icon;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.github.cameltooling.idea.service.CamelPreferenceService;
@@ -26,10 +26,7 @@ import com.intellij.codeInsight.daemon.GutterMark;
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
 import com.intellij.navigation.GotoRelatedItem;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.intellij.psi.xml.XmlTag;
-import com.intellij.psi.xml.XmlToken;
 import org.jetbrains.yaml.YAMLTokenTypes;
 import org.jetbrains.yaml.psi.YAMLMapping;
 
@@ -43,7 +40,7 @@ public class YamlCamelRouteLineMarkerProviderTestIT extends CamelLightCodeInsigh
         List<GutterMark> gutters = myFixture.findAllGutters();
         assertNotNull(gutters);
 
-        assertEquals("Does not contain the expected amount of Camel gutters", 3, gutters.size());
+        assertEquals("Does not contain the expected amount of Camel gutters", 4, gutters.size());
 
         Icon defaultIcon = ApplicationManager.getApplication().getService(CamelPreferenceService.class).getCamelIcon();
         gutters.forEach(gutterMark -> {

--- a/camel-idea-plugin/src/test/resources/testData/JavaCamelRouteLineMarkerProviderTestData.java
+++ b/camel-idea-plugin/src/test/resources/testData/JavaCamelRouteLineMarkerProviderTestData.java
@@ -29,5 +29,9 @@ public class JavaCamelRouteLineMarkerProviderTestData extends RouteBuilder {
                 .to("file:outbox");
         from("file:outbox")
                 .to("file:inbox");
+        rest()
+            .get("/hello").to("direct:hello")
+            .get("/bye").consumes("application/json").to("direct:bye")
+            .post("/bye").to("mock:update");
     }
 }

--- a/camel-idea-plugin/src/test/resources/testData/XmlCamelRouteLineMarkerProviderTestData.xml
+++ b/camel-idea-plugin/src/test/resources/testData/XmlCamelRouteLineMarkerProviderTestData.xml
@@ -33,4 +33,15 @@
     <from uri="file:outbox"/>
     <to uri="file:inbox"/>
   </route>
+  <rest>
+    <get uri="/hello">
+      <to uri="direct:hello"/>
+    </get>
+    <get uri="/bye" consumes="application/json">
+      <to uri="direct:bye"/>
+    </get>
+    <post uri="/bye">
+      <to uri="mock:update"/>
+    </post>
+  </rest>
 </routes>

--- a/camel-idea-plugin/src/test/resources/testData/YamlCamelRouteLineMarkerProviderTestData.yaml
+++ b/camel-idea-plugin/src/test/resources/testData/YamlCamelRouteLineMarkerProviderTestData.yaml
@@ -39,3 +39,17 @@
       uri: "file:outbox"
       steps:
         - to: file:inbox
+- rest:
+    get:
+      - path: "/hello"
+        to:
+          uri: "direct:hello"
+      - consumes: "application/json"
+        path: "/bye"
+        to:
+          uri: "direct:bye"
+    post:
+      - path: "/bye"
+        to:
+          uri: "mock:update"
+


### PR DESCRIPTION
fixes #413 

## Motivation

When using the rest DSL, no gutter is shown for `rest()`

## Modifications:

* Move the logic that identifies patterns for gutter in extensions
* Add test with a rest definition without URI for each supported extension
* Fix violations on files modified (not related to the initial issue)