### PR TITLE
Ref #426: Strike through deprecated options in URI

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/CamelEndpointAnnotator.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/CamelEndpointAnnotator.java
@@ -19,6 +19,7 @@ package com.github.cameltooling.idea.annotator;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+
 import com.github.cameltooling.idea.reference.endpoint.CamelEndpoint;
 import com.github.cameltooling.idea.reference.endpoint.direct.DirectEndpointReference;
 import com.github.cameltooling.idea.service.CamelCatalogService;
@@ -26,15 +27,19 @@ import com.github.cameltooling.idea.service.CamelPreferenceService;
 import com.github.cameltooling.idea.service.QueryUtils;
 import com.github.cameltooling.idea.util.CamelIdeaUtils;
 import com.github.cameltooling.idea.util.IdeaUtils;
+import com.intellij.lang.annotation.AnnotationBuilder;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.HighlightSeverity;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.markup.EffectType;
+import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.ResolveResult;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.xml.XmlToken;
+import com.intellij.ui.JBColor;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.EndpointValidationResult;
 import org.jetbrains.annotations.NotNull;
@@ -49,31 +54,47 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
 
     private static final Logger LOG = Logger.getInstance(CamelEndpointAnnotator.class);
 
+    /**
+     * The specific text attributes in case of a deprecation.
+     */
+    private static final TextAttributes DEPRECATION_ATTRIBUTES;
+    static {
+        TextAttributes textAttributes = new TextAttributes();
+        textAttributes.setEffectType(EffectType.STRIKEOUT);
+        textAttributes.setEffectColor(JBColor.BLACK);
+        DEPRECATION_ATTRIBUTES = textAttributes;
+    }
+
     @Override
     boolean isEnabled() {
-        return ServiceManager.getService(CamelPreferenceService.class).isRealTimeEndpointValidation();
+        return getCamelPreferenceService().isRealTimeEndpointValidation();
     }
 
     /**
      * Validate endpoint options list aka properties. eg "timer:trigger?delay=1000&bridgeErrorHandler=true"
-     * if the URI is not valid a error annotation is created and highlight the invalid value.
+     * if the URI is not valid an error annotation is created and highlight the invalid value.
      */
     void validateText(@NotNull PsiElement element, @NotNull AnnotationHolder holder, @NotNull String uri) {
         if (QueryUtils.isQueryContainingCamelComponent(element.getProject(), uri)) {
-            CamelCatalog catalogService = ServiceManager.getService(element.getProject(), CamelCatalogService.class).get();
-
             IElementType type = element.getNode().getElementType();
-            LOG.trace("Element " + element + " of type: " + type + " to validate endpoint uri: " + uri);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(String.format("Element %s of type: %s to validate endpoint uri: %s", element, type, uri));
+            }
 
             // skip special values such as configuring ActiveMQ brokerURL
             if (getCamelIdeaUtils().skipEndpointValidation(element)) {
-                LOG.debug("Skipping element " + element + " for validation with text: " + uri);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("Skipping element %s for validation with text: %s", element, uri));
+                }
                 return;
             }
 
             // camel catalog expects &amp; as & when it parses so replace all &amp; as &
             String camelQuery = getIdeaUtils().getInnerText(uri);
