### PR TITLE
Ref #904: Keep a copy of maven resource bundle keys

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/ui/CamelRunnerConfPanel.form
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/ui/CamelRunnerConfPanel.form
@@ -28,7 +28,7 @@
             <properties>
               <componentClass value="com.intellij.ui.EditorTextField"/>
               <labelLocation value="West"/>
-              <text resource-bundle="messages/MavenConfigurableBundle" key="maven.settings.runner.profiles"/>
+              <text resource-bundle="messages/LegacyMavenConfigurableBundle" key="maven.settings.runner.profiles"/>
             </properties>
           </component>
           <component id="3c5c0" class="com.intellij.ui.components.JBLabel">
@@ -40,7 +40,7 @@
               <fontColor value="BRIGHTER"/>
               <horizontalAlignment value="2"/>
               <horizontalTextPosition value="2"/>
-              <text resource-bundle="messages/MavenConfigurableBundle" key="maven.settings.runner.profiles.notes"/>
+              <text resource-bundle="messages/LegacyMavenConfigurableBundle" key="maven.settings.runner.profiles.notes"/>
             </properties>
           </component>
           <component id="2561b" class="com.intellij.ui.components.JBLabel" binding="myFakeLabel">
@@ -66,13 +66,13 @@
             <properties>
               <componentClass value="com.intellij.openapi.ui.TextFieldWithBrowseButton"/>
               <labelLocation value="West"/>
-              <text resource-bundle="messages/MavenConfigurableBundle" key="maven.settings.working.directory"/>
+              <text resource-bundle="messages/LegacyMavenConfigurableBundle" key="maven.settings.working.directory"/>
             </properties>
           </component>
           <component id="b7a16" class="com.intellij.openapi.ui.FixedSizeButton" binding="showProjectTreeButton">
             <constraints border-constraint="East"/>
             <properties>
-              <toolTipText resource-bundle="messages/MavenConfigurableBundle" key="maven.settings.working.directory.tooltip"/>
+              <toolTipText resource-bundle="messages/LegacyMavenConfigurableBundle" key="maven.settings.working.directory.tooltip"/>
             </properties>
           </component>
         </children>

--- a/camel-idea-plugin/src/main/resources/messages/LegacyMavenConfigurableBundle.properties
+++ b/camel-idea-plugin/src/main/resources/messages/LegacyMavenConfigurableBundle.properties
@@ -1,0 +1,20 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+maven.settings.working.directory.tooltip=Select maven project
+maven.settings.working.directory=Working &directory
+maven.settings.runner.profiles=&Profiles (separated with space)
+maven.settings.runner.profiles.notes=Add prefix '-' to disable profile, e.g. "-test"


### PR DESCRIPTION
fixes #904 

## Motivation

With IntelliJ IDEA 2023.2.2 (Community Edition), when we try to access the Camel debug configurations, we end up with a  `MissingResourceException` due to the removal of a key on which we rely from the resource bundle of the maven plugin [by this commit](https://github.com/JetBrains/intellij-community/commit/6c08a2f231186126f650cd0c5df434e1698879e7).

## Modifications

* Copy all the maven resource bundle keys used by the plugin to an internal resource bundle to fix the issue and prevent the same issue on other keys in the future