### PR TITLE
Ref #945: formatting - Exclude new expressions

### DIFF
--- a/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/extension/camel/JavaCamelIdeaUtils.java
+++ b/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/service/extension/camel/JavaCamelIdeaUtils.java
@@ -32,6 +32,7 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.JavaResolveResult;
 import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiCallExpression;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
@@ -656,11 +657,11 @@ public class JavaCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
         if (element == null) {
             LOG.debug("No element cannot be found at index %d".formatted(offset));
         } else if (element instanceof PsiIdentifier) {
-            PsiMethodCallExpression parent = PsiTreeUtil.getParentOfType(element, PsiMethodCallExpression.class);
+            PsiCallExpression parent = PsiTreeUtil.getParentOfType(element, PsiCallExpression.class);
             if (parent == null) {
-                LOG.debug("The parent PsiMethodCallExpression of the element at index %d cannot be found".formatted(offset));
-            } else {
-                JavaResolveResult[] results = parent.getMethodExpression().multiResolve(false);
+                LOG.debug("The parent PsiCallExpression of the element at index %d cannot be found".formatted(offset));
+            } else if (parent instanceof PsiMethodCallExpression methodCallExpression) {
+                JavaResolveResult[] results = methodCallExpression.getMethodExpression().multiResolve(false);
                 if (results.length == 0) {
                     LOG.debug("The method corresponding to the element at index %d cannot be resolved".formatted(offset));
                 } else if (Arrays.stream(results).map(JavaResolveResult::getElement)
@@ -671,6 +672,8 @@ public class JavaCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
                 } else {
                     LOG.trace("The method doesn't match with the predicate");
                 }
+            } else {
+                LOG.debug("The parent PsiCallExpression of the element at index %d is not a method call".formatted(offset));
             }
         } else {
             LOG.trace("The element at index %d is not a PsiIdentifier".formatted(offset));

--- a/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/formatter/CamelPostFormatProcessorIT.java
+++ b/camel-idea-plugin/src/test/java/com/github/cameltooling/idea/formatter/CamelPostFormatProcessorIT.java
@@ -73,6 +73,14 @@ public class CamelPostFormatProcessorIT extends CamelLightCodeInsightFixtureTest
     }
 
     /**
+     * Ensures that the test case defined in <a href="https://github.com/camel-tooling/camel-idea-plugin/issues/945">#945</a>
+     * is properly fixed.
+     */
+    public void testFormatting945() {
+        doTest("Formatting945", null);
+    }
+
+    /**
      * Ensures that a partial format not including a route has no effect.
      */
     public void testPartialFormat() {

--- a/camel-idea-plugin/src/test/resources/testData/formatter/after/Formatting945.txt
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/after/Formatting945.txt
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+
+public class Formatting945 extends RouteBuilder {
+    @Override
+    public void configure() {
+        from("direct:start")
+            .doTry()
+                .process(new ProcessorFail())
+                .to("mock:result")
+            .doCatch(IOException.class, IllegalStateException.class)
+                .to("mock:catch")
+            .doFinally()
+                .to("mock:finally")
+            .end();
+
+        from("direct:start2")
+            .doTry()
+                .unmarshal(new JacksonDataFormat(objectMapper, Foo.class))
+            .doCatch(JsonProcessingException.class)
+                .to("direct:deserialization-error-handler")
+            .end()
+    }
+
+    public static class ProcessorFail implements Processor {
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            throw new IOException("Forced");
+        }
+    }
+}

--- a/camel-idea-plugin/src/test/resources/testData/formatter/before/Formatting945.java
+++ b/camel-idea-plugin/src/test/resources/testData/formatter/before/Formatting945.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+
+public class Formatting945 extends RouteBuilder {
+    @Override
+    public void configure() {
+        from("direct:start")
+            .doTry()
+            .process(new ProcessorFail())
+            .to("mock:result")
+            .doCatch(IOException.class, IllegalStateException.class)
+            .to("mock:catch")
+            .doFinally()
+            .to("mock:finally")
+            .end();
+
+        from("direct:start2")
+            .doTry()
+            .unmarshal(new JacksonDataFormat(objectMapper, Foo.class))
+            .doCatch(JsonProcessingException.class)
+            .to("direct:deserialization-error-handler")
+            .end()
+    }
+
+    public static class ProcessorFail implements Processor {
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            throw new IOException("Forced");
+        }
+    }
+}


### PR DESCRIPTION
fixes #945 

## Motivation

When using the keyword new in the middle of Camel route, the formatting doesn't work as expected so it needs to be improved.

## Modifications:

* Ensure that new expressions are not seen as method calls