-            camelQuery = camelQuery.replaceAll("&amp;", "&");
+            if (camelQuery == null) {
+                return;
+            }
+            camelQuery = camelQuery.replace("&amp;", "&");
 
             // strip up ending incomplete parameter
             if (camelQuery.endsWith("&") || camelQuery.endsWith("?")) {
@@ -83,9 +104,9 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
             boolean stringFormat = getCamelIdeaUtils().isFromStringFormatEndpoint(element);
             if (stringFormat) {
                 // if the node is fromF or toF, then replace all %X with {{%X}} as we cannot parse that value
-                camelQuery = camelQuery.replaceAll("%s", "\\{\\{\\%s\\}\\}");
-                camelQuery = camelQuery.replaceAll("%d", "\\{\\{\\%d\\}\\}");
-                camelQuery = camelQuery.replaceAll("%b", "\\{\\{\\%b\\}\\}");
+                camelQuery = camelQuery.replace("%s", "{{%s}}");
+                camelQuery = camelQuery.replace("%d", "{{%d}}");
+                camelQuery = camelQuery.replace("%b", "{{%b}}");
             }
 
             boolean consumerOnly = getCamelIdeaUtils().isConsumerEndpoint(element);
@@ -96,21 +117,22 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
             }
 
             try {
-                CamelPreferenceService preference = getCamelPreferenceService();
-
+                CamelCatalog catalogService = element.getProject().getService(CamelCatalogService.class).get();
                 EndpointValidationResult result = catalogService.validateEndpointProperties(camelQuery, false, consumerOnly, producerOnly);
 
                 extractMapValue(result, result.getInvalidBoolean(), uri, element, holder, new BooleanErrorMsg());
                 extractMapValue(result, result.getInvalidEnum(), uri, element, holder, new EnumErrorMsg());
                 extractMapValue(result, result.getInvalidInteger(), uri, element, holder, new IntegerErrorMsg());
+                extractMapValue(result, result.getInvalidDuration(), uri, element, holder, new DurationErrorMsg());
                 extractMapValue(result, result.getInvalidNumber(), uri, element, holder, new NumberErrorMsg());
                 extractMapValue(result, result.getInvalidReference(), uri, element, holder, new ReferenceErrorMsg());
-                extractSetValue(result, result.getUnknown(), uri, element, holder, new UnknownErrorMsg(), false);
-                extractSetValue(result, result.getLenient(), uri, element, holder, new LenientOptionMsg(preference.isHighlightCustomOptions()), true);
-                extractSetValue(result, result.getNotConsumerOnly(), uri, element, holder, new NotConsumerOnlyErrorMsg(), false);
-                extractSetValue(result, result.getNotProducerOnly(), uri, element, holder, new NotProducerOnlyErrorMsg(), false);
-            } catch (Throwable e) {
-                LOG.warn("Error validating Camel endpoint: " + uri, e);
+                extractSetValue(result, result.getUnknown(), uri, element, holder, new UnknownErrorMsg(), false, null);
+                extractSetValue(result, result.getLenient(), uri, element, holder, new LenientOptionMsg(getCamelPreferenceService().isHighlightCustomOptions()), true, null);
+                extractSetValue(result, result.getNotConsumerOnly(), uri, element, holder, new NotConsumerOnlyErrorMsg(), false, null);
+                extractSetValue(result, result.getNotProducerOnly(), uri, element, holder, new NotProducerOnlyErrorMsg(), false, null);
+                extractSetValue(result, result.getDeprecated(), uri, element, holder, new DeprecatedErrorMsg(), true, DEPRECATION_ATTRIBUTES);
+            } catch (Exception e) {
+                LOG.warn(String.format("Error validating Camel endpoint: %s", uri), e);
             }
         }
     }
@@ -121,26 +143,38 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
         }
         if (CamelEndpoint.isDirectEndpoint(camelQuery)) { //only direct endpoints have references (for now)
             Arrays.stream(element.getReferences())
-                .filter(r -> r instanceof DirectEndpointReference)
-                .map(r -> (DirectEndpointReference) r)
+                .filter(DirectEndpointReference.class::isInstance)
+                .map(DirectEndpointReference.class::cast)
                 .findAny()
                 .ifPresent(endpointReference -> {
                     ResolveResult[] targets = endpointReference.multiResolve(false);
                     if (targets.length == 0) {
                         TextRange range = endpointReference.getRangeInElement().shiftRight(element.getTextRange().getStartOffset());
-                        holder.newAnnotation(HighlightSeverity.ERROR, "Cannot find endpoint declaration: " + endpointReference.getCanonicalText())
+                        holder.newAnnotation(HighlightSeverity.ERROR, String.format("Cannot find endpoint declaration: %s", endpointReference.getCanonicalText()))
                             .range(range).create();
                     }
                 });
         }
     }
 
