### PR TITLE
Ref #879: Filter and order the routes to format

### DIFF
--- a/camel-idea-plugin/src/test/resources/testData/formatter/after/Formatting879.txt
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/after/Formatting879.txt
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+
+public class Formatting879 extends RouteBuilder {
+    @Override
+    public void configure() {
+        from("scheduler: test")
+            .choice()
+                .when(simple("condition1").isEqualTo("value1"))
+                    .process(exchange -> log.debug("execute process1"))
+                    .to("direct:route1")
+                .when(simple("condition2").isEqualTo("value2"))
+                    .process(exchange -> log.debug("execute process2"))
+                .otherwise()
+                    .when(simple("condition3").isEqualTo("value3"))
+                        .to("direct:route3")
+                    .otherwise()
+                        .process(exchange -> log.debug("execute process4"))
+                        .filter(Exchange::isFailed)
+                        .to("direct:route4")
+                    .end();
+        from("direct:route3")
+            .process(exchange -> log.debug("execute route 3"));
+        from("direct:route4")
+            .process(exchange -> log.debug("execute route 4"));
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/formatter/after/RouteWithExpressions.txt
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/after/RouteWithExpressions.txt
@@ -65,6 +65,18 @@ public class RouteWithExpressions extends RouteBuilder {
                     .end())
                 .isEqualTo("bar"))
             .to("mock:d");
+        from("direct:e")
+            .choice()
+                .when(
+                    expression(
+                        expression()
+                            .header()
+                            .expression("foo")
+                        .end())
+                    .isEqualTo("bar"))
+                    .to("mock:e1")
+                .otherwise()
+                    .to("mock:e2");
 
         AdviceWith.adviceWith(context, "advice-with-on-exception-transacted-test-route", a -> {
             a.weaveAddFirst().transform(constant("Bye World"));

--- a/camel-idea-plugin/src/test/resources/testData/formatter/before/Formatting879.java
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/before/Formatting879.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+
+public class Formatting879 extends RouteBuilder {
+    @Override
+    public void configure() {
+        from("scheduler: test")
+            .choice()
+            .when(simple("condition1").isEqualTo("value1"))
+            .process(exchange -> log.debug("execute process1"))
+            .to("direct:route1")
+            .when(simple("condition2").isEqualTo("value2"))
+            .process(exchange -> log.debug("execute process2"))
+            .otherwise()
+            .when(simple("condition3").isEqualTo("value3"))
+            .to("direct:route3")
+            .otherwise()
+            .process(exchange -> log.debug("execute process4"))
+            .filter(Exchange::isFailed)
+            .to("direct:route4")
+            .end();
+        from("direct:route3")
+            .process(exchange -> log.debug("execute route 3"));
+        from("direct:route4")
+            .process(exchange -> log.debug("execute route 4"));
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/formatter/before/RouteWithExpressions.java
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/before/RouteWithExpressions.java
@@ -42,6 +42,7 @@ public class RouteWithExpressions extends RouteBuilder {
         from("direct:b").setBody().expression(expression().simple().expression("Hello World Out").end()).to("mock:b");
         from("direct:c").setBody(expression().simple().expression("Hello World In").end()).to("mock:c");
         from("direct:d").filter(expression(expression().header().expression("foo").end()).isEqualTo("bar")).to("mock:d");
+        from("direct:e").choice().when(expression(expression().header().expression("foo").end()).isEqualTo("bar")).to("mock:e1").otherwise().to("mock:e2");
 
         AdviceWith.adviceWith(context, "advice-with-on-exception-transacted-test-route", a -> {
             a.weaveAddFirst().transform(constant("Bye World"));


### PR DESCRIPTION
fixes #879 

## Motivation

When we try to format a Camel route in a project where Camel routes are defined in different files, we can end up with exceptions of type `IndexOutOfBoundsException`.

## Modifications:

* Ensure that the Camel routes to format are only those that are in the target file
* Ensure that the Camel routes to format are sorted by offset
* Improve the way to format the predicates that could be inlined or not
* Improve the way to format the predicates that could be inside a when clause or not