### PR TITLE
Update the IntelliJ versions

### DIFF
--- a/camel-idea-plugin/build.gradle
+++ b/camel-idea-plugin/build.gradle
@@ -32,13 +32,12 @@ intellij {
 // to support IDEA 2022 onwards
 // http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 patchPluginXml {
-    sinceBuild = "223"
+    sinceBuild = "222"
     untilBuild = "231.*"
 }
 
 runPluginVerifier {
-    ideVersions = [ "2022.3", "2023.1" ]
-
+    ideVersions = [ "2022.2", "2022.3", "2023.1" ]
 }
 
 // publishPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 camelVersion = 3.20.4
 camelQuarkusVersion = 2.16.0
 camelKameletVersion = 3.20.3
-ideaVersion=2022.3.2
+ideaVersion=2023.1.1


### PR DESCRIPTION
## Motivation

New versions of IntelliJ have been released, the supported versions should be shifted accordingly.

## Modifications:

* Change the default IntelliJ version used to the latest version
* Adapt the configuration of the IntelliJ gradle plugin to the supported versions