### PR TITLE
Ref #848: Add support of Camel 4 and drop Camel 2

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/documentation/CamelDocumentationProvider.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/documentation/CamelDocumentationProvider.java
@@ -291,9 +291,7 @@ public class CamelDocumentationProvider extends DocumentationProviderEx implemen
             String json = camelCatalog.componentJSonSchema(name);
             ComponentModel component = JsonMapper.generateComponentModel(json);
             String version = component.getVersion();
-            if (version.startsWith("2")) {
-                version = "2.x";
-            } else if (version.startsWith("3.4")) {
+            if (version.startsWith("3.4")) {
                 version = "3.4.x"; // LTS
             } else if (version.startsWith("3.7")) {
                 version = "3.7.x"; // LTS

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/CamelProjectComponentTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/CamelProjectComponentTestIT.java
@@ -56,11 +56,11 @@ public class CamelProjectComponentTestIT extends JavaProjectTestCase {
         CamelService service = myProject.getService(CamelService.class);
         assertEquals(0, service.getLibraries().size());
 
-        File camelJar = createTestArchive("camel-core-2.22.0.jar");
+        File camelJar = createTestArchive("camel-core-4.0.0-M3.jar");
         VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(camelJar);
 
         final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(myProject);
-        addLibraryToModule(virtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-core:2.22.0-snapshot");
+        addLibraryToModule(virtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-core:4.0.0-snapshot");
 
         UIUtil.dispatchAllInvocationEvents();
         assertEquals(1, service.getLibraries().size());
@@ -71,13 +71,13 @@ public class CamelProjectComponentTestIT extends JavaProjectTestCase {
         CamelService service = myProject.getService(CamelService.class);
         assertEquals(0, service.getLibraries().size());
 
-        VirtualFile camelCoreVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-core-2.22.0.jar"));
-        VirtualFile camelSpringVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-spring-2.22.0.jar"));
+        VirtualFile camelCoreVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-core-4.0.0.jar"));
+        VirtualFile camelSpringVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-spring-4.0.0.jar"));
 
         final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(myProject);
 
-        Library springLibrary = addLibraryToModule(camelSpringVirtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-spring:2.22.0-snapshot");
-        addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-core:2.22.0-snapshot");
+        Library springLibrary = addLibraryToModule(camelSpringVirtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-spring:4.0.0-snapshot");
+        addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-core:4.0.0-snapshot");
 
         UIUtil.dispatchAllInvocationEvents();
         assertEquals(2, service.getLibraries().size());
@@ -93,13 +93,13 @@ public class CamelProjectComponentTestIT extends JavaProjectTestCase {
         CamelService service = myProject.getService(CamelService.class);
         assertEquals(0, service.getLibraries().size());
 
-        File camelJar = createTestArchive("camel-core-2.22.0.jar");
+        File camelJar = createTestArchive("camel-core-4.0.0.jar");
         VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(camelJar);
 
         final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(myProject);
         ApplicationManager.getApplication().runWriteAction(() -> {
             final Module moduleA = createModule("myNewModel.iml");
-            Library library = projectLibraryTable.createLibrary("Maven: org.apache.camel:camel-core:2.22.0-snapshot");
+            Library library = projectLibraryTable.createLibrary("Maven: org.apache.camel:camel-core:4.0.0-snapshot");
             final Library.ModifiableModel libraryModifiableModel = library.getModifiableModel();
             assertNotNull(virtualFile);
             libraryModifiableModel.addRoot(virtualFile, OrderRootType.CLASSES);
@@ -115,12 +115,12 @@ public class CamelProjectComponentTestIT extends JavaProjectTestCase {
         CamelService service = myProject.getService(CamelService.class);
         assertEquals(0, service.getLibraries().size());
 
-        VirtualFile camelCoreVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-core-2.22.0.jar"));
+        VirtualFile camelCoreVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-core-4.0.0.jar"));
         VirtualFile legacyJarPackagingFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("legacy-custom-file-0.12.snapshot.jar"));
 
         final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(myProject);
 
-        addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-core:2.22.0-snapshot");
+        addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "Maven: org.apache.camel:camel-core:4.0.0-snapshot");
         addLibraryToModule(legacyJarPackagingFile, projectLibraryTable, "c:\\test\\libs\\legacy-custom-file-0.12.snapshot.jar");
 
         UIUtil.dispatchAllInvocationEvents();
@@ -132,11 +132,11 @@ public class CamelProjectComponentTestIT extends JavaProjectTestCase {
         CamelService service = myProject.getService(CamelService.class);
         assertEquals(0, service.getLibraries().size());
 
-        VirtualFile camelCoreVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-core-2.22.0.jar"));
+        VirtualFile camelCoreVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTestArchive("camel-core-4.0.0.jar"));
 
         final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(myProject);
 
-        addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "org.apache.camel:camel-core:2.22.0-snapshot");
+        addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "org.apache.camel:camel-core:4.0.0-snapshot");
 
         UIUtil.dispatchAllInvocationEvents();
         assertEquals(1, service.getLibraries().size());

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionSpringBootLegacyTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/PropertiesPropertyKeyCompletionSpringBootLegacyTestIT.java
@@ -32,15 +32,15 @@ public class PropertiesPropertyKeyCompletionSpringBootLegacyTestIT extends Prope
         return new String[]{
             "com.sun.xml.bind:jaxb-core:2.3.0",
             "com.sun.xml.bind:jaxb-impl:2.3.0",
-            "org.apache.camel:camel-core:2.25.4",
-            "org.apache.camel:camel-spring-boot:2.25.4",
-            "org.apache.camel:camel-sql-starter:2.25.4"
+            "org.apache.camel:camel-core:3.1.0",
+            "org.apache.camel.springboot:camel-spring-boot:3.1.0",
+            "org.apache.camel.springboot:camel-sql-starter:3.1.0"
         };
     }
 
     protected void assertComponentOptionSuggestion(List<String> strings) {
-        assertContainsElements(strings, "camel.component.sql.data-source = ", "camel.component.sql.use-placeholder = ",
-            "camel.component.sql.resolve-property-placeholders = ", "camel.component.sql.enabled = ");
+        assertContainsElements(strings, "camel.component.sql.data-source = ", "camel.component.sql.enabled = ",
+            "camel.component.sql.use-placeholder = ");
     }
 
     protected void assertDataFormatNameSuggestion(List<String> strings) {

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectionTestHelper.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectionTestHelper.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public abstract class CamelInspectionTestHelper extends JavaInspectionTestCase {
 
-    public static final String CAMEL_CORE_MAVEN_ARTIFACT = "org.apache.camel:camel-core:2.22.0";
+    public static final String CAMEL_CORE_MAVEN_ARTIFACT = "org.apache.camel:camel-core:3.20.0";
 
     @NotNull
     @Override


### PR DESCRIPTION
fixes #848 
fixes #648

## Motivation

Camel 4 is about to be released but the plugin doesn't support it yet. Moreover, Camel 2 is a bit old now, so the support of it needs to be dropped.

## Modifications

* Makes the test checking for core maven dependency more flexible to cover Camel 3 and 4
* Removes all references to Camel 2