### PR TITLE
Ref #898: Upgrade to Camel 4.0

### DIFF
--- a/camel-idea-plugin/build.gradle
+++ b/camel-idea-plugin/build.gradle
@@ -60,12 +60,15 @@ dependencies {
     implementation "org.apache.camel:camel-tooling-model:${camelVersion}"
     implementation "org.apache.camel:camel-management-api:${camelVersion}"
     implementation "org.apache.camel.springboot:camel-catalog-provider-springboot:${camelVersion}"
-    implementation "org.apache.camel.karaf:camel-catalog-provider-karaf:${camelVersion}"
+    implementation "org.apache.camel.karaf:camel-catalog-provider-karaf:${camelKarafVersion}"
     implementation "org.apache.camel.quarkus:camel-quarkus-catalog:${camelQuarkusVersion}"
     implementation "org.apache.camel.kamelets:camel-kamelets:${camelKameletVersion}"
     implementation "io.github.classgraph:classgraph:4.8.162"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.3"
     implementation "io.fabric8:kubernetes-model-apiextensions:6.7.2"
+    // To remove once https://github.com/camel-tooling/camel-idea-plugin/issues/751 will be implemented
+    runtimeOnly "org.apache.ivy:ivy:2.5.2"
+    runtimeOnly "org.apache.groovy:groovy:4.0.14"
 
     testImplementation "org.apache.camel:camel-core:${camelVersion}"
     testImplementation "org.apache.camel.springboot:camel-spring-boot:${camelVersion}"

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelMavenVersionManager.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelMavenVersionManager.java
@@ -167,7 +167,7 @@ class CamelMavenVersionManager implements VersionManager {
         // Nothing to do
     }
 
-    ClassLoader getClassLoader() {
+    public ClassLoader getClassLoader() {
         return classLoader;
     }
 

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/annotator/CamelEndpointAnnotatorTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/annotator/CamelEndpointAnnotatorTestIT.java
@@ -114,20 +114,6 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
         myFixture.checkHighlighting(false, false, true, true);
     }
 
-    public void testAnnotatorDeprecatedPropertyValidation() {
-        myFixture.configureByText("AnnotatorTestData.java", getJavaDeprecatedPropertyTestData());
-        myFixture.checkHighlighting(false, false, true, true);
-
-        List<HighlightInfo> list = myFixture.doHighlighting();
-
-        System.out.println("list=" + list);
-        // find the warning from the highlights as checkWarning cannot do that for us for warnings
-        boolean found = list.stream().anyMatch(i -> i.getText().equals("cache")
-            && i.getDescription().equals("Deprecated option")
-            && i.getSeverity().equals(HighlightSeverity.WARNING));
-        assertTrue("Should find the warning", found);
-    }
-
     public void testAnnotatorDurationPropertyValidation() {
         myFixture.configureByText("AnnotatorTestData.java", getJavaInvalidDurationPropertyTestData());
         myFixture.checkHighlighting(false, false, true, true);
@@ -354,16 +340,6 @@ public class CamelEndpointAnnotatorTestIT extends CamelLightCodeInsightFixtureTe
             + "        public void configure() throws Exception {\n"
             + "            from(\"timer:trigger?delay=<error descr=\"Invalid duration value: ImNotADuration\">ImNotADuration</error>\")\n"
             + "                .to(\"file:outbox\");\n"
-            + "        }\n"
-            + "    }";
-    }
-
-    private String getJavaDeprecatedPropertyTestData() {
-        return "import org.apache.camel.builder.RouteBuilder;\n"
-            + "public class MyRouteBuilder extends RouteBuilder {\n"
-            + "        public void configure() throws Exception {\n"
-            + "            from(\"timer:trigger\")\n"
-            + "                .to(\"bean:out?cache=true\");\n"
             + "        }\n"
             + "    }";
     }

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaEndpointSmartCompletionValueTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaEndpointSmartCompletionValueTestIT.java
@@ -22,7 +22,7 @@ import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.codeInsight.completion.CompletionType;
 import org.hamcrest.Matchers;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Testing smart completion with Camel Java DSL
@@ -94,9 +94,8 @@ public class JavaEndpointSmartCompletionValueTestIT extends CamelLightCodeInsigh
         assertDoesntContain(strings, "timer:trigger?repeatCount=10");
         assertContainsElements(strings,
             "timer:trigger?exchangePattern=InOut",
-            "timer:trigger?exchangePattern=InOnly",
-            "timer:trigger?exchangePattern=InOptionalOut");
-        assertEquals(3, strings.size());
+            "timer:trigger?exchangePattern=InOnly");
+        assertEquals(2, strings.size());
     }
 
 }

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaHeaderValueCompletionTestIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/completion/JavaHeaderValueCompletionTestIT.java
@@ -221,10 +221,10 @@ public class JavaHeaderValueCompletionTestIT extends CamelLightCodeInsightFixtur
     private void testEnumCompletionWithUnknownComponent(TestType type) {
         myFixture.configureByFiles(type.getFilePath("HeaderValueEnumSuggestionsUnknownComponent"));
         myFixture.completeBasic();
-        myFixture.type("crea");
+        myFixture.type("list");
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertTrue("Should contain 'CREATE'", strings.stream().anyMatch(s -> s.contains("CREATE")));
+        assertTrue("Should contain 'listPatches'", strings.stream().anyMatch(s -> s.contains("listPatches")));
         myFixture.type('\n');
         myFixture.checkResultByFile(type.getFilePath("HeaderValueEnumSuggestionsUnknownComponentResult"));
     }
