### PR TITLE
Ref #864: Java DSL Formatter - Avoid formatting expression clauses

### DIFF
--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,7 @@
       <ul>
         <li>Add support of Camel 4</li>
         <li>Drop support of Camel 2</li>
+        <li>Java DSL Formatter - Avoid formatting expression clauses</li>
         <li>Bug fixes</li>
       </ul>
     ]]>

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/formatter/CamelPostFormatProcessorIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/formatter/CamelPostFormatProcessorIT.java
@@ -33,6 +33,29 @@ import org.jetbrains.annotations.Nullable;
  */
 public class CamelPostFormatProcessorIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
+    private static final String CAMEL_SUPPORT_MAVEN_ARTIFACT = String.format("org.apache.camel:camel-support:%s", CAMEL_VERSION);
+
+    /**
+     * Ensures that expressions are not formatted and the language DSL is supported.
+     */
+    public void testRouteWithExpressions() {
+        doTest("RouteWithExpressions", null);
+    }
+
+    /**
+     * Ensures that the data format DSL is supported.
+     */
+    public void testRouteWithDataFormatDSL() {
+        doTest("RouteWithDataFormatDSL", null);
+    }
+
+    /**
+     * Ensures that a malformed route won't make the formatter fail.
+     */
+    public void testMalformedRoute() {
+        doTest("MalformedRoute", null);
+    }
+
     /**
      * Ensures that an entire file can be formatted using the default settings.
      */
@@ -57,7 +80,7 @@ public class CamelPostFormatProcessorIT extends CamelLightCodeInsightFixtureTest
     @Nullable
     @Override
     protected String[] getMavenDependencies() {
-        return new String[]{CAMEL_CORE_MODEL_MAVEN_ARTIFACT};
+        return new String[]{CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_SUPPORT_MAVEN_ARTIFACT};
     }
 
     @Override

