### PR TITLE
Bump IDEA to 2022.2.4

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for v in "2022.1.4" "2022.2.3"; do
+for v in "2022.1.4" "2022.2.4"; do
     echo "## Building with version $v..."
     ./gradlew --no-daemon -PideaVersion="$v" clean build
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 camelVersion = 3.19.0
 camelQuarkusVersion = 2.14.0
 camelKameletVersion = 0.9.3
-ideaVersion=2022.2.3
+ideaVersion=2022.2.4


### PR DESCRIPTION
## Motivation

A new maintenance version of IDEA 2022.2 has been released and needs to be supported.

## Modifications:

* Bump the default version of IDEA used to `2022.2.4`
* Bump the version of IDEA 2022.2 tested by the CI to `2022.2.4`