@@ -237,10 +237,10 @@ public class JavaHeaderValueCompletionTestIT extends CamelLightCodeInsightFixtur
         TestType type = TestType.JAVA;
         myFixture.configureByFiles(type.getFilePath("HeaderValueEnumSuggestionsWithFullyQualifiedConstantAsName"));
         myFixture.completeBasic();
-        myFixture.type("crea");
+        myFixture.type("list");
         List<String> strings = myFixture.getLookupElementStrings();
         assertNotNull(strings);
-        assertTrue("Should contain 'CREATE'", strings.stream().anyMatch(s -> s.contains("CREATE")));
+        assertTrue("Should contain 'listPatches'", strings.stream().anyMatch(s -> s.contains("listPatches")));
         myFixture.type('\n');
         myFixture.checkResultByFile(type.getFilePath("HeaderValueEnumSuggestionsWithFullyQualifiedConstantAsNameResult"));
     }

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestion.java
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestion.java
@@ -22,7 +22,7 @@ public final class HeaderValueDefaultSuggestion extends RouteBuilder {
     @Override
     public void configure() {
         from("jms:queue")
-            .setHeader("CamelCMISFolderPath", <caret>)
-            .to("cmis://label");
+            .setHeader("CamelHttpProtocolVersion", <caret>)
+            .to("netty-http:http://localhost:8080/admin");
     }
 }

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestion.xml
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestion.xml
@@ -21,10 +21,10 @@
 
     <route>
         <from uri="jms:queue"/>
-        <setHeader name="CamelCMISFolderPath">
+        <setHeader name="CamelHttpProtocolVersion">
             <<caret>
         </setHeader>
-        <to uri="cmis://label"/>
+        <to uri="netty-http:http://localhost:8080/admin"/>
     </route>
 
 </routes>

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestion.yaml
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestion.yaml
@@ -19,6 +19,6 @@
       uri: jms:queue
       steps:
         - set-header:
-            name: CamelCMISFolderPath
+            name: CamelHttpProtocolVersion
             expression:<caret>
-        - to: "cmis://label"
+        - to: "netty-http:http://localhost:8080/admin"

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestionResult.java
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestionResult.java
@@ -22,7 +22,7 @@ public final class HeaderValueDefaultSuggestion extends RouteBuilder {
     @Override
     public void configure() {
         from("jms:queue")
-            .setHeader("CamelCMISFolderPath", constant("/"))
-            .to("cmis://label");
+            .setHeader("CamelHttpProtocolVersion", constant("HTTP/1.1"))
+            .to("netty-http:http://localhost:8080/admin");
     }
 }

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestionResult.xml
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestionResult.xml
@@ -21,10 +21,10 @@
 
     <route>
         <from uri="jms:queue"/>
-        <setHeader name="CamelCMISFolderPath">
-            <constant>/</constant>
+        <setHeader name="CamelHttpProtocolVersion">
+            <constant>HTTP/1.1</constant>
         </setHeader>
-        <to uri="cmis://label"/>
+        <to uri="netty-http:http://localhost:8080/admin"/>
     </route>
 
 </routes>

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestionResult.yaml
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueDefaultSuggestionResult.yaml
@@ -19,7 +19,7 @@
       uri: jms:queue
       steps:
         - set-header:
-            name: CamelCMISFolderPath
+            name: CamelHttpProtocolVersion
             expression:
-              constant: /
-        - to: "cmis://label"
+              constant: HTTP/1.1
+        - to: "netty-http:http://localhost:8080/admin"

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponent.java
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponent.java
@@ -22,7 +22,7 @@ public final class HeaderValueEnumSuggestionsUnknownComponent extends RouteBuild
     @Override
     public void configure() {
         from("jms:queue")
-            .setHeader("cmis:action", <caret>)
-            .to("cmis://label");
+            .setHeader("CamelGrapeCommand", <caret>)
+            .to("grape:defaultCoordinates");
     }
 }

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponent.xml
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponent.xml
@@ -21,10 +21,10 @@
 
     <route>
         <from uri="jms:queue"/>