+    /**
+     * @return the {@link HighlightSeverity} corresponding to the given message
+     */
+    private HighlightSeverity getHighlightSeverity(CamelAnnotatorEndpointMessage<?> msg) {
+        if (msg.isInfoLevel()) {
+            return HighlightSeverity.INFORMATION;
+        } else if (msg.isWarnLevel()) {
+            return HighlightSeverity.WARNING;
+        }
+        return HighlightSeverity.ERROR;
+    }
+
     private void extractSetValue(EndpointValidationResult result, Set<String> validationSet, String fromElement, PsiElement element,
-                                 AnnotationHolder holder, CamelAnnotatorEndpointMessage msg, boolean lenient) {
+                                 AnnotationHolder holder, CamelAnnotatorEndpointMessage<String> msg, boolean lenient,
+                                 TextAttributes textAttributes) {
         if (validationSet != null && (lenient || !result.isSuccess())) {
 
-            for (String entry : validationSet) {
-                String propertyValue = entry;
+            for (String propertyValue : validationSet) {
 
                 int startIdxQueryParameters = fromElement.indexOf("?" + propertyValue);
                 startIdxQueryParameters = (startIdxQueryParameters == -1) ? fromElement.indexOf("&" + propertyValue) : fromElement.indexOf("?");
@@ -153,22 +187,20 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
                 TextRange range = new TextRange(element.getTextRange().getStartOffset() + propertyIdx,
                     element.getTextRange().getStartOffset() + propertyIdx + propertyLength);
 
-                if (msg.isInfoLevel()) {
-                    holder.newAnnotation(HighlightSeverity.INFORMATION, summaryMessage(result, propertyValue, msg))
-                            .range(range).create();
-                } else if (msg.isWarnLevel()) {
-                    holder.newAnnotation(HighlightSeverity.WARNING, summaryMessage(result, propertyValue, msg))
-                            .range(range).create();
-                } else {
-                    holder.newAnnotation(HighlightSeverity.ERROR, summaryMessage(result, propertyValue, msg))
-                            .range(range).create();
+                AnnotationBuilder builder = holder.newAnnotation(getHighlightSeverity(msg), summaryMessage(result, propertyValue, msg));
+                if (textAttributes != null) {
+                    builder
+                        .enforcedTextAttributes(textAttributes);
                 }
+                builder
+                    .range(range).create();
             }
         }
     }
 
     private void extractMapValue(EndpointValidationResult result, Map<String, String> validationMap,
-                                 String fromElement, @NotNull PsiElement element, @NotNull AnnotationHolder holder, CamelAnnotatorEndpointMessage msg) {
+                                 String fromElement, @NotNull PsiElement element, @NotNull AnnotationHolder holder,
+                                 CamelAnnotatorEndpointMessage<Map.Entry<String, String>> msg) {
         if ((!result.isSuccess()) && validationMap != null) {
 
             for (Map.Entry<String, String> entry : validationMap.entrySet()) {
@@ -212,12 +244,10 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
     private static class BooleanErrorMsg implements CamelAnnotatorEndpointMessage<Map.Entry<String, String>> {
         @Override
         public String getErrorMessage(EndpointValidationResult result, Map.Entry<String, String> entry) {
-            boolean empty = entry.getValue() == null || entry.getValue().length() == 0;
-            if (empty) {
+            if (entry.getValue() == null || entry.getValue().isEmpty()) {
                 return "Empty boolean value";
-            } else {
-                return "Invalid boolean value: " + entry.getValue();
             }
+            return String.format("Invalid boolean value: %s", entry.getValue());
         }
     }
 
@@ -246,26 +276,32 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
     private static class ReferenceErrorMsg implements CamelAnnotatorEndpointMessage<Map.Entry<String, String>> {
         @Override
         public String getErrorMessage(EndpointValidationResult result, Map.Entry<String, String> entry) {
-            boolean empty = isEmpty(entry.getValue());
-            if (empty) {
+            if (isEmpty(entry.getValue())) {
                 return "Empty reference value";
             } else if (!entry.getValue().startsWith("#")) {
-                return "Invalid reference value: " + entry.getValue() + " must start with #";
-            } else {
-                return "Invalid reference value: " + entry.getValue();
+                return String.format("Invalid reference value: %s must start with #", entry.getValue());
             }
+            return String.format("Invalid reference value: %s", entry.getValue());
         }
     }
 
     private static class IntegerErrorMsg implements CamelAnnotatorEndpointMessage<Map.Entry<String, String>> {
         @Override
         public String getErrorMessage(EndpointValidationResult result, Map.Entry<String, String> entry) {
-            boolean empty = isEmpty(entry.getValue());
-            if (empty) {
+            if (isEmpty(entry.getValue())) {
                 return "Empty integer value";
-            } else {
-                return "Invalid integer value: " + entry.getValue();
             }
+            return String.format("Invalid integer value: %s", entry.getValue());
+        }
+    }
+
+    private static class DurationErrorMsg implements CamelAnnotatorEndpointMessage<Map.Entry<String, String>> {
+        @Override
+        public String getErrorMessage(EndpointValidationResult result, Map.Entry<String, String> entry) {
+            if (isEmpty(entry.getValue())) {
+                return "Empty duration value";
+            }
+            return String.format("Invalid duration value: %s", entry.getValue());
         }
     }
 
@@ -273,6 +309,19 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
         @Override
         public String getErrorMessage(EndpointValidationResult result, String property) {
             return "Unknown option";
+        }
+    }
+
+    private static class DeprecatedErrorMsg implements CamelAnnotatorEndpointMessage<String> {
+        @Override
+        public String getErrorMessage(EndpointValidationResult result, String property) {
+            return "Deprecated option";
+        }
+
+        @Override
+        public boolean isWarnLevel() {
+            // this is only a warning
+            return true;
         }
     }
 
@@ -286,7 +335,7 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
 
         @Override
         public String getErrorMessage(EndpointValidationResult result, String property) {
-            return property + " is a custom option that is not part of the Camel component";
+            return String.format("%s is a custom option that is not part of the Camel component", property);
         }
 
         @Override
@@ -303,12 +352,10 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
     private static class NumberErrorMsg implements CamelAnnotatorEndpointMessage<Map.Entry<String, String>> {
         @Override
         public String getErrorMessage(EndpointValidationResult result, Map.Entry<String, String> entry) {
-            boolean empty = isEmpty(entry.getValue());
-            if (empty) {
+            if (isEmpty(entry.getValue())) {
                 return "Empty number value";
-            } else {
-                return "Invalid number value: " + entry.getValue();
             }
+            return String.format("Invalid number value: %s", entry.getValue());
         }
     }
 
@@ -343,8 +390,7 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
      *
      * @return the summary, or <tt>empty</tt> if no validation errors
      */
-    @SuppressWarnings("unchecked")
-    private <T> String summaryMessage(EndpointValidationResult result, T entry, CamelAnnotatorEndpointMessage msg) {
+    private <T> String summaryMessage(EndpointValidationResult result, T entry, CamelAnnotatorEndpointMessage<T> msg) {
         if (result.getIncapable() != null) {
             return "Incapable of parsing uri: " + result.getIncapable();
         } else if (result.getSyntaxError() != null) {
@@ -357,15 +403,15 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
     }
 
     private static CamelPreferenceService getCamelPreferenceService() {
-        return ServiceManager.getService(CamelPreferenceService.class);
+        return ApplicationManager.getApplication().getService(CamelPreferenceService.class);
     }
 
     private static IdeaUtils getIdeaUtils() {
-        return ServiceManager.getService(IdeaUtils.class);
+        return ApplicationManager.getApplication().getService(IdeaUtils.class);
     }
 
     private CamelIdeaUtils getCamelIdeaUtils() {
-        return ServiceManager.getService(CamelIdeaUtils.class);
+        return ApplicationManager.getApplication().getService(CamelIdeaUtils.class);
     }
 
 }

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
         <li>Upgrade to Camel 3.19</li>
         <li>Set the body, Headers or Exchange properties from the context menu of the Debugger Window using the Camel simple language</li>
         <li>Adapt the debugger to Camel 3.19+</li>
+        <li>Deprecated endpoint options are now marked with strike-through in endpoint URI</li>
       </ul>
     ]]>
   </change-notes>

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/annotator/CamelEndpointAnnotatorTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/annotator/CamelEndpointAnnotatorTestIT.java
@@ -21,10 +21,11 @@ import java.util.List;
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.lang.annotation.HighlightSeverity;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Test Camel URI validation and the expected value is highlighted
- *
+ * <p>
  * TIP : Writing highlighting test can be tricky because if the highlight is one character off
  * it will fail, but the error messaged might still be correct. In this case it's likely the TextRange
  * is incorrect.
@@ -34,6 +35,12 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
     @Override
     protected String getTestDataPath() {
         return "src/test/resources/testData/annotator/";
+    }
+
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{CAMEL_CORE_MODEL_MAVEN_ARTIFACT};
     }
 
     public void testAnnotatorStringFormatValid() {
@@ -67,25 +74,22 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
         myFixture.checkHighlighting(false, false, true, true);
     }
 
-//    @Ignore
-//    public void testAnnotatorWithTheSameWordTwiceValidation() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaWithSameWordTwiceTestData());
-//        myFixture.checkHighlighting(false, false, true, true);
-//    }
+    public void testAnnotatorWithTheSameWordTwiceValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaWithSameWordTwiceTestData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
 
     public void testAnnotatorUnknownOptionWithPAthValidation() {
         myFixture.configureByText("AnnotatorTestData.java", getJavaUnknownOptionsWithPathConsumerTestData());
         myFixture.checkHighlighting(false, false, true, true);
     }
 
-//    @Ignore
-//    public void testExpectedSymbolFunctionEndButWasEOL() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaExpectedSymbolFunctionEndTestData());
-//        myFixture.checkHighlighting(false, false, true, true);
-//    }
+    public void testExpectedSymbolFunctionEndButWasEOL() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaExpectedSymbolFunctionEndTestData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
 
     public void testAnnotatorUnknownOptionWithConsumerAnnotationValidation() {
-        //assertTrue("Ignored until we fix the issue with running the test with SDK", true);
         myFixture.configureByText("AnnotatorTestData.java", getJavaUnknownOptionsConsumerAnnotationTestData());
         myFixture.checkHighlighting(false, false, true, true);
     }
@@ -100,17 +104,39 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
         myFixture.checkHighlighting(false, false, true, true);
     }
 
-//    @Ignore
-//    public void testAnnotatorIntegerPropertyValidation() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaInvalidIntegerPropertyTestData());
-//        myFixture.checkHighlighting(false, false, true, true);
-//    }
+    public void testAnnotatorIntegerPropertyValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaInvalidIntegerPropertyTestData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
 
-//    @Ignore
-//    public void testXmlAnnotatorIntegerPropertyValidation() {
-//        myFixture.configureByText("AnnotatorTestData.xml", getXmlInvalidIntegerPropertyTestData());
-//        myFixture.checkHighlighting(false, false, true, true);
-//    }
+    public void testXmlAnnotatorIntegerPropertyValidation() {
+        myFixture.configureByText("AnnotatorTestData.xml", getXmlInvalidIntegerPropertyTestData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
+
+    public void testAnnotatorDeprecatedPropertyValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaDeprecatedPropertyTestData());
+        myFixture.checkHighlighting(false, false, true, true);
+
+        List<HighlightInfo> list = myFixture.doHighlighting();
+
+        System.out.println("list=" + list);
+        // find the warning from the highlights as checkWarning cannot do that for us for warnings
+        boolean found = list.stream().anyMatch(i -> i.getText().equals("cache")
+            && i.getDescription().equals("Deprecated option")
+            && i.getSeverity().equals(HighlightSeverity.WARNING));
+        assertTrue("Should find the warning", found);
+    }
+
+    public void testAnnotatorDurationPropertyValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaInvalidDurationPropertyTestData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
+
+    public void testXmlAnnotatorDurationPropertyValidation() {
+        myFixture.configureByText("AnnotatorTestData.xml", getXmlInvalidDurationPropertyTestData());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
 
     public void testXmlAnnotatorWithCommentValidation() {
         myFixture.configureByText("AnnotatorTestData.xml", getXmlWithCommentTestData());
@@ -236,7 +262,7 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
         return "import org.apache.camel.builder.RouteBuilder;\n"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
             + "        public void configure() throws Exception {\n"
-            + "            from(\"timer:trigger?delay=<error descr=\"Invalid integer value: foo\">foo</error>&<error descr=\"Unknown option\">foo</error>=bar\")\n"
+            + "            from(\"sql:foo?backoffErrorThreshold=<error descr=\"Invalid integer value: foo\">foo</error>&<error descr=\"Unknown option\">foo</error>=bar\")\n"
             + "                .to(\"file:test?allowNullBody=true&<error descr=\"Unknown option\">foo</error>=bar\")\n"
             + "        }\n"
             + "    }";
@@ -273,6 +299,7 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
 
     private String getJavaExpectedSymbolFunctionEndTestData() {
         return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "import org.apache.camel.Exchange;\n"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
             + "        public void configure() throws Exception {\n"
             + "            from(\"direct:start\")\n"
@@ -308,7 +335,7 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
         return "import org.apache.camel.builder.RouteBuilder;\n"
             + "public class MyRouteBuilder extends RouteBuilder {\n"
             + "        public void configure() throws Exception {\n"
-            + "            from(\"timer:trigger?delay=<error descr=\"Invalid integer value: ImNotANumber\">ImNotANumber</error>\")\n"
+            + "            from(\"sql:foo?backoffErrorThreshold=<error descr=\"Invalid integer value: ImNotANumber\">ImNotANumber</error>\")\n"
             + "                .to(\"file:outbox\");\n"
             + "        }\n"
             + "    }";
@@ -316,7 +343,34 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
 
     private String getXmlInvalidIntegerPropertyTestData() {
         return "<route id=\"generateOrder-route\">\n"
-            + "      <from uri=\"timer:trigger?delay=<error descr=\"Invalid integer value: ImNotANumber\">ImNotANumber</error>\"/>\n"
+            + "      <from uri=\"sql:foo?backoffErrorThreshold=<error descr=\"Invalid integer value: ImNotANumber\">ImNotANumber</error>\"/>\n"
+            + "      <to uri=\"file:outbox\"/>\n"
+            + "    </route>";
+    }
+
+    private String getJavaInvalidDurationPropertyTestData() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"timer:trigger?delay=<error descr=\"Invalid duration value: ImNotADuration\">ImNotADuration</error>\")\n"
+            + "                .to(\"file:outbox\");\n"
+            + "        }\n"
+            + "    }";
+    }
+
+    private String getJavaDeprecatedPropertyTestData() {
+        return "import org.apache.camel.builder.RouteBuilder;\n"
+            + "public class MyRouteBuilder extends RouteBuilder {\n"
+            + "        public void configure() throws Exception {\n"
+            + "            from(\"timer:trigger\")\n"
+            + "                .to(\"bean:out?cache=true\");\n"
+            + "        }\n"
+            + "    }";
+    }
+
+    private String getXmlInvalidDurationPropertyTestData() {
+        return "<route id=\"generateOrder-route\">\n"
+            + "      <from uri=\"timer:trigger?delay=<error descr=\"Invalid duration value: ImNotADuration\">ImNotADuration</error>\"/>\n"
             + "      <to uri=\"file:outbox\"/>\n"
             + "    </route>";
     }


### PR DESCRIPTION
fixes #426 

## Motivation

We would like to be able to strike through deprecated options in URI.

## Modifications:

* Add support for deprecated options in the `EndpointValidationResult`
* Set specific text attributes in case of deprecation to have it strikeout
* Fix violations
* Re-add commented tests
* Add support for duration options in the `EndpointValidationResult`

## Result

![Deprecated Option](https://user-images.githubusercontent.com/1618116/202660611-6f8c0a91-8293-4ffc-887f-51ea2f09953d.png)
