### PR TITLE
Ref #641: Camel Debugger - Improve multi-project build support

### DIFF
--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
       v.0.9.7
       <ul>
         <li>Fixes the bug preventing the debugging of a Gradle task</li>
-        <li>Add Camel Debugger support to Gradle project</li>
+        <li>Make Camel Debugger support Gradle</li>
         <li>Bug fixes</li>
       </ul>
     ]]>


### PR DESCRIPTION
fixes #641 (part 2)

## Motivation

The first part of the fix for #641 doesn't cover well the multi-project build as it assumes that the name of the project matches the name of a direct subdirectory which is not always true.

## Modifcations

* Generates Kotlin/Groovy code in the build file that adds the dependencies from the root build file
* Generates Kotlin/Groovy code in the settings file to refer to the location of the generated build file

## Result

The multi-project builds can now benefit from the Camel Debugger