### PR TITLE
Ref #862: Keep the case of the version

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/ArtifactCoordinates.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/ArtifactCoordinates.java
@@ -59,7 +59,7 @@ public final class ArtifactCoordinates {
      */
     @NotNull
     public static ArtifactCoordinates parse(LibraryOrderEntry libraryOrderEntry) {
-        String presentableName = libraryOrderEntry.getPresentableName().toLowerCase();
+        String presentableName = libraryOrderEntry.getPresentableName();
         String[] split = presentableName.split(":");
         if (split.length < 3) {
             return new ArtifactCoordinates("$", presentableName, null);

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/CamelProjectComponentTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/CamelProjectComponentTestIT.java
@@ -20,6 +20,7 @@ package com.github.cameltooling.idea;
 import java.io.File;
 
 import com.github.cameltooling.idea.service.CamelService;
+import com.github.cameltooling.idea.util.ArtifactCoordinates;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
@@ -137,11 +138,17 @@ public class CamelProjectComponentTestIT extends JavaProjectTestCase {
         final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(myProject);
 
         addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "org.apache.camel:camel-core:4.0.0-snapshot");
+        addLibraryToModule(camelCoreVirtualFile, projectLibraryTable, "org.apache.camel:camel-core-engine:4.0.0-M3");
 
         UIUtil.dispatchAllInvocationEvents();
-        assertEquals(1, service.getLibraries().size());
+        assertEquals(2, service.getLibraries().size());
         assertTrue(service.getLibraries().contains("camel-core"));
-
+        ArtifactCoordinates coreArtifact = service.getProjectLibraryCoordinates("org.apache.camel", "camel-core");
+        assertNotNull(coreArtifact);
+        assertEquals("4.0.0-SNAPSHOT", coreArtifact.getVersion());
+        ArtifactCoordinates coreEngineArtifact = service.getProjectLibraryCoordinates("org.apache.camel", "camel-core-engine");
+        assertNotNull(coreEngineArtifact);
+        assertEquals("4.0.0-M3", coreEngineArtifact.getVersion());
     }
 
     private File createTestArchive(String filename) {


### PR DESCRIPTION
fixes #862

## Motivation

When we try to open a project that uses a milestone version of Camel, we end up with a warning indicating that the catalog could not be loaded automatically

## Modifications

* Avoid altering the case of the version since a maven repository is case-sensitive 