### PR TITLE
Ref #871: Adapt the debugger code to Camel 4

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
@@ -168,7 +168,9 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
         }
         parameters.getProgramParametersList().addAll(settings.getTaskNames());
         String sScriptParametersBefore = settings.getScriptParameters();
-        parameters.getProgramParametersList().addAll(Arrays.asList(sScriptParametersBefore.split(" ")));
+        if (sScriptParametersBefore != null) {
+            parameters.getProgramParametersList().addAll(Arrays.asList(sScriptParametersBefore.split(" ")));
+        }
         patchJavaParametersOnDebug(project, ExecutionMode.GRADLE_GENERIC, parameters);
         Map<String, String> env = parameters.getEnv();
         if (env.isEmpty()) {

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerSession.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerSession.java
@@ -660,7 +660,7 @@ public class CamelDebuggerSession implements AbstractDebuggerSession {
                 LOG.debug("Collecting suspended breakpoint nodes ids");
                 @SuppressWarnings("unchecked")
                 Collection<String> suspendedBreakpointIDs = (Collection<String>) serverConnection.invoke(
-                    this.debuggerMBeanObjectName, "getSuspendedBreakpointNodeIds", new Object[]{}, new String[]{}
+                    this.debuggerMBeanObjectName, "suspendedBreakpointNodeIds", new Object[]{}, new String[]{}
                 );
                 if (suspendedBreakpointIDs != null && !suspendedBreakpointIDs.isEmpty()) {
                     LOG.debug("Found suspended breakpoint nodes ids: ", suspendedBreakpointIDs.size());


### PR DESCRIPTION
fixes #871 

## Motivation

The Camel Debugger is no more working when using Camel V4, indeed it never stops at the breakpoints.

## Modifications

* Calls `suspendedBreakpointNodeIds` instead of `getSuspendedBreakpointNodeIds` since it has been removed in Camel 4 and it exists since Camel 3.15 which is the first version for which the Camel Debugger is supported
* Fixes a potential NPE