### PR TITLE
Avoid NoSuchMethodError when creating a SafeConstructor

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/extension/YamlPropertyPlaceholdersSmartCompletion.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/completion/extension/YamlPropertyPlaceholdersSmartCompletion.java
@@ -30,6 +30,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.apache.commons.io.FilenameUtils;
 import org.jetbrains.annotations.NotNull;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -47,7 +48,7 @@ public class YamlPropertyPlaceholdersSmartCompletion implements CamelPropertyCom
     @NotNull
     private Map<String, Object> getProperties(VirtualFile virtualFile) {
         Map<String, Object> result = new HashMap<>();
-        Yaml yaml = new Yaml(new SafeConstructor());
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         try {
             // Parse the YAML file and return the output as a series of Maps and Lists
             result = yaml.load(virtualFile.getInputStream());


### PR DESCRIPTION
## Motivation

After upgrading `kubernetes-model-apiextensions` from `6.6.2` to `6.7.0`, a test fails with an error of type `java.lang.NoSuchMethodError at YamlPropertyPlaceholdersSmartCompletion.java:50`

## Modifications:

* Uses the new correct constructor.