### PR TITLE
Ref #844: Move appropriate settings to project settings

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/extension/CamelEndpointSmartCompletionExtension.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/extension/CamelEndpointSmartCompletionExtension.java
@@ -29,7 +29,7 @@ import javax.swing.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.cameltooling.idea.service.CamelCatalogService;
-import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 import com.github.cameltooling.idea.service.KameletService;
 import com.github.cameltooling.idea.util.CamelIdeaUtils;
 import com.github.cameltooling.idea.util.IdeaUtils;
@@ -237,7 +237,7 @@ public class CamelEndpointSmartCompletionExtension implements CamelCompletionExt
                 }
                 final ComponentModel componentModel = JsonMapper.generateComponentModel(json);
                 final KameletService service = project.getService(KameletService.class);
-                if (CamelPreferenceService.getService().isOnlyShowKameletOptions()) {
+                if (CamelProjectPreferenceService.getService(project).isOnlyShowKameletOptions()) {
                     componentModel.getEndpointOptions().clear();
                 }
                 // Add the list of name of Kamelets available according to the type of endpoint

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/property/CamelYamlPropertyKeyCompletion.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/property/CamelYamlPropertyKeyCompletion.java
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
 import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
 import com.github.cameltooling.idea.completion.OptionSuggestion;
 import com.github.cameltooling.idea.completion.SimpleSuggestion;
-import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 import com.github.cameltooling.idea.service.CamelService;
 import com.github.cameltooling.idea.service.extension.idea.YamlIdeaUtils;
 import com.github.cameltooling.idea.util.CamelIdeaUtils;
@@ -178,7 +178,7 @@ public class CamelYamlPropertyKeyCompletion extends CamelPropertyKeyCompletion {
      * @return {@code true} if the Camel Runtime of the given project is compatible, {@code false} otherwise.
      */
     private static boolean isCamelRuntimeCompatible(final Project project) {
-        final CamelCatalogProvider provider = CamelPreferenceService.getService()
+        final CamelCatalogProvider provider = CamelProjectPreferenceService.getService(project)
             .getCamelCatalogProvider()
             .getActualProvider(project);
         return provider == CamelCatalogProvider.QUARKUS || provider == CamelCatalogProvider.SPRING_BOOT;

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/preference/editorsettings/CamelEditorSettingsPage.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/preference/editorsettings/CamelEditorSettingsPage.java
@@ -24,7 +24,6 @@ import javax.swing.*;
 import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
 import com.github.cameltooling.idea.service.CamelPreferenceService;
 import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
-import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.options.BaseConfigurable;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurationException;
@@ -125,11 +124,11 @@ public class CamelEditorSettingsPage extends BaseConfigurable implements Searcha
         preferenceService.setDownloadCatalog(downloadCatalogCheckBox.isSelected());
         preferenceService.setScanThirdPartyComponents(scanThirdPartyComponentsCatalogCheckBox.isSelected());
         preferenceService.setShowCamelIconInGutter(camelIconInGutterCheckBox.isSelected());
-        preferenceService.setEnableCamelDebugger(enableDebuggerCheckBox.isSelected());
-        preferenceService.setCamelDebuggerAutoSetup(camelDebuggerAutoSetupCheckBox.isSelected());
-        preferenceService.setOnlyShowKameletOptions(onlyShowKameletOptionsCheckBox.isSelected());
-        preferenceService.setCamelCatalogProvider((CamelCatalogProvider) camelRuntimeProviderComboBox.getSelectedItem());
         CamelProjectPreferenceService projectPreferenceService = CamelProjectPreferenceService.getService(project);
+        projectPreferenceService.setEnableCamelDebugger(enableDebuggerCheckBox.isSelected());
+        projectPreferenceService.setCamelDebuggerAutoSetup(camelDebuggerAutoSetupCheckBox.isSelected());
+        projectPreferenceService.setOnlyShowKameletOptions(onlyShowKameletOptionsCheckBox.isSelected());
+        projectPreferenceService.setCamelCatalogProvider((CamelCatalogProvider) camelRuntimeProviderComboBox.getSelectedItem());
         projectPreferenceService.setCamelProject((Boolean) isCamelProjectComboBox.getSelectedItem());
         projectPreferenceService.setCatalogVersion(catalogVersion.getText());
     }
@@ -146,10 +145,10 @@ public class CamelEditorSettingsPage extends BaseConfigurable implements Searcha
         return preferenceService.isDownloadCatalog() != downloadCatalogCheckBox.isSelected()
                 || preferenceService.isScanThirdPartyComponents() != scanThirdPartyComponentsCatalogCheckBox.isSelected()
                 || preferenceService.isShowCamelIconInGutter() != camelIconInGutterCheckBox.isSelected()
-                || preferenceService.isEnableCamelDebugger() != enableDebuggerCheckBox.isSelected()
-                || preferenceService.isCamelDebuggerAutoSetup() != camelDebuggerAutoSetupCheckBox.isSelected()
-                || preferenceService.isOnlyShowKameletOptions() != onlyShowKameletOptionsCheckBox.isSelected()
-                || preferenceService.getCamelCatalogProvider() != camelRuntimeProviderComboBox.getSelectedItem()
+                || projectPreferenceService.isEnableCamelDebugger() != enableDebuggerCheckBox.isSelected()
+                || projectPreferenceService.isCamelDebuggerAutoSetup() != camelDebuggerAutoSetupCheckBox.isSelected()
+                || projectPreferenceService.isOnlyShowKameletOptions() != onlyShowKameletOptionsCheckBox.isSelected()
+                || projectPreferenceService.getCamelCatalogProvider() != camelRuntimeProviderComboBox.getSelectedItem()
                 || isCamelProjectComboBox.getSelectedItem() != projectPreferenceService.isCamelProject()
                 || !Objects.equals(catalogVersionText, projectPreferenceService.getCatalogVersion());
     }
@@ -160,12 +159,12 @@ public class CamelEditorSettingsPage extends BaseConfigurable implements Searcha
         downloadCatalogCheckBox.setSelected(preferenceService.isDownloadCatalog());
         scanThirdPartyComponentsCatalogCheckBox.setSelected(preferenceService.isScanThirdPartyComponents());
         camelIconInGutterCheckBox.setSelected(preferenceService.isShowCamelIconInGutter());
-        enableDebuggerCheckBox.setSelected(preferenceService.isEnableCamelDebugger());
-        camelDebuggerAutoSetupCheckBox.setSelected(preferenceService.isCamelDebuggerAutoSetup());
-        onlyShowKameletOptionsCheckBox.setSelected(preferenceService.isOnlyShowKameletOptions());
-        camelRuntimeProviderComboBox.setSelectedItem(preferenceService.getCamelCatalogProvider());
         CamelProjectPreferenceService projectPreferenceService = CamelProjectPreferenceService.getService(project);
         if (projectPreferenceService != null) {
+            enableDebuggerCheckBox.setSelected(projectPreferenceService.isEnableCamelDebugger());
+            camelDebuggerAutoSetupCheckBox.setSelected(projectPreferenceService.isCamelDebuggerAutoSetup());
+            onlyShowKameletOptionsCheckBox.setSelected(projectPreferenceService.isOnlyShowKameletOptions());
+            camelRuntimeProviderComboBox.setSelectedItem(projectPreferenceService.getCamelCatalogProvider());
             isCamelProjectComboBox.setSelectedItem(projectPreferenceService.isCamelProject());
             catalogVersion.setText(projectPreferenceService.getCatalogVersion());
         }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
@@ -42,6 +42,7 @@ import com.github.cameltooling.idea.runner.CamelSpringBootRunConfigurationType;
 import com.github.cameltooling.idea.runner.debugger.breakpoint.CamelBreakpointHandler;
 import com.github.cameltooling.idea.service.CamelCatalogService;
 import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 import com.github.cameltooling.idea.service.CamelRuntime;
 import com.github.cameltooling.idea.service.CamelService;
 import com.intellij.execution.Executor;
@@ -237,7 +238,7 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
         } else if (mode.canCheckCamelBreakpoints() && !CamelBreakpointHandler.hasBreakpoints(project)) {
             LOG.debug("The project has no camel breakpoints so no need to patch the parameters");
         } else {
-            CamelPreferenceService preferenceService = CamelPreferenceService.getService();
+            CamelProjectPreferenceService preferenceService = CamelProjectPreferenceService.getService(project);
             if (!preferenceService.isEnableCamelDebugger()) {
                 LOG.debug("The Camel Debugger has been disabled so no need to patch the parameters");
             } else if (preferenceService.isCamelDebuggerAutoSetup()) {

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.github.cameltooling.idea.runner.debugger.breakpoint.CamelBreakpointHandler;
 import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 import com.github.cameltooling.idea.service.CamelService;
 import com.intellij.debugger.DebuggerManagerEx;
 import com.intellij.debugger.DefaultDebugEnvironment;
@@ -63,10 +64,6 @@ public class CamelDebuggerRunner extends GenericDebuggerRunner {
 
     @Override
     public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
-        CamelPreferenceService preferenceService = CamelPreferenceService.getService();
-        if (!preferenceService.isEnableCamelDebugger()) {
-            return false;
-        }
         if (profile instanceof GradleRunConfiguration) {
             // GradleRunConfiguration must be excluded otherwise it won't be possible to debug a gradle task
             // see https://github.com/camel-tooling/camel-idea-plugin/issues/824
@@ -76,6 +73,9 @@ public class CamelDebuggerRunner extends GenericDebuggerRunner {
             try {
                 final RunConfigurationBase<?> base = (RunConfigurationBase<?>) profile;
                 final Project project = base.getProject();
+                if (!CamelProjectPreferenceService.getService(project).isEnableCamelDebugger()) {
+                    return false;
+                }
                 final CamelService camelService = project.getService(CamelService.class);
                 if (camelService != null) {
                     boolean isDebug = executorId.equals(DefaultDebugExecutor.EXECUTOR_ID);

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelExternalSystemTaskDebugRunner.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelExternalSystemTaskDebugRunner.java
@@ -20,6 +20,7 @@ import java.net.ServerSocket;
 
 import com.github.cameltooling.idea.runner.debugger.breakpoint.CamelBreakpointHandler;
 import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 import com.github.cameltooling.idea.service.CamelService;
 import com.intellij.build.BuildView;
 import com.intellij.debugger.DebugEnvironment;
@@ -32,6 +33,7 @@ import com.intellij.debugger.impl.GenericDebuggerRunner;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.configurations.RemoteConnection;
+import com.intellij.execution.configurations.RunConfigurationBase;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.executors.DefaultDebugExecutor;
@@ -72,8 +74,8 @@ public class CamelExternalSystemTaskDebugRunner extends GenericDebuggerRunner {
 
     @Override
     public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
-        CamelPreferenceService preferenceService = CamelPreferenceService.getService();
-        if (!preferenceService.isEnableCamelDebugger()) {
+        if (profile instanceof RunConfigurationBase<?> configuration
+            && !CamelProjectPreferenceService.getService(configuration.getProject()).isEnableCamelDebugger()) {
             return false;
         }
         if (profile instanceof ExternalSystemRunConfiguration configuration) {

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelCatalogService.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelCatalogService.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultVersionManager;
@@ -44,9 +43,9 @@ public class CamelCatalogService implements Disposable {
      */
     public CamelCatalogService(Project project) {
         this.project = project;
-        ApplicationManager.getApplication().getMessageBus()
+        project.getMessageBus()
             .connect(this)
-            .subscribe(CamelPreferenceService.CamelCatalogProviderChangeListener.TOPIC, this::onCamelCatalogProviderChanged);
+            .subscribe(CamelProjectPreferenceService.CamelCatalogProviderChangeListener.TOPIC, this::onCamelCatalogProviderChanged);
         project.getMessageBus()
             .connect(this)
             .subscribe(CamelService.CamelCatalogListener.TOPIC, this::onCamelCatalogReady);
@@ -60,7 +59,7 @@ public class CamelCatalogService implements Disposable {
         if (instance == null) {
             synchronized (this) {
                 if (instance == null) {
-                    this.instance = CamelPreferenceService.getService().getCamelCatalogProvider().get(project);
+                    this.instance = CamelProjectPreferenceService.getService(project).getCamelCatalogProvider().get(project);
                 }
             }
         }
@@ -90,9 +89,9 @@ public class CamelCatalogService implements Disposable {
      */
     private void updateRuntimeProvider(CamelCatalog catalog) {
         final VersionManager versionManager = catalog.getVersionManager();
-        if (versionManager instanceof CamelMavenVersionManager) {
-            CamelPreferenceService.getService().getCamelCatalogProvider().updateRuntimeProvider(
-                project, catalog, ((CamelMavenVersionManager) versionManager).getClassLoader()
+        if (versionManager instanceof CamelMavenVersionManager mavenVersionManager) {
+            CamelProjectPreferenceService.getService(project).getCamelCatalogProvider().updateRuntimeProvider(
+                project, catalog, mavenVersionManager.getClassLoader()
             );
         }
     }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelPreferenceService.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelPreferenceService.java
@@ -23,14 +23,12 @@ import java.util.Objects;
 
 import javax.swing.*;
 
-import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.util.IconLoader;
-import com.intellij.util.messages.Topic;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import com.intellij.util.xmlb.annotations.Transient;
 import org.jetbrains.annotations.NotNull;
@@ -70,19 +68,6 @@ public class CamelPreferenceService implements PersistentStateComponent<CamelPre
     private boolean downloadCatalog = true;
     private boolean scanThirdPartyComponents = true;
     private boolean showCamelIconInGutter = true;
-    private boolean enableCamelDebugger = true;
-    /**
-     * The flag indicating whether the Camel Debugger should be automatically setup.
-     */
-    private boolean camelDebuggerAutoSetup = true;
-    /**
-     * Flag indicating whether only the options of the Kamelet should be proposed.
-     */
-    private boolean onlyShowKameletOptions = true;
-    /**
-     * The {@link CamelCatalogProvider} set in the preferences.
-     */
-    private CamelCatalogProvider camelCatalogProvider;
     private List<String> ignorePropertyList = new ArrayList<>();
     private List<String> excludePropertyFiles = new ArrayList<>();
 
@@ -156,30 +141,6 @@ public class CamelPreferenceService implements PersistentStateComponent<CamelPre
         this.showCamelIconInGutter = showCamelIconInGutter;
     }
 
-    public boolean isEnableCamelDebugger() {
-        return enableCamelDebugger;
-    }
-
-    public void setEnableCamelDebugger(boolean enableCamelDebugger) {
-        this.enableCamelDebugger = enableCamelDebugger;
-    }
-
-    public boolean isOnlyShowKameletOptions() {
-        return onlyShowKameletOptions;
-    }
-
-    public void setOnlyShowKameletOptions(boolean onlyShowKameletOptions) {
-        this.onlyShowKameletOptions = onlyShowKameletOptions;
-    }
-
-    public void setCamelDebuggerAutoSetup(boolean camelDebuggerAutoSetup) {
-        this.camelDebuggerAutoSetup = camelDebuggerAutoSetup;
-    }
-
-    public boolean isCamelDebuggerAutoSetup() {
-        return camelDebuggerAutoSetup;
-    }
-
     public List<String> getIgnorePropertyList() {
         if (ignorePropertyList.isEmpty()) {
             ignorePropertyList = new ArrayList<>(Arrays.asList(DEFAULT_IGNORE_PROPERTIES));
@@ -202,34 +163,6 @@ public class CamelPreferenceService implements PersistentStateComponent<CamelPre
     // called with reflection when loadState is called
     public void setExcludePropertyFiles(List<String> excludePropertyFiles) {
         this.excludePropertyFiles = excludePropertyFiles;
-    }
-
-    /**
-     * @return the {@link CamelCatalogProvider} defined in the preferences, {@link CamelCatalogProvider#AUTO} by default.
-     */
-    public CamelCatalogProvider getCamelCatalogProvider() {
-        return getCamelCatalogProvider(camelCatalogProvider);
-    }
-
-    /**
-     * Set the {@link CamelCatalogProvider} to use. The change listeners are notified in case the value has changed.
-     * @param camelCatalogProvider the new {@link CamelCatalogProvider} to use
-     */
-    public void setCamelCatalogProvider(CamelCatalogProvider camelCatalogProvider) {
-        final boolean hasChanged = getCamelCatalogProvider() != getCamelCatalogProvider(camelCatalogProvider);
-        this.camelCatalogProvider = camelCatalogProvider;
-        if (hasChanged) {
-            ApplicationManager.getApplication().getMessageBus().syncPublisher(CamelCatalogProviderChangeListener.TOPIC)
-                .onChange();
-        }
-    }
-
-    /**
-     * @return {@link CamelCatalogProvider#AUTO} if the given {@link CamelCatalogProvider} is {@code null}, the
-     * given {@link CamelCatalogProvider} otherwise.
-     */
-    private CamelCatalogProvider getCamelCatalogProvider(CamelCatalogProvider camelCatalogProvider) {
-        return camelCatalogProvider == null ? CamelCatalogProvider.AUTO : camelCatalogProvider;
     }
 
     public Icon getCamelIcon() {
@@ -270,9 +203,6 @@ public class CamelPreferenceService implements PersistentStateComponent<CamelPre
             && downloadCatalog == that.downloadCatalog
             && scanThirdPartyComponents == that.scanThirdPartyComponents
             && showCamelIconInGutter == that.showCamelIconInGutter
-            && camelCatalogProvider == that.camelCatalogProvider
-            && onlyShowKameletOptions == that.onlyShowKameletOptions
-            && camelDebuggerAutoSetup == that.camelDebuggerAutoSetup
             && Objects.equals(ignorePropertyList, that.ignorePropertyList)
             && Objects.equals(excludePropertyFiles, that.excludePropertyFiles);
     }
@@ -280,8 +210,8 @@ public class CamelPreferenceService implements PersistentStateComponent<CamelPre
     @Override
     public int hashCode() {
         return Objects.hash(realTimeEndpointValidation, realTimeSimpleValidation, realTimeJSonPathValidation,
-            realTimeIdReferenceTypeValidation, downloadCatalog, scanThirdPartyComponents, camelCatalogProvider,
-            onlyShowKameletOptions, camelDebuggerAutoSetup, ignorePropertyList, excludePropertyFiles);
+            realTimeIdReferenceTypeValidation, downloadCatalog, scanThirdPartyComponents,
+            ignorePropertyList, excludePropertyFiles);
     }
 
     public boolean isRealTimeBeanMethodValidationCheckBox() {
@@ -290,25 +220,5 @@ public class CamelPreferenceService implements PersistentStateComponent<CamelPre
 
     public void setRealTimeBeanMethodValidationCheckBox(boolean realTimeBeanMethodValidationCheckBox) {
         this.realTimeBeanMethodValidationCheckBox = realTimeBeanMethodValidationCheckBox;
-    }
-
-    /**
-     * {@code CamelCatalogProviderChangeListener} defines a listener to notify in case the {@link CamelCatalogProvider}
-     * defined in the preferences has changed.
-     */
-    public interface CamelCatalogProviderChangeListener {
-
-        /**
-         * The topic to subscribe to in order to be notified when the {@link CamelCatalogProvider} has changed.
-         */
-        @Topic.AppLevel
-        Topic<CamelCatalogProviderChangeListener> TOPIC = Topic.create(
-            "CamelCatalogProviderChangeListener", CamelCatalogProviderChangeListener.class
-        );
-
-        /**
-         * Called when the {@link CamelCatalogProvider} defined in the preferences has changed.
-         */
-        void onChange();
     }
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelService.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelService.java
@@ -430,7 +430,7 @@ public class CamelService implements Disposable {
      * Loads the Camel catalog version corresponding to the project settings.
      */
     void loadCamelCatalog() {
-        loadCamelCatalog(project.getService(CamelProjectPreferenceService.class).getCatalogVersion());
+        loadCamelCatalog(CamelProjectPreferenceService.getService(project).getCatalogVersion());
     }
 
     /**
@@ -466,7 +466,8 @@ public class CamelService implements Disposable {
      * @param version the version of the Camel catalog to load.
      */
     private void loadCamelCatalogInBackground(@NotNull String version) {
-        final CamelCatalogProvider provider = CamelPreferenceService.getService().getCamelCatalogProvider()
+        final CamelCatalogProvider provider = CamelProjectPreferenceService.getService(project)
+            .getCamelCatalogProvider()
             .getActualProvider(project);
         new Task.Backgroundable(project, "Download the Camel catalog for the " + provider.getName() + " Runtime", true) {
             public void run(@NotNull ProgressIndicator indicator) {

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaEndpointSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaEndpointSmartCompletionTestIT.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
-import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 import com.intellij.codeInsight.lookup.LookupElement;
 import org.hamcrest.Matchers;
 
@@ -33,7 +33,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
 
     protected void tearDown() throws Exception {
         try {
-            CamelPreferenceService.getService().setOnlyShowKameletOptions(true);
+            CamelProjectPreferenceService.getService(getProject()).setOnlyShowKameletOptions(true);
         } finally {
             super.tearDown();
         }
@@ -394,7 +394,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
      * Ensure that the configuration option of a given Kamelet can be suggested with other options.
      */
     public void testJavaKameletOptionSuggestions() {
-        CamelPreferenceService.getService().setOnlyShowKameletOptions(false);
+        CamelProjectPreferenceService.getService(getProject()).setOnlyShowKameletOptions(false);
         myFixture.configureByText("CamelRoute.java", getJavaKameletOptionSuggestionsData());
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
@@ -409,7 +409,7 @@ public class JavaEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
      * Ensure that the configuration option of a given Kamelet can be suggested without other options.
      */
     public void testJavaKameletOptionAloneSuggestions() {
-        CamelPreferenceService.getService().setOnlyShowKameletOptions(true);
+        CamelProjectPreferenceService.getService(getProject()).setOnlyShowKameletOptions(true);
         myFixture.configureByText("CamelRoute.java", getJavaKameletOptionSuggestionsData());
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionTestIT.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
-import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 import com.intellij.codeInsight.lookup.LookupElement;
 
 /**
@@ -38,7 +38,7 @@ public class PropertiesPropertyKeyCompletionTestIT extends CamelLightCodeInsight
     @Override
     protected void tearDown() throws Exception {
         try {
-            CamelPreferenceService.getService().setCamelCatalogProvider(null);
+            CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(null);
         } finally {
             super.tearDown();
         }
@@ -125,7 +125,7 @@ public class PropertiesPropertyKeyCompletionTestIT extends CamelLightCodeInsight
      * Ensures that group suggestions for default Camel Runtime matches with the expectations.
      */
     public void testGroupSuggestionForDefaultCamelRuntime() {
-        CamelPreferenceService.getService().setCamelCatalogProvider(CamelCatalogProvider.DEFAULT);
+        CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(CamelCatalogProvider.DEFAULT);
         testGroupSuggestionWithFullFirstKeyWithSeparator();
     }
 
@@ -133,7 +133,7 @@ public class PropertiesPropertyKeyCompletionTestIT extends CamelLightCodeInsight
      * Ensures that group suggestions for Quarkus Camel Runtime matches with the expectations.
      */
     public void testGroupSuggestionForQuarkusCamelRuntime() {
-        CamelPreferenceService.getService().setCamelCatalogProvider(CamelCatalogProvider.QUARKUS);
+        CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(CamelCatalogProvider.QUARKUS);
         testGroupSuggestionWithFullFirstKeyWithSeparator();
     }
 
@@ -141,7 +141,7 @@ public class PropertiesPropertyKeyCompletionTestIT extends CamelLightCodeInsight
      * Ensures that group suggestions for Karaf Camel Runtime matches with the expectations.
      */
     public void testGroupSuggestionForKarafCamelRuntime() {
-        CamelPreferenceService.getService().setCamelCatalogProvider(CamelCatalogProvider.KARAF);
+        CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(CamelCatalogProvider.KARAF);
         myFixture.configureByFiles(getFileName("full-first-key-with-separator"));
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertyValueCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertyValueCompletionTestIT.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
-import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 import com.intellij.codeInsight.lookup.LookupElement;
 
 /**
@@ -38,7 +38,7 @@ public class PropertyValueCompletionTestIT extends CamelLightCodeInsightFixtureT
     @Override
     protected void tearDown() throws Exception {
         try {
-            CamelPreferenceService.getService().setCamelCatalogProvider(null);
+            CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(null);
         } finally {
             super.tearDown();
         }
@@ -364,17 +364,17 @@ public class PropertyValueCompletionTestIT extends CamelLightCodeInsightFixtureT
         assertNullOrEmpty(strings);
     }
 
-    private static String getFileName(FileType type, String fileNamePrefix) {
+    private String getFileName(FileType type, String fileNamePrefix) {
         if (type == FileType.YAML) {
             // Switch to Quarkus mode
             return getFileName(type, fileNamePrefix, CamelCatalogProvider.QUARKUS);
         }
         return getFileName(type, fileNamePrefix, null);
     }
-    private static String getFileName(FileType type, String fileNamePrefix, CamelCatalogProvider provider) {
+    private String getFileName(FileType type, String fileNamePrefix, CamelCatalogProvider provider) {
         if (provider != null) {
             // Switch to Quarkus mode
-            CamelPreferenceService.getService().setCamelCatalogProvider(provider);
+            CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(provider);
         }
         return String.format("%s.%s", fileNamePrefix, type.name().toLowerCase());
     }

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/XmlEndpointSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/XmlEndpointSmartCompletionTestIT.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
-import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -35,7 +35,7 @@ public class XmlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtu
 
     protected void tearDown() throws Exception {
         try {
-            CamelPreferenceService.getService().setOnlyShowKameletOptions(true);
+            CamelProjectPreferenceService.getService(getProject()).setOnlyShowKameletOptions(true);
         } finally {
             super.tearDown();
         }
@@ -368,7 +368,7 @@ public class XmlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtu
      * Ensure that the configuration option of a given Kamelet can be suggested with other options.
      */
     public void testXmlKameletOptionSuggestions() {
-        CamelPreferenceService.getService().setOnlyShowKameletOptions(false);
+        CamelProjectPreferenceService.getService(getProject()).setOnlyShowKameletOptions(false);
         myFixture.configureByText("CamelRoute.xml", getXmlKameletOptionSuggestionsData());
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
@@ -383,7 +383,7 @@ public class XmlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtu
      * Ensure that the configuration option of a given Kamelet can be suggested without other options.
      */
     public void testXmlKameletOptionAloneSuggestions() {
-        CamelPreferenceService.getService().setOnlyShowKameletOptions(true);
+        CamelProjectPreferenceService.getService(getProject()).setOnlyShowKameletOptions(true);
         myFixture.configureByText("CamelRoute.xml", getXmlKameletOptionSuggestionsData());
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/YamlEndpointSmartCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/YamlEndpointSmartCompletionTestIT.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
-import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -35,7 +35,7 @@ public class YamlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
 
     protected void tearDown() throws Exception {
         try {
-            CamelPreferenceService.getService().setOnlyShowKameletOptions(true);
+            CamelProjectPreferenceService.getService(getProject()).setOnlyShowKameletOptions(true);
         } finally {
             super.tearDown();
         }
@@ -359,7 +359,7 @@ public class YamlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
      * Ensure that the configuration option of a given Kamelet can be suggested with other options.
      */
     public void testYamlKameletOptionSuggestions() {
-        CamelPreferenceService.getService().setOnlyShowKameletOptions(false);
+        CamelProjectPreferenceService.getService(getProject()).setOnlyShowKameletOptions(false);
         myFixture.configureByText("CamelRoute.yaml", getYamlKameletOptionSuggestionsData());
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
@@ -374,7 +374,7 @@ public class YamlEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixt
      * Ensure that the configuration option of a given Kamelet can be suggested without other options.
      */
     public void testYamlKameletOptionAloneSuggestions() {
-        CamelPreferenceService.getService().setOnlyShowKameletOptions(true);
+        CamelProjectPreferenceService.getService(getProject()).setOnlyShowKameletOptions(true);
         myFixture.configureByText("CamelRoute.yaml", getYamlKameletOptionSuggestionsData());
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/YamlPropertyKeyCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/YamlPropertyKeyCompletionTestIT.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
-import com.github.cameltooling.idea.service.CamelPreferenceService;
+import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 import com.intellij.codeInsight.lookup.LookupElement;
 
 /**
@@ -38,7 +38,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
     @Override
     protected void tearDown() throws Exception {
         try {
-            CamelPreferenceService.getService().setCamelCatalogProvider(null);
+            CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(null);
         } finally {
             super.tearDown();
         }
@@ -139,7 +139,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
      * Ensures that group suggestions for default Camel Runtime matches with the expectations.
      */
     public void testGroupSuggestionForDefaultCamelRuntime() {
-        CamelPreferenceService.getService().setCamelCatalogProvider(CamelCatalogProvider.DEFAULT);
+        CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(CamelCatalogProvider.DEFAULT);
         myFixture.configureByFiles(getFileName("full-first-key-with-separator"));
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
@@ -150,7 +150,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
      * Ensures that group suggestions for Quarkus Camel Runtime matches with the expectations.
      */
     public void testGroupSuggestionForQuarkusCamelRuntime() {
-        CamelPreferenceService.getService().setCamelCatalogProvider(CamelCatalogProvider.QUARKUS);
+        CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(CamelCatalogProvider.QUARKUS);
         testGroupSuggestionWithFullFirstKeyWithSeparator();
     }
 
@@ -158,7 +158,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
      * Ensures that group suggestions for Karaf Camel Runtime matches with the expectations.
      */
     public void testGroupSuggestionForKarafCamelRuntime() {
-        CamelPreferenceService.getService().setCamelCatalogProvider(CamelCatalogProvider.KARAF);
+        CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(CamelCatalogProvider.KARAF);
         myFixture.configureByFiles(getFileName("full-first-key-with-separator"));
         myFixture.completeBasic();
         List<String> strings = myFixture.getLookupElementStrings();
@@ -527,7 +527,7 @@ public class YamlPropertyKeyCompletionTestIT extends CamelLightCodeInsightFixtur
     }
 
     private String getFileName(String fileNamePrefix) {
-        CamelPreferenceService preferenceService = CamelPreferenceService.getService();
+        CamelProjectPreferenceService preferenceService = CamelProjectPreferenceService.getService(getProject());
         if (preferenceService.getCamelCatalogProvider() == CamelCatalogProvider.AUTO) {
             preferenceService.setCamelCatalogProvider(CamelCatalogProvider.QUARKUS);
         }

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogServiceTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelCatalogServiceTestIT.java
@@ -37,25 +37,25 @@ public class CamelCatalogServiceTestIT extends CamelLightCodeInsightFixtureTestC
     @Override
     protected void tearDown() throws Exception {
         try {
-            CamelPreferenceService.getService().setCamelCatalogProvider(null);
+            CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(null);
         } finally {
             super.tearDown();
         }
     }
 
     public void testNoCatalogInstance() {
-        getModule().getProject().getService(CamelService.class).setCamelPresent(false);
+        getProject().getService(CamelService.class).setCamelPresent(false);
         myFixture.configureByFiles("CompleteJavaEndpointConsumerTestData.java", "CompleteYmlPropertyTestData.java",
             "CompleteJavaPropertyTestData.properties", "CompleteYmlPropertyTestData.java", "CompleteYmlPropertyTestData.yml");
         myFixture.complete(CompletionType.BASIC, 1);
-        assertFalse(getModule().getProject().getService(CamelCatalogService.class).isInstantiated());
+        assertFalse(getProject().getService(CamelCatalogService.class).isInstantiated());
     }
 
     public void testCatalogInstance() {
         myFixture.configureByFiles("CompleteJavaEndpointConsumerTestData.java", "CompleteYmlPropertyTestData.java",
             "CompleteJavaPropertyTestData.properties", "CompleteYmlPropertyTestData.java", "CompleteYmlPropertyTestData.yml");
         myFixture.complete(CompletionType.BASIC, 1);
-        assertTrue(getModule().getProject().getService(CamelCatalogService.class).isInstantiated());
+        assertTrue(getProject().getService(CamelCatalogService.class).isInstantiated());
     }
 
     /**
@@ -65,11 +65,11 @@ public class CamelCatalogServiceTestIT extends CamelLightCodeInsightFixtureTestC
         myFixture.configureByFiles("CompleteJavaEndpointConsumerTestData.java", "CompleteYmlPropertyTestData.java",
             "CompleteJavaPropertyTestData.properties", "CompleteYmlPropertyTestData.java", "CompleteYmlPropertyTestData.yml");
         myFixture.complete(CompletionType.BASIC, 1);
-        CamelCatalogService service = getModule().getProject().getService(CamelCatalogService.class);
+        CamelCatalogService service = getProject().getService(CamelCatalogService.class);
         assertTrue(service.isInstantiated());
         CamelCatalog catalog = service.get();
         assertSame(catalog, service.get());
-        CamelPreferenceService.getService().setCamelCatalogProvider(CamelCatalogProvider.QUARKUS);
+        CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(CamelCatalogProvider.QUARKUS);
         assertTrue(service.isInstantiated());
         assertNotSame(catalog, service.get());
     }

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelPreferenceServiceTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/service/CamelPreferenceServiceTestIT.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.github.cameltooling.idea.catalog.CamelCatalogProvider;
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.util.messages.MessageBusConnection;
 
 /**
@@ -32,7 +32,7 @@ public class CamelPreferenceServiceTestIT extends CamelLightCodeInsightFixtureTe
 
     @Override
     protected void tearDown() throws Exception {
-        CamelPreferenceService.getService().setCamelCatalogProvider(null);
+        CamelProjectPreferenceService.getService(getProject()).setCamelCatalogProvider(null);
         if (connection != null) {
             connection.disconnect();
         }
@@ -43,7 +43,7 @@ public class CamelPreferenceServiceTestIT extends CamelLightCodeInsightFixtureTe
      * Ensure that the default {@link CamelCatalogProvider} is {@link CamelCatalogProvider#AUTO}
      */
     public void testAutoByDefault() {
-        assertEquals(CamelCatalogProvider.AUTO, CamelPreferenceService.getService().getCamelCatalogProvider());
+        assertEquals(CamelCatalogProvider.AUTO, CamelProjectPreferenceService.getService(getProject()).getCamelCatalogProvider());
     }
 
     /**
@@ -51,10 +51,11 @@ public class CamelPreferenceServiceTestIT extends CamelLightCodeInsightFixtureTe
      */
     public void testChangeNotification() {
         AtomicInteger counter = new AtomicInteger();
-        CamelPreferenceService.CamelCatalogProviderChangeListener listener = counter::incrementAndGet;
-        CamelPreferenceService service = CamelPreferenceService.getService();
-        connection = ApplicationManager.getApplication().getMessageBus().connect();
-        connection.subscribe(CamelPreferenceService.CamelCatalogProviderChangeListener.TOPIC, listener);
+        CamelProjectPreferenceService.CamelCatalogProviderChangeListener listener = counter::incrementAndGet;
+        Project project = getProject();
+        CamelProjectPreferenceService service = CamelProjectPreferenceService.getService(project);
+        connection = project.getMessageBus().connect();
+        connection.subscribe(CamelProjectPreferenceService.CamelCatalogProviderChangeListener.TOPIC, listener);
         assertEquals(0, counter.get());
         service.setCamelCatalogProvider(CamelCatalogProvider.AUTO);
         assertEquals(0, counter.get());


### PR DESCRIPTION
fixes #844 

## Motivation

Up to now, all the preferences are global while some preferences should be scoped to the project so we need to review them and adapt their scope if needed.

## Modifications:

* Moves "EnableCamelDebugger", "CamelDebuggerAutoSetup", "OnlyShowKameletOptions" and "CamelCatalogProvider" to the project settings