### PR TITLE
Ref #837: Bump the checkstyle's version to use Java 17 syntax

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ allprojects {
     apply plugin: 'checkstyle'
 
     checkstyle {
-        toolVersion = '8.23'
+        toolVersion = '10.11.0'
         configDirectory = file("$rootProject.projectDir/config/checkstyle")
     }
     

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/AbstractCamelAnnotator.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/AbstractCamelAnnotator.java
@@ -74,7 +74,7 @@ abstract class AbstractCamelAnnotator implements Annotator {
             return true;
         } else {
             final PsiPolyadicExpression parentOfType = PsiTreeUtil.getParentOfType(element, PsiPolyadicExpression.class);
-            if (((element instanceof PsiLiteralExpression) || (element instanceof PropertyValueImpl)) && (parentOfType == null)) {
+            if ((element instanceof PsiLiteralExpression || element instanceof PropertyValueImpl) && parentOfType == null) {
                 return true;
             }
         }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/CamelBeanMethodAnnotator.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/CamelBeanMethodAnnotator.java
@@ -101,7 +101,7 @@ public class CamelBeanMethodAnnotator implements Annotator {
                 return;
             }
 
-            if ((matchMethods.size() - privateMethods) > 1 && (!isAnnotatedWithHandler)) {
+            if ((matchMethods.size() - privateMethods) > 1 && !isAnnotatedWithHandler) {
                 errorMessage = String.format(METHOD_HAS_AMBIGUOUS_ACCESS, methodNameWithParameters, psiClass.getQualifiedName());
             } else {
                 errorMessage = allPrivates ? String.format(METHOD_HAS_PRIVATE_ACCESS, methodNameWithParameters, psiClass.getQualifiedName()) : null;

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/CamelEndpointAnnotator.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/annotator/CamelEndpointAnnotator.java
@@ -202,7 +202,7 @@ public class CamelEndpointAnnotator extends AbstractCamelAnnotator {
     private void extractMapValue(EndpointValidationResult result, Map<String, String> validationMap,
                                  String fromElement, @NotNull PsiElement element, @NotNull AnnotationHolder holder,
                                  CamelAnnotatorEndpointMessage<Map.Entry<String, String>> msg) {
-        if ((!result.isSuccess()) && validationMap != null) {
+        if (!result.isSuccess() && validationMap != null) {
 
             for (Map.Entry<String, String> entry : validationMap.entrySet()) {
                 String propertyValue = entry.getValue();

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/extension/PropertiesPropertyPlaceholdersSmartCompletion.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/extension/PropertiesPropertyPlaceholdersSmartCompletion.java
@@ -56,7 +56,7 @@ public class PropertiesPropertyPlaceholdersSmartCompletion implements CamelPrope
         final boolean present = preferenceService.getExcludePropertyFiles()
             .stream()
             .anyMatch(s -> !s.isEmpty() && FilenameUtils.wildcardMatch(filename, s));
-        return (!present) && (filename.endsWith(".properties"));
+        return !present && filename.endsWith(".properties");
     }
 
     @Override

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/extension/YamlPropertyPlaceholdersSmartCompletion.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/extension/YamlPropertyPlaceholdersSmartCompletion.java
@@ -63,7 +63,7 @@ public class YamlPropertyPlaceholdersSmartCompletion implements CamelPropertyCom
         final boolean present = preferenceService.getExcludePropertyFiles()
             .stream()
             .anyMatch(s -> !s.isEmpty() && FilenameUtils.wildcardMatch(filename, s));
-        return (!present) && (filename.endsWith(".yaml") || filename.endsWith(".yml"));
+        return !present && (filename.endsWith(".yaml") || filename.endsWith(".yml"));
     }
 
     @Override

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/inspection/AbstractCamelInspection.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/inspection/AbstractCamelInspection.java
@@ -247,7 +247,7 @@ public abstract class AbstractCamelInspection extends LocalInspectionTool {
                                  String fromElement, PsiElement element, final @NotNull ProblemsHolder holder,
                                  boolean isOnTheFly, CamelAnnotatorEndpointMessage msg) {
 
-        if ((!result.isSuccess()) && validationSet != null) {
+        if (!result.isSuccess() && validationSet != null) {
             for (String entry : validationSet) {
                 String desc = summaryErrorMessage(result, entry, msg);
                 holder.registerProblem(element, desc);
@@ -259,7 +259,7 @@ public abstract class AbstractCamelInspection extends LocalInspectionTool {
                                  String fromElement, @NotNull PsiElement element, final @NotNull ProblemsHolder holder,
                                  boolean isOnTheFly, CamelAnnotatorEndpointMessage msg) {
 
-        if ((!result.isSuccess()) && validationMap != null) {
+        if (!result.isSuccess() && validationMap != null) {
             for (Map.Entry<String, String> entry : validationMap.entrySet()) {
                 String desc = summaryErrorMessage(result, entry, msg);
                 holder.registerProblem(element, desc);

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/intention/CamelAddEndpointIntention.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/intention/CamelAddEndpointIntention.java
@@ -164,7 +164,7 @@ public class CamelAddEndpointIntention extends PsiElementBaseIntentionAction imp
                 boolean onlyProduce = model.isProducerOnly();
                 boolean both = !onlyConsume && !onlyProduce;
 
-                if (both || (consumerOnly && onlyConsume) || (!consumerOnly && onlyProduce)) {
+                if (both || consumerOnly && onlyConsume || !consumerOnly && onlyProduce) {
                     names.add(name);
                 }
             }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/extension/camel/XmlCamelIdeaUtils.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/extension/camel/XmlCamelIdeaUtils.java
@@ -98,7 +98,7 @@ public class XmlCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtilsE
     @Override
     public boolean isInsideCamelRoute(PsiElement element, boolean excludeRouteStart) {
         XmlTag tag = PsiTreeUtil.getParentOfType(element, XmlTag.class);
-        if (tag == null || (excludeRouteStart && isCamelRouteStartTag(tag))) {
+        if (tag == null || excludeRouteStart && isCamelRouteStartTag(tag)) {
             return false;
         }
         return getIdeaUtils().findFirstParent(tag, false, this::isCamelRouteTag, PsiFile.class::isInstance) != null;

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -72,6 +72,10 @@ lengths, if/try depths, etc...
         <property name="file" value="${config_loc}/suppressions.xml"/>
     </module>
 
+    <module name="LineLength">
+        <property name="max" value="200"/>
+    </module>
+
     <module name="TreeWalker">
 
 
@@ -132,9 +136,6 @@ lengths, if/try depths, etc...
         </module>
         <module name="ExecutableStatementCount">
             <property name="max" value="100"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="200"/>
         </module>
         <module name="MethodLength">
             <property name="max" value="200"/>


### PR DESCRIPTION
fixes #837 

## Motivation

All the IDEA versions supported by the plugin need Java 17, so we can start using the Java 17 syntax in the code however, for now, it is not yet possible because it is rejected by the current version of checkstyle used in the plugin. 

## Modifications

* Upgrades the version of checkstyle to the latest version
* Updates the file `checkstyle.xml` to be compatible with this new version of checkstyle
* Fixes the violations raised by the plugin

## Result

It is now possible to use the Java 17 syntax in the code of the plugin