### PR TITLE
chore: externalize the version of the maven resolver

### DIFF
--- a/camel-idea-plugin/build.gradle
+++ b/camel-idea-plugin/build.gradle
@@ -64,8 +64,8 @@ dependencies {
     implementation "org.apache.camel.quarkus:camel-quarkus-catalog:${camelQuarkusVersion}"
     implementation "org.apache.camel.kamelets:camel-kamelets:${camelKameletVersion}"
     // Needed to avoid conflicts with the version of the maven resolver used by IntelliJ
-    implementation "org.apache.maven.resolver:maven-resolver-api:1.9.14"
-    implementation "org.apache.maven.resolver:maven-resolver-impl:1.9.14"
+    implementation "org.apache.maven.resolver:maven-resolver-api:${mavenResolverVersion}"
+    implementation "org.apache.maven.resolver:maven-resolver-impl:${mavenResolverVersion}"
     implementation "io.github.classgraph:classgraph:4.8.162"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2"
     implementation "io.fabric8:kubernetes-model-apiextensions:6.8.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ camelQuarkusVersion = 3.4.0
 camelKameletVersion = 4.0.1
 camelKarafVersion = 3.21.0
 ideaVersion=2023.2.2
+mavenResolverVersion=1.9.14


### PR DESCRIPTION
## Motivation

Dependabot sees `maven-resolver-api` and `maven-resolver-impl` as two different libraries while they should be seen and upgraded as single one.

## Modifications:

* Use a property to define globally the version of the maven resolver used