### PR TITLE
Ref #773: Prevent doc generation issue by providing it from getText

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/documentation/CamelDocumentationProvider.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/documentation/CamelDocumentationProvider.java
@@ -650,6 +650,10 @@ public class CamelDocumentationProvider extends DocumentationProviderEx implemen
             return generateCamelOptionDocumentation(option);
         }
 
+        @Override
+        public String getText() {
+            return toString();
+        }
     }
 
     /**
@@ -677,6 +681,11 @@ public class CamelDocumentationProvider extends DocumentationProviderEx implemen
         @Override
         public String toString() {
             return generateCamelSimpleDocumentation(suggestion);
+        }
+
+        @Override
+        public String getText() {
+            return toString();
         }
     }
 


### PR DESCRIPTION
fixes #773

## Motivation

Browsing endpoint options quick docs causes error of type `cannot be presented [Plugin: org.apache.camel]`

## Modifications:

* Provide the content of the doc to present also with the `getText` method