--- a/camel-idea-plugin/src/test/resources/testData/formatter/after/EntireFile.txt
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/after/EntireFile.txt
@@ -44,8 +44,7 @@ public class EntireFile extends RouteBuilder {
                 .when(credentialsValid)
                     .process(createNumbersResponseFromBGResponse)
                 .otherwise()
-                    .setHeader(Exchange.HTTP_RESPONSE_CODE)
-                    .constant(401)
+                    .setHeader(Exchange.HTTP_RESPONSE_CODE).constant(401)
                 .end();
 
         from("direct:start-conditional-bean")
@@ -65,8 +64,7 @@ public class EntireFile extends RouteBuilder {
                 .when(credentialsValid)
                     .process(createNumbersResponseFromBGResponse)
                 .otherwise()
-                    .setHeader(Exchange.HTTP_RESPONSE_CODE)
-                    .constant(401)
+                    .setHeader(Exchange.HTTP_RESPONSE_CODE).constant(401)
                 .end();
         from("direct:a")
             .choice()

--- a/camel-idea-plugin/src/test/resources/testData/formatter/after/MalformedRoute.txt
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/after/MalformedRoute.txt
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class MalformedRoute extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+
+        from("direct:start-conditional-bean")
+            .routeId("conditional-bean-route").end().end().setBody().constant("foo");
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/formatter/after/PartialFormatWithRoute.txt
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/after/PartialFormatWithRoute.txt
@@ -43,8 +43,7 @@ public class EntireFile extends RouteBuilder {
                 .when(credentialsValid)
                     .process(createNumbersResponseFromBGResponse)
                 .otherwise()
-                    .setHeader(Exchange.HTTP_RESPONSE_CODE)
-                    .constant(401)
+                    .setHeader(Exchange.HTTP_RESPONSE_CODE).constant(401)
                 .end();
 
         from("direct:start-conditional-bean")

--- a/camel-idea-plugin/src/test/resources/testData/formatter/after/RouteWithDataFormatDSL.txt
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/after/RouteWithDataFormatDSL.txt
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Map;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.dataformat.CsvDataFormat;
+
+public class RouteWithDataFormatDSL extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        CsvDataFormat dataFormat = new CsvDataFormat();
+        dataFormat.setDelimiter("|");
+        from("direct:format")
+            .setBody(constant(Map.of("foo", "abc", "bar", 123)))
+            .marshal(dataFormat);
+
+        from("direct:format")
+            .setBody(constant(Map.of("foo", "abc", "bar", 123)))
+            .marshal()
+            .csv();
+
+        from("direct:format")
+            .setBody(constant(Map.of("foo", "abc", "bar", 123)))
+            .marshal(
+                dataFormat()
+                    .csv()
+                    .delimiter(",")
+                .end());
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/formatter/after/RouteWithExpressions.txt
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/after/RouteWithExpressions.txt
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.builder.RouteBuilder;
+
+import static org.apache.camel.builder.Builder.constant;
+
+public class RouteWithExpressions extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+
+        from("timer:foo")
+            .setBody(simple("xxx"))
+            .setBody().simple("xxx", String.class)
+            .setBody().constant("xxx");
+
+        from("disruptor:foo")
+            .transform(constant("Bye World"))
+            .to("mock:result");
+
+        from("direct:a")
+            .split(
+                expression()
+                    .tokenize()
+                    .token("\n")
+                .end())
+            .to("mock:a");
+
+        from("direct:b")
+            .setBody().expression(
+                expression()
+                    .simple()
+                    .expression("Hello World Out")
+                .end())
+            .to("mock:b");
+        from("direct:c")
+            .setBody(
+                expression()
+                    .simple()
+                    .expression("Hello World In")
+                .end())
+            .to("mock:c");
+        from("direct:d")
+            .filter(
+                expression(
+                    expression()
+                        .header()
+                        .expression("foo")
+                    .end())
+                .isEqualTo("bar"))
+            .to("mock:d");
+
+        AdviceWith.adviceWith(context, "advice-with-on-exception-transacted-test-route", a -> {
+            a.weaveAddFirst().transform(constant("Bye World"));
+        });
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/formatter/before/MalformedRoute.java
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/before/MalformedRoute.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class MalformedRoute extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+
+        from("direct:start-conditional-bean").routeId("conditional-bean-route").end().end().setBody().constant("foo");
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/formatter/before/RouteWithDataFormatDSL.java
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/before/RouteWithDataFormatDSL.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Map;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.dataformat.CsvDataFormat;
+
+public class RouteWithDataFormatDSL extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        CsvDataFormat dataFormat = new CsvDataFormat();
+        dataFormat.setDelimiter("|");
+        from("direct:format").setBody(constant(Map.of("foo", "abc", "bar", 123))).marshal(dataFormat);
+
+        from("direct:format").setBody(constant(Map.of("foo", "abc", "bar", 123))).marshal().csv();
+
+        from("direct:format").setBody(constant(Map.of("foo", "abc", "bar", 123))).marshal(dataFormat().csv().delimiter(",").end());
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/formatter/before/RouteWithExpressions.java
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/before/RouteWithExpressions.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.builder.RouteBuilder;
+
+import static org.apache.camel.builder.Builder.constant;
+
+public class RouteWithExpressions extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+
+        from("timer:foo")
+            .setBody(simple("xxx"))
+            .setBody().simple("xxx", String.class)
+            .setBody().constant("xxx");
+
+        from("disruptor:foo").transform(constant("Bye World")).to("mock:result");
+
+        from("direct:a").split(
+            expression()
+                .tokenize()
+                .token("\n")
+                .end()
+        ).to("mock:a");
+
+        from("direct:b").setBody().expression(expression().simple().expression("Hello World Out").end()).to("mock:b");
+        from("direct:c").setBody(expression().simple().expression("Hello World In").end()).to("mock:c");
+        from("direct:d").filter(expression(expression().header().expression("foo").end()).isEqualTo("bar")).to("mock:d");
+
+        AdviceWith.adviceWith(context, "advice-with-on-exception-transacted-test-route", a -> {
+            a.weaveAddFirst().transform(constant("Bye World"));
+        });
+    }
+}


### PR DESCRIPTION
fixes #864 

## Motivation

The expression clauses are formatted but we would rather prefer not to format them for clarity.

## Modifications

* Excludes the methods of `ExpressionClause` from the methods to format
* Adds support of DataFormat DSL and Language DSL
* Prevents the Java DSL Formatter from failing when the route is not properly written
* Reformat the affected class

## Results:

Here is an example of formatted code

```
        from("timer:foo")
            .setBody(simple("xxx"))
            .setBody().simple("xxx", String.class)
            .setBody().constant("xxx");

        from("disruptor:foo")
            .transform(constant("Bye World"))
            .to("mock:result");

        from("direct:a")
            .split(
                expression()
                    .tokenize()
                    .token("\n")
                .end())
            .to("mock:a");

        from("direct:b")
            .setBody().expression(
                expression()
                    .simple()
                    .expression("Hello World Out")
                .end())
            .to("mock:b");
        from("direct:c")
            .setBody(
                expression()
                    .simple()
                    .expression("Hello World In")
                .end())
            .to("mock:c");
        from("direct:d")
            .filter(
                expression(
                    expression()
                        .header()
                        .expression("foo")
                    .end())
                .isEqualTo("bar"))
            .to("mock:d");
```