-        <setHeader name="cmis:action">
+        <setHeader name="CamelGrapeCommand">
             <<caret>
         </setHeader>
-        <to uri="cmis://label"/>
+        <to uri="grape:defaultCoordinates"/>
     </route>
 
 </routes>

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponent.yaml
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponent.yaml
@@ -19,6 +19,6 @@
       uri: jms:queue
       steps:
         - set-header:
-            name: "cmis:action"
+            name: "CamelGrapeCommand"
             expression:<caret>
-        - to: "cmis://label"
+        - to: "grape:defaultCoordinates"

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponentResult.java
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponentResult.java
@@ -22,7 +22,7 @@ public final class HeaderValueEnumSuggestionsUnknownComponent extends RouteBuild
     @Override
     public void configure() {
         from("jms:queue")
-            .setHeader("cmis:action", constant(org.apache.camel.component.cmis.CamelCMISActions.CREATE))
-            .to("cmis://label");
+            .setHeader("CamelGrapeCommand", constant(org.apache.camel.component.grape.GrapeCommand.listPatches))
+            .to("grape:defaultCoordinates");
     }
 }

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponentResult.xml
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponentResult.xml
@@ -21,10 +21,10 @@
 
     <route>
         <from uri="jms:queue"/>
-        <setHeader name="cmis:action">
-            <constant>CREATE</constant>
+        <setHeader name="CamelGrapeCommand">
+            <constant>listPatches</constant>
         </setHeader>
-        <to uri="cmis://label"/>
+        <to uri="grape:defaultCoordinates"/>
     </route>
 
 </routes>

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponentResult.yaml
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsUnknownComponentResult.yaml
@@ -19,7 +19,7 @@
       uri: jms:queue
       steps:
         - set-header:
-            name: "cmis:action"
+            name: "CamelGrapeCommand"
             expression:
-              constant: CREATE
-        - to: "cmis://label"
+              constant: listPatches
+        - to: "grape:defaultCoordinates"

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsWithFullyQualifiedConstantAsName.java
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsWithFullyQualifiedConstantAsName.java
@@ -22,7 +22,7 @@ public final class HeaderValueEnumSuggestionsWithFullyQualifiedConstantAsName ex
     @Override
     public void configure() {
         from("jms:queue")
-            .setHeader(org.apache.camel.component.cmis.CamelCMISConstants.CMIS_ACTION, <caret>)
-            .to("cmis://label");
+            .setHeader(org.apache.camel.component.grape.GrapeConstants.GRAPE_COMMAND, <caret>)
+            .to("grape:defaultCoordinates");
     }
 }

--- a/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsWithFullyQualifiedConstantAsNameResult.java
+++ b/camel-idea-plugin/src/test/resources/testData/completion/header/set/HeaderValueEnumSuggestionsWithFullyQualifiedConstantAsNameResult.java
@@ -22,7 +22,7 @@ public final class HeaderValueEnumSuggestionsWithFullyQualifiedConstantAsName ex
     @Override
     public void configure() {
         from("jms:queue")
-            .setHeader(org.apache.camel.component.cmis.CamelCMISConstants.CMIS_ACTION, constant(org.apache.camel.component.cmis.CamelCMISActions.CREATE))
-            .to("cmis://label");
+            .setHeader(org.apache.camel.component.grape.GrapeConstants.GRAPE_COMMAND, constant(org.apache.camel.component.grape.GrapeCommand.listPatches))
+            .to("grape:defaultCoordinates");
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
-camelVersion = 3.20.6
-camelQuarkusVersion = 2.16.0
-camelKameletVersion = 3.20.6
+camelVersion = 4.0.1
+camelQuarkusVersion = 3.4.0
+camelKameletVersion = 4.0.0
+camelKarafVersion = 3.21.0
 ideaVersion=2023.2.2


### PR DESCRIPTION
fixes #898 

## Motivation

Camel 4.0 has been released so we would like to upgrade Camel to that version.

## Modifications:

* Use a specific version for the Karaf catalog as there is no version 4 available
* Add Groovy/Ivy as runtime dependencies explicitly since they are needed by the plugin since they are no longer transitively inherited by Camel
* Adapt the code to Camel 4
* Adapt some tests to the Camel 4 catalog
* Remove the test ensuring the deprecating warning could be detected by the plugin because there are no more deprecated options in the Camel 4 catalog
* Upgrade all camel dependencies to the latest versions
