### PR TITLE
Ref #908: Camel Debugger - Add support of Camel SpringBoot 4

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/CamelJBangRunProfileState.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/CamelJBangRunProfileState.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import com.github.cameltooling.idea.service.CamelProjectPreferenceService;
 import com.github.cameltooling.idea.service.CamelRuntime;
+import com.github.cameltooling.idea.util.ArtifactCoordinates;
 import com.intellij.debugger.impl.DebuggerManagerImpl;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
@@ -164,8 +165,12 @@ public class CamelJBangRunProfileState extends CommandLineState implements Targe
         Set<String> dependencies = new HashSet<>(options.getDependencies());
         if (debug) {
             CamelRuntime runtime = preferenceService.getCamelCatalogProvider().getRuntime();
-            dependencies.add(runtime.getDebugArtifactId());
-            dependencies.add(runtime.getManagementArtifactId());
+            dependencies.add(runtime.getDebugArtifact().getArtifactId());
+            dependencies.add(runtime.getManagementArtifact().getArtifactId());
+            ArtifactCoordinates additionalArtifact = runtime.getAdditionalArtifact();
+            if (additionalArtifact != null) {
+                dependencies.add(additionalArtifact.getArtifactId());
+            }
         }
         if (!dependencies.isEmpty()) {
             builder.addParameter(String.format("--deps=%s", String.join(",", dependencies)));

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelRuntime.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/CamelRuntime.java
@@ -33,7 +33,7 @@ public enum CamelRuntime {
     /**
      * The default Camel Runtime.
      */
-    DEFAULT(List.of(CAMEL_GROUP_ID), null, null, "camel-debug", "camel-management", "camel:run") {
+    DEFAULT(List.of(CAMEL_GROUP_ID), null, null, "camel-debug", "camel-management", "camel:run", null) {
         @Override
         @Nullable
         public String getVersion(final Project project) {
@@ -45,21 +45,22 @@ public enum CamelRuntime {
      */
     QUARKUS(
         List.of("org.apache.camel.quarkus"), "camel-quarkus-core", "camel-quarkus-catalog", "camel-quarkus-debug",
-        "camel-quarkus-management", "quarkus:dev"
+        "camel-quarkus-management", "quarkus:dev", null
     ),
     /**
      * The Karaf Runtime.
      */
     KARAF(
         List.of(CAMEL_GROUP_ID, "org.apache.camel.karaf"), "camel-core-osgi", "camel-catalog-provider-karaf",
-        "camel-debug", "camel-management", null
+        "camel-debug", "camel-management", null, null
     ),
     /**
      * The SpringBoot Runtime
      */
     SPRING_BOOT(
         List.of(CAMEL_GROUP_ID, "org.apache.camel.springboot"), "camel-spring-boot",
-        "camel-catalog-provider-springboot", "camel-debug-starter", "camel-management-starter", "spring-boot:run"
+        "camel-catalog-provider-springboot", "camel-debug-starter", "camel-management-starter", "spring-boot:run",
+        ArtifactCoordinates.of(CAMEL_GROUP_ID, "camel-spring-xml", null)
     );
     /**
      * The logger.
@@ -81,15 +82,20 @@ public enum CamelRuntime {
     @Nullable
     private final String catalogArtifactId;
     /**
-     * The id of the artifact containing Camel Debug.
+     * The artifact containing Camel Debug.
      */
     @NotNull
-    private final String debugArtifactId;
+    private final ArtifactCoordinates debugArtifact;
     /**
-     * The id of the artifact containing Camel Management.
+     * The artifact containing Camel Management.
      */
     @NotNull
-    private final String managementArtifactId;
+    private final ArtifactCoordinates managementArtifact;
+    /**
+     * The artifact of the additional debug dependency.
+     */
+    @Nullable
+    private final ArtifactCoordinates additionalArtifact;
     /**
      * The pair {@code maven-plugin-name:goal-name} to call to launch the Camel runtime when applicable, {@code null}
      * otherwise.
@@ -107,15 +113,20 @@ public enum CamelRuntime {
      * @param managementArtifactId the id of the artifact containing Camel Management.
      * @param pluginGoal           the pair {@code maven-plugin-name:goal-name} to call to launch the Camel runtime when applicable, {@code null}
      *                             otherwise.
+     * @param additionalArtifact the artifact of the additional debug dependency.
      */
     CamelRuntime(@NotNull List<String> groupIds, @Nullable String coreArtifactId, @Nullable String catalogArtifactId,
-                 @NotNull String debugArtifactId, @NotNull String managementArtifactId, @Nullable String pluginGoal) {
+                 @NotNull String debugArtifactId, @NotNull String managementArtifactId, @Nullable String pluginGoal,
+                 @Nullable ArtifactCoordinates additionalArtifact) {
         this.groupIds = groupIds;
         this.coreArtifactId = coreArtifactId;
         this.catalogArtifactId = catalogArtifactId;
-        this.debugArtifactId = debugArtifactId;
-        this.managementArtifactId = managementArtifactId;
+        // Use the last group id as it is only supported in recent versions
+        String groupId = groupIds.get(groupIds.size() - 1);
+        this.debugArtifact = ArtifactCoordinates.of(groupId, debugArtifactId, null);
+        this.managementArtifact = ArtifactCoordinates.of(groupId, managementArtifactId, null);
         this.pluginGoal = pluginGoal;
+        this.additionalArtifact = additionalArtifact;
     }
 
     @NotNull
@@ -134,13 +145,18 @@ public enum CamelRuntime {
     }
 
     @NotNull
-    public String getDebugArtifactId() {
-        return debugArtifactId;
+    public ArtifactCoordinates getDebugArtifact() {
+        return debugArtifact;
     }
 
     @NotNull
-    public String getManagementArtifactId() {
-        return managementArtifactId;
+    public ArtifactCoordinates getManagementArtifact() {
+        return managementArtifact;
+    }
+
+    @Nullable
+    public ArtifactCoordinates getAdditionalArtifact() {
+        return additionalArtifact;
     }
 
     @Nullable

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/ArtifactCoordinates.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/util/ArtifactCoordinates.java
@@ -118,4 +118,12 @@ public final class ArtifactCoordinates {
     public String getVersion() {
         return version;
     }
+
+    @Override
+    public String toString() {
+        if (version == null) {
+            return String.format("%s:%s", groupId, artifactId);
+        }
+        return String.format("%s:%s:%s", groupId, artifactId, version);
+    }
 }


### PR DESCRIPTION
fixes #908 

## Motivation

Several problems prevent the Camel Debugger from working properly with Camel SpringBoot 4 applications. 

If the debugger is launched using a Java run configuration, then the Camel Debugger will be able to connect to the Camel SpringBoot application using JMX, but an error indicating that `camel-spring-xml` must added to the classpath is thrown. 

If the debugger is launched using the Camel run configuration for SpringBoot, then the Camel Debugger won't be able to connect as the Camel SpringBoot application is launched in a different process. 

## Modifications:

* Allow to add an additional artifact when configuring the debugger to also add `camel-spring-xml` for SpringBoot
* Access to JMX using a JMX service URL in case of SpringBoot
* Avoid Gradle issues when the generated parameters have not been removed from the Gradle configuration
* Avoid NPE when a Camel checkpoint has been added to a Java class and the Java class is then commented out