### PR TITLE
Fix the build on Windows

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-for v in "2022.1.4" "2022.2.4" "2022.3.2"; do
+for v in "2022.2.5" "2022.3.3" "2023.1.1"; do
     echo "## Building with version $v..."
-    ./gradlew --no-daemon -PideaVersion="$v" clean build
+    ./gradlew --no-daemon clean
+    ./gradlew --no-daemon --no-parallel -PideaVersion="$v" build
 
     status=$?
     if [[ $status -ne 0 ]]; then


### PR DESCRIPTION
## Motivation

The build always fails due to a clean issue on Windows.

## Modifications:

* Call the clean task separately
* Update the versions of IntelliJ against which the tests are launched