### PR TITLE
Remove spring-context from the test dependencies

### DIFF
--- a/camel-idea-plugin/build.gradle
+++ b/camel-idea-plugin/build.gradle
@@ -76,7 +76,6 @@ dependencies {
     testImplementation 'org.jboss.shrinkwrap:shrinkwrap-depchain:1.2.6'
     testImplementation 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-depchain:3.2.1'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'org.springframework:spring-context:6.0.13'
     testImplementation "org.apache.camel:camel-jsonpath:${camelVersion}"
 }
 


### PR DESCRIPTION
## Motivation

No need to keep a dependency that is no longer used and is updated regularly for nothing by dependabot.

## Modifications

* Remove spring-context from the test dependencies

