### PR TITLE
Ref #769: Allow to load a runtime provider w/o the core artifacts

### DIFF
--- a/camel-idea-plugin/build.gradle
+++ b/camel-idea-plugin/build.gradle
@@ -80,6 +80,8 @@ dependencies {
 description = 'Apache Camel IDE :: IDEA Plugin'
 
 test {
+    // Force a specific grape configuration as temporary fix to prevent dependency retrieval issues
+    systemProperty("grape.config", "grapeConfig.xml")
 // Start: To get Grape log messages
 //    systemProperty("groovy.grape.report.downloads", "true")
 //    systemProperty("ivy.message.logger.level", "4")

--- a/camel-idea-plugin/grapeConfig.xml
+++ b/camel-idea-plugin/grapeConfig.xml
@@ -1,0 +1,35 @@
+<!--
+
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+
+-->
+<ivysettings>
+  <settings defaultResolver="downloadGrapes"/>
+  <resolvers>
+    <chain name="downloadGrapes" returnFirst="true">
+      <filesystem name="cachedGrapes">
+        <ivy pattern="${user.home}/.groovy/grapes/[organisation]/[module]/ivy-[revision].xml"/>
+        <artifact pattern="${user.home}/.groovy/grapes/[organisation]/[module]/[type]s/[artifact]-[revision](-[classifier]).[ext]"/>
+      </filesystem>
+      <!-- Remove localm2 as temporary fix to prevent getting dependency retrieval issues with Grape -->
+      <!--ibiblio name="localm2" root="${user.home.url}/.m2/repository/" checkmodified="true" changingPattern=".*" changingMatcher="regexp" m2compatible="true"/-->
+      <!-- TODO: add 'endorsed groovy extensions' resolver here -->
+      <ibiblio name="ibiblio" m2compatible="true"/>
+    </chain>
+  </resolvers>
+</ivysettings>

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelService.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelService.java
@@ -53,7 +53,6 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
-import com.intellij.openapi.roots.CompilerModuleExtension;
 import com.intellij.openapi.roots.LibraryOrderEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.OrderEntry;
@@ -282,7 +281,7 @@ public class CamelService implements Disposable {
      * otherwise.
      */
     @Nullable
-    private synchronized ArtifactCoordinates getProjectCamelCoreCoordinates() {
+    public synchronized ArtifactCoordinates getProjectCamelCoreCoordinates() {
         for (ArtifactCoordinates coordinates : projectLibraries.values()) {
             if (isCamel2CoreMavenDependency(coordinates) || isCamel3CoreMavenDependency(coordinates)) {
                 return coordinates;

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/ArtifactCoordinates.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/ArtifactCoordinates.java
@@ -84,6 +84,18 @@ public final class ArtifactCoordinates {
     }
 
     /**
+     * Construct a {@code ArtifactCoordinates} with the given parameters.
+     * @param groupId the id of the group of the artifact.
+     * @param artifactId the id of the artifact.
+     * @param version the version of the artifact.
+     * @return the corresponding {@code ArtifactCoordinates}.
+     */
+    @NotNull
+    public static ArtifactCoordinates of(@NotNull String groupId, @NotNull String artifactId, @Nullable String version) {
+        return new ArtifactCoordinates(groupId, artifactId, version);
+    }
+
+    /**
      * @return the id of the group of the artifact.
      */
     @NotNull

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionSpringBootLegacyTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionSpringBootLegacyTestIT.java
@@ -16,15 +16,8 @@
  */
 package com.github.cameltooling.idea.completion;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
-import com.github.cameltooling.idea.completion.extension.PropertiesPropertyPlaceholdersSmartCompletion;
-import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.roots.ModifiableRootModel;
-import org.codehaus.plexus.util.FileUtils;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -32,13 +25,6 @@ import org.jetbrains.annotations.Nullable;
  * the Spring Boot runtime.
  */
 public class PropertiesPropertyKeyCompletionSpringBootLegacyTestIT extends PropertiesPropertyKeyCompletionSpringBootTestIT {
-
-    private static final Logger LOG = Logger.getInstance(PropertiesPropertyKeyCompletionSpringBootLegacyTestIT.class);
-
-    /**
-     * Indicates whether the jaxb libs could be removed from the local caches.
-     */
-    private boolean couldDeleteJaxb;
 
     @Nullable
     @Override
@@ -52,44 +38,12 @@ public class PropertiesPropertyKeyCompletionSpringBootLegacyTestIT extends Prope
         };
     }
 
-    @Override
-    protected void loadDependencies(@NotNull ModifiableRootModel model) {
-        // Ugly hack to prevent Grape issues due to the absence of jaxb-core-2.3.0.jar in the local maven repository only the pom exists
-        // Here we remove jaxb-core and jaxb-impl from the local maven repository and from the Gradle cache
-        // to ensure that the jar file will properly be downloaded along with its pom file
-        try {
-            File[] files = getMavenArtifacts("com.sun.xml.bind:jaxb-core:2.3.0", "org.apache.camel:camel-core:2.25.4");
-            File parentFile = files[0].getParentFile().getParentFile().getParentFile().getParentFile();
-            List<String> artifacts = List.of("jaxb-core/2.3.0", "jaxb-impl/2.3.0");
-            // Remove the folder of jaxb-core and jaxb-impl from the Gradle cache
-            if (parentFile.getName().equals("com.sun.xml.bind")) {
-                // The artifact has been found in gradle so let's remove it
-                for (String artifact : artifacts) {
-                    FileUtils.deleteDirectory(new File(parentFile, artifact));
-                }
-            }
-            // Remove the folder of jaxb-core and jaxb-impl from the local maven repository
-            parentFile = files[1].getParentFile().getParentFile().getParentFile().getParentFile().getParentFile().getParentFile();
-            for (String artifact : artifacts) {
-                FileUtils.deleteDirectory(new File(parentFile, String.format("com/sun/xml/bind/%s", artifact)));
-            }
-            this.couldDeleteJaxb = true;
-        } catch (IOException e) {
-            LOG.warn("Could not delete the jaxb libs from the local caches", e);
-        }
-        super.loadDependencies(model);
-    }
-
     protected void assertComponentOptionSuggestion(List<String> strings) {
         assertContainsElements(strings, "camel.component.sql.data-source = ", "camel.component.sql.use-placeholder = ",
             "camel.component.sql.resolve-property-placeholders = ", "camel.component.sql.enabled = ");
     }
 
     protected void assertDataFormatNameSuggestion(List<String> strings) {
-        if (!couldDeleteJaxb) {
-            LOG.warn("The jaxb libs could not be removed, the test needs to be skipped");
-            return;
-        }
         assertContainsElements(strings, "camel.dataformat.json-jackson.", "camel.dataformat.csv.", "camel.dataformat.bindy-csv.");
     }
 
@@ -97,10 +51,6 @@ public class PropertiesPropertyKeyCompletionSpringBootLegacyTestIT extends Prope
      * Ensures that data format option suggestions can properly be proposed even with an old name.
      */
     public void testDataFormatOptionWithOldName() {
-        if (!couldDeleteJaxb) {
-            LOG.warn("The jaxb libs could not be removed, the test needs to be skipped");
-            return;
-        }
         myFixture.configureByFiles(getFileName("data-format-options-with-old-name"));
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogProviderWithKarafArtifactTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogProviderWithKarafArtifactTestIT.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.service;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The integration tests ensuring that the {@link CamelCatalogProvider} works as expected in case the core artifact of
+ * Camel Karaf is part of the dependencies of the project.
+ */
+public class CamelCatalogProviderWithKarafArtifactTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    private static final String CORE_RUNTIME_MAVEN_ARTIFACT = "org.apache.camel.karaf:camel-core-osgi:3.18.2";
+
+    private final CamelCatalogProvider provider = CamelCatalogProvider.KARAF;
+
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{CORE_RUNTIME_MAVEN_ARTIFACT};
+    }
+
+    /**
+     * Ensure that the Catalog can be retrieved.
+     */
+    public void testGetCatalog() {
+        CamelCatalog catalog = provider.get(getProject());
+        assertNotNull(catalog.getRuntimeProvider());
+        assertSame(catalog, catalog.getRuntimeProvider().getCamelCatalog());
+        assertInstanceOf(catalog, DefaultCamelCatalog.class);
+    }
+
+    /**
+     * Ensure that the runtime provider can be loaded.
+     */
+    public void testRuntimeProvider() {
+        getProject().getService(CamelCatalogService.class).get().setVersionManager(new CamelMavenVersionManager());
+        assertTrue(provider.loadRuntimeProviderVersion(getProject()));
+    }
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogProviderWithQuarkusArtifactTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogProviderWithQuarkusArtifactTestIT.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.service;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The integration tests ensuring that the {@link CamelCatalogProvider} works as expected in case the core artifact of
+ * Camel Quarkus is part of the dependencies of the project.
+ */
+public class CamelCatalogProviderWithQuarkusArtifactTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    private static final String CORE_RUNTIME_MAVEN_ARTIFACT = "org.apache.camel.quarkus:camel-quarkus-core:2.13.0";
+
+    private final CamelCatalogProvider provider = CamelCatalogProvider.QUARKUS;
+
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{CORE_RUNTIME_MAVEN_ARTIFACT};
+    }
+
+    /**
+     * Ensure that the Catalog can be retrieved.
+     */
+    public void testGetCatalog() {
+        CamelCatalog catalog = provider.get(getProject());
+        assertNotNull(catalog.getRuntimeProvider());
+        assertSame(catalog, catalog.getRuntimeProvider().getCamelCatalog());
+        assertInstanceOf(catalog, DefaultCamelCatalog.class);
+    }
+
+    /**
+     * Ensure that the runtime provider can be loaded.
+     */
+    public void testRuntimeProvider() {
+        getProject().getService(CamelCatalogService.class).get().setVersionManager(new CamelMavenVersionManager());
+        assertTrue(provider.loadRuntimeProviderVersion(getProject()));
+    }
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogProviderWithSpringBootArtifactTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogProviderWithSpringBootArtifactTestIT.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.service;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The integration tests ensuring that the {@link CamelCatalogProvider} works as expected in case the core artifact of
+ * Camel Spring Boot is part of the dependencies of the project.
+ */
+public class CamelCatalogProviderWithSpringBootArtifactTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    private static final String CORE_RUNTIME_MAVEN_ARTIFACT = "org.apache.camel.springboot:camel-spring-boot:3.18.1";
+
+    private final CamelCatalogProvider provider = CamelCatalogProvider.SPRING_BOOT;
+
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{CORE_RUNTIME_MAVEN_ARTIFACT};
+    }
+
+    /**
+     * Ensure that the Catalog can be retrieved.
+     */
+    public void testGetCatalog() {
+        CamelCatalog catalog = provider.get(getProject());
+        assertNotNull(catalog.getRuntimeProvider());
+        assertSame(catalog, catalog.getRuntimeProvider().getCamelCatalog());
+        assertInstanceOf(catalog, DefaultCamelCatalog.class);
+    }
+
+    /**
+     * Ensure that the runtime provider can be loaded.
+     */
+    public void testRuntimeProvider() {
+        getProject().getService(CamelCatalogService.class).get().setVersionManager(new CamelMavenVersionManager());
+        assertTrue(provider.loadRuntimeProviderVersion(getProject()));
+    }
+}

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogProviderWithoutRuntimeArtifactTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogProviderWithoutRuntimeArtifactTestIT.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.service;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
+import com.github.cameltooling.idea.util.ArtifactCoordinates;
+import com.intellij.testFramework.ServiceContainerUtil;
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.DefaultCamelCatalog;
+
+/**
+ * The integration tests ensuring that the {@link CamelCatalogProvider} works as expected in case the core artifact of
+ * a Camel Runtime is not part of the dependencies of the project.
+ */
+public class CamelCatalogProviderWithoutRuntimeArtifactTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        ServiceContainerUtil.registerServiceInstance(getProject(), CamelService.class, new CamelService(getProject()) {
+            @Override
+            public ArtifactCoordinates getProjectCamelCoreCoordinates() {
+                return ArtifactCoordinates.of("org.apache.camel", "camel-core-engine", "3.18.1");
+            }
+        });
+    }
+
+    /**
+     * Ensure that the Karaf Catalog can be retrieved.
+     */
+    public void testGetKarafCatalog() {
+        testGetCatalog(CamelCatalogProvider.KARAF);
+    }
+
+    /**
+     * Ensure that the Spring Boot Catalog can be retrieved.
+     */
+    public void testGetSpringBootCatalog() {
+        testGetCatalog(CamelCatalogProvider.SPRING_BOOT);
+    }
+
+    private void testGetCatalog(CamelCatalogProvider provider) {
+        CamelCatalog catalog = provider.get(getProject());
+        assertNotNull(catalog.getRuntimeProvider());
+        assertSame(catalog, catalog.getRuntimeProvider().getCamelCatalog());
+        assertInstanceOf(catalog, DefaultCamelCatalog.class);
+    }
+
+    /**
+     * Ensure that the Karaf runtime provider can be loaded.
+     */
+    public void testKarafRuntimeProvider() {
+        testRuntimeProvider(CamelCatalogProvider.KARAF);
+    }
+
+    /**
+     * Ensure that the SpringBoot runtime provider can be loaded.
+     */
+    public void testSpringBootRuntimeProvider() {
+        testRuntimeProvider(CamelCatalogProvider.SPRING_BOOT);
+    }
+
+    private void testRuntimeProvider(CamelCatalogProvider provider) {
+        getProject().getService(CamelCatalogService.class).get().setVersionManager(new CamelMavenVersionManager());
+        assertTrue(provider.loadRuntimeProviderVersion(getProject()));
+    }
+}


### PR DESCRIPTION
fixes #769 

## Motivation

When we force a runtime by settings if the corresponding core artifacts are not part of the dependencies of the project, the catalog is not downloaded while we would expect to download it anyway.

## Modifications:

* Add a fallback method that will retrieve the catalog corresponding to the version of Camel
* Do nothing in the case of Quarkus as the versions are different
* Add a specific `grapeConfig.xml` as a temporary workaround to prevent dependency retrieval issue