### PR TITLE
Ref #930: camel-debugger - Allow to find the source file by file name

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
@@ -644,6 +644,7 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
      */
     private static void addCamelDebuggerEnvironmentVariable(JavaParameters parameters) {
         parameters.getEnv().put("CAMEL_DEBUGGER_SUSPEND", "true");
+        parameters.getEnv().put("CAMEL_MAIN_DEBUGGING", "true");
     }
 
     /**
@@ -711,7 +712,10 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
 
             @Override
             void addRequiredParameters(JavaParameters parameters) {
-                super.addRequiredMavenGoals(parameters);
+                // Avoid to compile as it can prevent the automatic addition of the Camel Debugger from working properly
+                // Indeed otherwise, the addition of the Camel Debugger to a custom pom file is simply ignored
+                parameters.getProgramParametersList().addAt(0, "clean");
+                parameters.getProgramParametersList().addAt(1, runtime.getPluginGoal());
             }
 
             @Override
@@ -845,7 +849,7 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
         /**
          * The corresponding Camel Runtime.
          */
-        private final CamelRuntime runtime;
+        protected final CamelRuntime runtime;
 
         /**
          * Constructs a {@code ExecutionMode} with the given Camel Runtime.

--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerSession.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerSession.java
@@ -878,6 +878,7 @@ public class CamelDebuggerSession implements AbstractDebuggerSession {
                 if (basePath != null && url.startsWith(basePath)) {
                     sourceLocations.add(String.format("file:%s", url.substring(basePath.length() + 1))); // file:file.xml
                 }
+                sourceLocations.add(virtualFile.getName()); // file.xml
             } else { //Then it must be a Jar
                 sourceLocations = List.of(String.format("classpath:%s", url.substring(url.lastIndexOf("!") + 2)));
             }
@@ -897,8 +898,9 @@ public class CamelDebuggerSession implements AbstractDebuggerSession {
                 } else {
                     relativePath = virtualFile.getName();
                 }
-                sourceLocations.add(relativePath); // file.xml
-                sourceLocations.add(String.format("file:%s", relativePath)); // file:file.xml
+                sourceLocations.add(relativePath); // file.java
+                sourceLocations.add(String.format("file:%s", relativePath)); // file:file.java
+                sourceLocations.add(virtualFile.getName()); // file.java
             }
             break;
         default: // noop

--- a/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/camel-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
   <change-notes><![CDATA[
       v.1.1.1
       <ul>
+        <li>Camel-Debugger: Improve the support of Camel Quarkus</li>
         <li>Bug fixes</li>
       </ul>
     ]]>


### PR DESCRIPTION
fixes #930 

## Motivation

When using the Camel Quarkus, the Camel Debugger doesn't work because he cannot retrieve the source file corresponding to the breakpoints known by Camel.

## Modifications

* Add the file name as a potential location known by Camel
* Avoid calling `compile` in the case of Quarkus as it could prevent the automatic addition of the Camel Debugger from working properly
* Set the environment variable `CAMEL_MAIN_DEBUGGING` required by Camel Quarkus to enable the camel-debug extension 