### PR TITLE
Ref #751: Use Apache Maven APIs for downloading artifacts

### DIFF
--- a/camel-idea-plugin/build.gradle
+++ b/camel-idea-plugin/build.gradle
@@ -66,9 +66,6 @@ dependencies {
     implementation "io.github.classgraph:classgraph:4.8.162"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2"
     implementation "io.fabric8:kubernetes-model-apiextensions:6.8.1"
-    // To remove once https://github.com/camel-tooling/camel-idea-plugin/issues/751 will be implemented
-    runtimeOnly "org.apache.ivy:ivy:2.5.2"
-    runtimeOnly "org.apache.groovy:groovy:4.0.14"
 
     testImplementation "org.apache.camel:camel-core:${camelVersion}"
     testImplementation "org.apache.camel.springboot:camel-spring-boot:${camelVersion}"
@@ -82,26 +79,7 @@ dependencies {
 
 description = 'Apache Camel IDE :: IDEA Plugin'
 
-test {
-    // Force a specific grape configuration as temporary fix to prevent dependency retrieval issues
-    systemProperty("grape.config", "grapeConfig.xml")
-// Start: To get Grape log messages
-//    systemProperty("groovy.grape.report.downloads", "true")
-//    systemProperty("ivy.message.logger.level", "4")
-//    testLogging {
-//        showStandardStreams = true
-//    }
-// End: To get Grape log messages
-}
-
 runIde {
-// Start: To get Grape log messages
-//    systemProperty("groovy.grape.report.downloads", "true")
-//    systemProperty("ivy.message.logger.level", "4")
-//    testLogging {
-//        showStandardStreams = true
-//    }
-// End: To get Grape log messages
  // Allow to have access to the PSI Structure...
     systemProperty("idea.is.internal", "true")
 }

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/MavenArtifactRetrieverContext.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/MavenArtifactRetrieverContext.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.service;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.tooling.maven.MavenArtifact;
+import org.apache.camel.tooling.maven.MavenDownloader;
+import org.apache.camel.tooling.maven.MavenDownloaderImpl;
+import org.apache.camel.tooling.maven.MavenResolutionException;
+
+/**
+ * {@code MavenArtifactRetrieverContext} is meant to be used to download artifacts from maven repositories.
+ * All the downloaded artifacts and their dependencies are automatically added to the underlying
+ * {@code URLClassLoader} to be able to have access to the local path of the artifacts.
+ */
+public class MavenArtifactRetrieverContext implements Closeable {
+
+    private final MavenDownloader downloader;
+    private final Map<String, String> repositories = new LinkedHashMap<>();
+    private final MavenClassLoader classLoader = new MavenClassLoader();
+
+    public MavenArtifactRetrieverContext() {
+        this.downloader = new MavenDownloaderImpl();
+        ((MavenDownloaderImpl) downloader).build();
+    }
+
+    /**
+     * To add a 3rd party Maven repository.
+     *
+     * @param name the repository name
+     * @param url  the repository url
+     */
+    public void addMavenRepository(String name, String url) {
+        repositories.put(name, url);
+    }
+
+    /**
+     * Downloads the artifact corresponding to the given coordinates and its dependencies, then adds them to
+     * the {@link ClassLoader}.
+     *
+     * @param groupId the group id of the artifact to download
+     * @param artifactId the artifact id of the artifact to download
+     * @param version the version of the artifact to download
+     * @throws IOException if an error occurs while downloading the artifact, or it could not
+     * be added to the {@link ClassLoader}.
+     */
+    public void add(String groupId, String artifactId, String version) throws IOException {
+        try {
+            List<MavenArtifact> artifacts = downloader.resolveArtifacts(
+                List.of(String.format("%s:%s:%s", groupId, artifactId, version)),
+                new LinkedHashSet<>(repositories.values()), true, version.contains("SNAPSHOT")
+            );
+            for (MavenArtifact artifact : artifacts) {
+                classLoader.addURL(artifact.getFile().toURI().toURL());
+            }
+        } catch (MavenResolutionException e) {
+            throw new IOException(e);
+        }
+    }
+
+    public URLClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    @Override
+    public void close() throws IOException {
+        classLoader.close();
+    }
+
+    private static class MavenClassLoader extends URLClassLoader {
+
+        MavenClassLoader() {
+            super(new URL[0]);
+        }
+
+        @Override
+        protected void addURL(URL url) {
+            super.addURL(url);
+        }
+    }
+}


### PR DESCRIPTION
fixes #751 

## Motivation

Instead of using Groovy Grape to download the artifacts, for the sake of uniformity, we would like to reuse the code of Camel based on the Apache Maven APIs.

## Modifications:

* Remove all dependencies related to Groovy Grape
* Remove all system properties related to Groovy Grape
* Replace Groovy Grave with the new class `MavenArtifactRetrieverContext` based on `MavenDownloader` from Camel
