### PR TITLE
uncomment commented tests, bug fixes, improved bean method references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ dependencies {
         testFramework TestFrameworkType.Platform.INSTANCE
     }
     implementation "org.apache.camel:camel-catalog:${camelVersion}"
+    implementation "org.apache.camel:camel-bean:${camelVersion}"
     implementation "org.apache.camel:camel-tooling-maven:${camelVersion}"
     implementation "org.apache.camel:camel-util:${camelVersion}"
     implementation "org.apache.camel:camel-util-json:${camelVersion}"

--- a/src/main/java/com/github/cameltooling/idea/annotator/CamelBeanMethodAnnotator.java
+++ b/src/main/java/com/github/cameltooling/idea/annotator/CamelBeanMethodAnnotator.java
@@ -96,11 +96,6 @@ public class CamelBeanMethodAnnotator implements Annotator {
 
             final boolean allPrivates = privateMethods == matchMethods.size();
 
-            if (methodNameWithParameters.indexOf("(", methodName.length()) > 0 && methodNameWithParameters.endsWith(")") && !allPrivates) {
-                //TODO implement logic for matching on parameters.
-                return;
-            }
-
             if ((matchMethods.size() - privateMethods) > 1 && !isAnnotatedWithHandler) {
                 errorMessage = String.format(METHOD_HAS_AMBIGUOUS_ACCESS, methodNameWithParameters, psiClass.getQualifiedName());
             } else {

--- a/src/main/java/com/github/cameltooling/idea/annotator/CamelBeanMethodAnnotator.java
+++ b/src/main/java/com/github/cameltooling/idea/annotator/CamelBeanMethodAnnotator.java
@@ -49,7 +49,7 @@ public class CamelBeanMethodAnnotator implements Annotator {
 
     boolean isEnabled(@NotNull PsiElement element) {
         return element.getProject().getService(CamelService.class).isCamelProject()
-            && CamelPreferenceService.getService().isRealTimeSimpleValidation()
+            && CamelPreferenceService.getService().isRealTimeBeanMethodValidationCheckBox()
             && CamelIdeaUtils.getService().getBeanPsiElement(element) != null;
     }
 

--- a/src/main/java/com/github/cameltooling/idea/completion/contributor/CamelJavaReferenceContributor.java
+++ b/src/main/java/com/github/cameltooling/idea/completion/contributor/CamelJavaReferenceContributor.java
@@ -30,6 +30,8 @@ import com.intellij.patterns.PatternCondition;
 import com.intellij.patterns.PsiJavaPatterns;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiJavaToken;
+import com.intellij.psi.PsiLiteralExpression;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.ProcessingContext;
 import org.jetbrains.annotations.NotNull;
 
@@ -53,7 +55,8 @@ public class CamelJavaReferenceContributor extends CamelContributor {
         extend(CompletionType.BASIC, psiElement(PsiJavaToken.class).with(new PatternCondition<>("CamelJavaBeanReferenceSmartCompletion") {
             @Override
             public boolean accepts(@NotNull PsiJavaToken psiJavaToken, ProcessingContext processingContext) {
-                return getCamelIdeaUtils().getBeanPsiElement(psiJavaToken) != null;
+                PsiLiteralExpression expression = PsiTreeUtil.getParentOfType(psiJavaToken, PsiLiteralExpression.class, false);
+                return expression != null && getCamelIdeaUtils().getBeanPsiElement(expression) != null;
             }
         }), new CamelJavaBeanReferenceSmartCompletion());
         // The name of the header corresponding to the first parameter of the method setHeader in the class

--- a/src/main/java/com/github/cameltooling/idea/reference/CamelBeanMethodReference.java
+++ b/src/main/java/com/github/cameltooling/idea/reference/CamelBeanMethodReference.java
@@ -18,7 +18,6 @@ package com.github.cameltooling.idea.reference;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -66,8 +65,9 @@ public class CamelBeanMethodReference extends PsiPolyVariantReferenceBase<PsiEle
     public ResolveResult[] multiResolve(boolean b) {
         List<ResolveResult> results = new ArrayList<>();
 
-        PsiMethod[] methodsByName = getPsiClass().findMethodsByName(methodNameOnly, true);
-        Collection<PsiMethod> beanMethods = JavaMethodUtils.getService().getBeanMethods(Arrays.asList(methodsByName));
+        PsiMethod[] methods = getPsiClass().findMethodsByName(methodNameOnly, true);
+        List<PsiMethod> beanMethods = JavaMethodUtils.getService().getMatchingBeanMethods(Arrays.asList(methods), methodName);
+
         Map<Boolean, List<PsiMethod>> methodsByPrivateness = beanMethods.stream().collect(Collectors.groupingBy(m -> m.getModifierList().hasModifierProperty(PsiModifier.PRIVATE)));
         List<PsiMethod> nonPrivateMethods = methodsByPrivateness.getOrDefault(false, List.of());
         List<PsiMethod> privateMethods = methodsByPrivateness.getOrDefault(true, List.of());

--- a/src/main/java/com/github/cameltooling/idea/reference/CamelBeanMethodReference.java
+++ b/src/main/java/com/github/cameltooling/idea/reference/CamelBeanMethodReference.java
@@ -18,7 +18,11 @@ package com.github.cameltooling.idea.reference;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import com.github.cameltooling.idea.util.CamelIdeaUtils;
 import com.github.cameltooling.idea.util.JavaMethodUtils;
 import com.intellij.openapi.util.TextRange;
@@ -27,6 +31,7 @@ import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementResolveResult;
 import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiPolyVariantReferenceBase;
 import com.intellij.psi.ResolveResult;
 import com.intellij.util.IncorrectOperationException;
@@ -61,8 +66,17 @@ public class CamelBeanMethodReference extends PsiPolyVariantReferenceBase<PsiEle
     public ResolveResult[] multiResolve(boolean b) {
         List<ResolveResult> results = new ArrayList<>();
 
-        final PsiMethod[] methodsByName = getPsiClass().findMethodsByName(methodNameOnly, true);
-        for (PsiMethod psiMethod : JavaMethodUtils.getService().getBeanMethods(Arrays.asList(methodsByName))) {
+        PsiMethod[] methodsByName = getPsiClass().findMethodsByName(methodNameOnly, true);
+        Collection<PsiMethod> beanMethods = JavaMethodUtils.getService().getBeanMethods(Arrays.asList(methodsByName));
+        Map<Boolean, List<PsiMethod>> methodsByPrivateness = beanMethods.stream().collect(Collectors.groupingBy(m -> m.getModifierList().hasModifierProperty(PsiModifier.PRIVATE)));
+        List<PsiMethod> nonPrivateMethods = methodsByPrivateness.getOrDefault(false, List.of());
+        List<PsiMethod> privateMethods = methodsByPrivateness.getOrDefault(true, List.of());
+
+        if (nonPrivateMethods.isEmpty() && !privateMethods.isEmpty()) {
+            return new ResolveResult[] { new PsiElementResolveResult(privateMethods.getFirst()) };
+        }
+
+        for (PsiMethod psiMethod: nonPrivateMethods) {
             if (CamelIdeaUtils.getService().isAnnotatedWithHandler(psiMethod)) {
                 return new ResolveResult[] {new PsiElementResolveResult(psiMethod)};
             }

--- a/src/main/java/com/github/cameltooling/idea/reference/blueprint/BlueprintReferenceContributor.java
+++ b/src/main/java/com/github/cameltooling/idea/reference/blueprint/BlueprintReferenceContributor.java
@@ -16,10 +16,9 @@
  */
 package com.github.cameltooling.idea.reference.blueprint;
 
-import com.intellij.patterns.PlatformPatterns;
+import com.intellij.patterns.XmlPatterns;
 import com.intellij.psi.PsiReferenceContributor;
 import com.intellij.psi.PsiReferenceRegistrar;
-import com.intellij.psi.xml.XmlAttributeValue;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -29,9 +28,9 @@ public class BlueprintReferenceContributor extends PsiReferenceContributor {
 
     @Override
     public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
-        registrar.registerReferenceProvider(PlatformPatterns.psiElement(XmlAttributeValue.class), new BlueprintJavaClassReferenceProvider());
-        registrar.registerReferenceProvider(PlatformPatterns.psiElement(XmlAttributeValue.class), new BeanReferenceProvider());
-        registrar.registerReferenceProvider(PlatformPatterns.psiElement(XmlAttributeValue.class), new BlueprintPropertyNameReferenceProvider());
+        registrar.registerReferenceProvider(XmlPatterns.xmlAttributeValue(), new BlueprintJavaClassReferenceProvider());
+        registrar.registerReferenceProvider(XmlPatterns.xmlAttributeValue(), new BeanReferenceProvider());
+        registrar.registerReferenceProvider(XmlPatterns.xmlAttributeValue(), new BlueprintPropertyNameReferenceProvider());
     }
 
 }

--- a/src/main/java/com/github/cameltooling/idea/service/CamelService.java
+++ b/src/main/java/com/github/cameltooling/idea/service/CamelService.java
@@ -44,6 +44,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.LibraryOrderEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
@@ -161,6 +162,9 @@ public class CamelService implements Disposable {
      * @return true if the current project is a Camel project, {@code false} otherwise.
      */
     public boolean isCamelProject() {
+        if (DumbService.isDumb(project)) { //let's not do anything in dumb mode
+            return false;
+        }
         final Boolean isCamelProject = CamelProjectPreferenceService.getService(project).isCamelProject();
         return isCamelProject == null ? isCamelPresent() : isCamelProject;
     }

--- a/src/main/java/com/github/cameltooling/idea/service/CamelService.java
+++ b/src/main/java/com/github/cameltooling/idea/service/CamelService.java
@@ -664,8 +664,12 @@ public class CamelService implements Disposable {
         // split into major, minor and patch
         String[] parts = version.split("\\.");
         if (parts.length >= 2) {
-            major = Integer.parseInt(parts[0]);
-            minor = Integer.parseInt(parts[1]);
+            try {
+                major = Integer.parseInt(parts[0]);
+                minor = Integer.parseInt(parts[1]);
+            } catch (NumberFormatException e) {
+                return false;
+            }
         }
 
         if (major > MIN_MAJOR_VERSION) {

--- a/src/main/java/com/github/cameltooling/idea/service/extension/camel/JavaCamelIdeaUtils.java
+++ b/src/main/java/com/github/cameltooling/idea/service/extension/camel/JavaCamelIdeaUtils.java
@@ -56,6 +56,7 @@ import com.intellij.psi.PsiTypeParameter;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.impl.source.PostprocessReformattingAspect;
 import com.intellij.psi.impl.source.PsiClassReferenceType;
+import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.search.searches.ClassInheritorsSearch;
 import com.intellij.psi.util.ClassUtil;
 import com.intellij.psi.util.InheritanceUtil;
@@ -406,12 +407,14 @@ public class JavaCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
 
     @Override
     public List<PsiElement> findEndpointUsages(Module module, Predicate<String> uriCondition) {
-        return findEndpoints(module, uriCondition, e -> !isCamelRouteStart(e));
+        var scope = module.getModuleWithDependentsScope();
+        return findEndpoints(module.getProject(), scope, uriCondition, e -> !isCamelRouteStart(e));
     }
 
     @Override
     public List<PsiElement> findEndpointDeclarations(Module module, Predicate<String> uriCondition) {
-        return findEndpoints(module, uriCondition, this::isCamelRouteStart);
+        var scope = module.getModuleWithDependenciesScope();
+        return findEndpoints(module.getProject(), scope, uriCondition, this::isCamelRouteStart);
     }
 
     @Override
@@ -440,13 +443,13 @@ public class JavaCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
             .findFirst();
     }
 
-    private List<PsiElement> findEndpoints(Module module, Predicate<String> uriCondition, Predicate<PsiLiteral> elementCondition) {
-        PsiManager manager = PsiManager.getInstance(module.getProject());
+    private List<PsiElement> findEndpoints(Project project, SearchScope scope, Predicate<String> uriCondition, Predicate<PsiLiteral> elementCondition) {
+        PsiManager manager = PsiManager.getInstance(project);
         PsiClass routeBuilderClass = findRouteBuilderClass(manager);
 
         List<PsiElement> results = new ArrayList<>();
         if (routeBuilderClass != null) {
-            Collection<PsiClass> routeBuilders = ClassInheritorsSearch.search(routeBuilderClass, module.getModuleScope(), true)
+            Collection<PsiClass> routeBuilders = ClassInheritorsSearch.search(routeBuilderClass, scope, true)
                 .findAll();
             for (PsiClass routeBuilder : routeBuilders) {
                 Collection<PsiLiteralExpression> literals = PsiTreeUtil.findChildrenOfType(routeBuilder, PsiLiteralExpression.class);

--- a/src/main/java/com/github/cameltooling/idea/service/extension/camel/JavaCamelIdeaUtils.java
+++ b/src/main/java/com/github/cameltooling/idea/service/extension/camel/JavaCamelIdeaUtils.java
@@ -62,6 +62,7 @@ import com.intellij.psi.util.ClassUtil;
 import com.intellij.psi.util.InheritanceUtil;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.testFramework.LightVirtualFile;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -357,9 +358,10 @@ public class JavaCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
         return true;
     }
 
+
     @Override
     public PsiClass getBeanClass(PsiElement element) {
-        final PsiElement beanPsiElement = getPsiElementForCamelBeanMethod(element);
+        PsiElement beanPsiElement = getPsiElementForCamelBeanMethod(PsiTreeUtil.getParentOfType(element, PsiLiteralExpression.class, false));
         if (beanPsiElement != null) {
             if (beanPsiElement instanceof PsiClass psiClass) {
                 return psiClass;
@@ -388,7 +390,7 @@ public class JavaCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
 
     @Override
     public PsiElement getPsiElementForCamelBeanMethod(PsiElement element) {
-        if (element instanceof PsiLiteral || element.getParent() instanceof PsiLiteralExpression) {
+        if (element instanceof PsiLiteralExpression) {
             final PsiExpressionList expressionList = PsiTreeUtil.getParentOfType(element, PsiExpressionList.class);
             if (expressionList != null) {
                 final PsiIdentifier identifier = PsiTreeUtil.getChildOfType(expressionList.getPrevSibling(), PsiIdentifier.class);
@@ -396,6 +398,7 @@ public class JavaCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
                     return expressionList;
                 }
             }
+            return null;
         }
         return null;
     }

--- a/src/main/java/com/github/cameltooling/idea/service/extension/camel/YamlCamelIdeaUtils.java
+++ b/src/main/java/com/github/cameltooling/idea/service/extension/camel/YamlCamelIdeaUtils.java
@@ -182,8 +182,7 @@ public class YamlCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
 
     @Override
     public boolean isCamelFile(PsiFile file) {
-        if (file != null && YAMLFileType.YML.equals(file.getFileType())) {
-            YAMLFile yamlFile = (YAMLFile) file;
+        if (file instanceof YAMLFile yamlFile) {
             List<YAMLDocument> yamlDocuments = yamlFile.getDocuments();
             return yamlDocuments.stream().anyMatch(document -> {
                 YAMLValue value = document.getTopLevelValue();

--- a/src/main/java/com/github/cameltooling/idea/service/extension/camel/YamlCamelIdeaUtils.java
+++ b/src/main/java/com/github/cameltooling/idea/service/extension/camel/YamlCamelIdeaUtils.java
@@ -30,12 +30,14 @@ import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.lang.ASTNode;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
 import com.intellij.patterns.ElementPattern;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.patterns.StandardPatterns;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.yaml.YAMLElementTypes;
 import org.jetbrains.yaml.YAMLFileType;
@@ -384,18 +386,18 @@ public class YamlCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
 
     @Override
     public List<PsiElement> findEndpointUsages(Module module, Predicate<String> uriCondition) {
-        return findEndpoints(module, PRODUCER_ENDPOINT, uriCondition);
+        return findEndpoints(module.getProject(), module.getModuleWithDependentsScope(), PRODUCER_ENDPOINT, uriCondition);
     }
 
     @Override
     public List<PsiElement> findEndpointDeclarations(Module module, Predicate<String> uriCondition) {
-        return findEndpoints(module, CONSUMER_ENDPOINT, uriCondition);
+        return findEndpoints(module.getProject(), module.getModuleWithDependenciesScope(), CONSUMER_ENDPOINT, uriCondition);
     }
 
-    private List<PsiElement> findEndpoints(Module module, ElementPattern<YAMLKeyValue> pattern, Predicate<String> uriCondition) {
+    private List<PsiElement> findEndpoints(Project project, GlobalSearchScope scope, ElementPattern<YAMLKeyValue> pattern, Predicate<String> uriCondition) {
         final List<PsiElement> result = new ArrayList<>();
         IdeaUtils.getService().iterateYamlFiles(
-            module,
+                project, scope,
             file -> PsiTreeUtil.processElements(
                 file,
                 element -> {

--- a/src/main/java/com/github/cameltooling/idea/util/BeanUtils.java
+++ b/src/main/java/com/github/cameltooling/idea/util/BeanUtils.java
@@ -94,7 +94,7 @@ public class BeanUtils implements Disposable {
     private List<ReferenceableBeanId> findReferenceableIds(@NotNull Module module, Predicate<String> idCondition, boolean stopOnMatch) {
         List<ReferenceableBeanId> results = new ArrayList<>();
         final IdeaUtils ideaUtils = IdeaUtils.getService();
-        ideaUtils.iterateXmlDocumentRoots(module, root -> {
+        ideaUtils.iterateXmlDocumentRoots(module.getProject(), module.getModuleContentScope(), root -> {
             if (isPartOfBeanContainer(root)) {
                 ideaUtils.iterateXmlNodes(root, XmlTag.class, tag -> Optional.of(tag)
                         .filter(this::isPartOfBeanContainer)

--- a/src/main/java/com/github/cameltooling/idea/util/IdeaUtils.java
+++ b/src/main/java/com/github/cameltooling/idea/util/IdeaUtils.java
@@ -43,6 +43,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleFileIndex;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.text.StringUtil;
@@ -437,17 +439,17 @@ public final class IdeaUtils implements Disposable {
 
     /**
      * Calls the given consumer for each Yaml file that could be found in the given module.
-     * @param module the module in which Yaml files should be found.
+     * @param project the project in which Yaml files should be found.
+     * @param scope the scope in which Yaml files should be found.
      * @param yamlFileConsumer the consumer to call anytime a Yaml has been found.
      */
-    public void iterateYamlFiles(Module module, Consumer<YAMLFile> yamlFileConsumer) {
-        final GlobalSearchScope moduleScope = module.getModuleContentScope();
-        final GlobalSearchScope yamlFiles = GlobalSearchScope.getScopeRestrictedByFileTypes(moduleScope, YAMLFileType.YML);
+    public void iterateYamlFiles(Project project, GlobalSearchScope scope, Consumer<YAMLFile> yamlFileConsumer) {
+        final GlobalSearchScope yamlFiles = GlobalSearchScope.getScopeRestrictedByFileTypes(scope, YAMLFileType.YML);
 
-        ModuleFileIndex fileIndex = ModuleRootManager.getInstance(module).getFileIndex();
+        ProjectFileIndex fileIndex = ProjectRootManager.getInstance(project).getFileIndex();
         fileIndex.iterateContent(f -> {
             if (yamlFiles.contains(f)) {
-                PsiFile file = PsiManager.getInstance(module.getProject()).findFile(f);
+                PsiFile file = PsiManager.getInstance(project).findFile(f);
                 if (file instanceof YAMLFile yamlFile) {
                     yamlFileConsumer.accept(yamlFile);
                 }
@@ -456,14 +458,13 @@ public final class IdeaUtils implements Disposable {
         });
     }
 
-    public void iterateXmlDocumentRoots(Module module, Consumer<XmlTag> rootTag) {
-        final GlobalSearchScope moduleScope = module.getModuleContentScope();
-        final GlobalSearchScope xmlFiles = GlobalSearchScope.getScopeRestrictedByFileTypes(moduleScope, XmlFileType.INSTANCE);
+    public void iterateXmlDocumentRoots(Project project, GlobalSearchScope scope, Consumer<XmlTag> rootTag) {
+        final GlobalSearchScope xmlFiles = GlobalSearchScope.getScopeRestrictedByFileTypes(scope, XmlFileType.INSTANCE);
 
-        ModuleFileIndex fileIndex = ModuleRootManager.getInstance(module).getFileIndex();
+        ProjectFileIndex fileIndex = ProjectRootManager.getInstance(project).getFileIndex();
         fileIndex.iterateContent(f -> {
             if (xmlFiles.contains(f)) {
-                PsiFile file = PsiManager.getInstance(module.getProject()).findFile(f);
+                PsiFile file = PsiManager.getInstance(project).findFile(f);
                 if (file instanceof XmlFile xmlFile) {
                     XmlTag root = xmlFile.getRootTag();
                     if (root != null) {

--- a/src/main/java/com/github/cameltooling/idea/util/JavaMethodUtils.java
+++ b/src/main/java/com/github/cameltooling/idea/util/JavaMethodUtils.java
@@ -19,16 +19,24 @@ package com.github.cameltooling.idea.util;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementFactory;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiParameter;
+import com.intellij.psi.PsiParameterList;
+import com.intellij.psi.PsiType;
+import com.intellij.util.IncorrectOperationException;
+import org.apache.camel.component.bean.BeanHelper;
+import org.jetbrains.annotations.NotNull;
 
 public class JavaMethodUtils implements Disposable {
 
@@ -111,11 +119,79 @@ public class JavaMethodUtils implements Disposable {
      * @param methods - List of methods to filter
      * @return - List of filtered methods
      */
-    public Collection<PsiMethod> getBeanMethods(Collection<PsiMethod> methods) {
+    public List<PsiMethod> getMatchingBeanMethods(List<PsiMethod> methods, String methodSpec) {
+        int paraStart = methodSpec.indexOf('(');
+        List<String> paramSpecs;
+        if (paraStart >= 0) {
+            if (!methodSpec.endsWith(")")) {
+                return List.of();
+            }
+            methodSpec = methodSpec.substring(paraStart + 1, methodSpec.length() - 1);
+            paramSpecs = Arrays.stream(methodSpec.split(",")).map(String::trim).toList();
+        } else {
+            paramSpecs = null;
+        }
         return methods.stream()
-            .filter(method -> !method.isConstructor() && !method.getModifierList().hasModifierProperty(PsiModifier.ABSTRACT))
-            .collect(Collectors.toList());
+                .filter(method -> !method.isConstructor() && !method.getModifierList().hasModifierProperty(PsiModifier.ABSTRACT))
+                .filter(method -> paramSpecs == null || beanMethodMatches(method, paramSpecs))
+                .toList();
     }
+
+    /**
+     * Basically a simplified re-implementation of {@link org.apache.camel.component.bean.BeanInfo#matchMethod}
+     */
+    private boolean beanMethodMatches(PsiMethod method, List<String> paramSpecs) {
+        PsiParameterList methodParams = method.getParameterList();
+        int paramCount = methodParams.getParametersCount();
+        if (paramCount != paramSpecs.size()) {
+            return false;
+        }
+        for (int i = 0; i < paramSpecs.size(); i++) {
+            PsiParameter methodParam = methodParams.getParameter(i);
+            if (!parameterMatchesSpec(methodParam, paramSpecs.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean parameterMatchesSpec(PsiParameter param, @NotNull String spec) {
+        if (spec.startsWith("${") || spec.equals("*")) {
+            return true;
+        }
+        int typeSeparatorPos = spec.indexOf(' ');
+        String typeSpec = spec;
+        if (typeSeparatorPos > -1) {
+            typeSpec = removeClassSuffix(spec.substring(0, typeSeparatorPos));
+        } else {
+            if (!typeSpec.endsWith(".class")) {
+                typeSpec = determineValueType(spec);
+                if (typeSpec == null) {
+                    return false;
+                }
+            } else {
+                typeSpec = removeClassSuffix(spec);
+            }
+        }
+
+        Project project = param.getProject();
+        try {
+            PsiType type = PsiElementFactory.getInstance(project).createTypeFromText(typeSpec, param);
+            return param.getType().isAssignableFrom(type);
+        } catch (IncorrectOperationException e) {
+            return false;
+        }
+    }
+
+    private String removeClassSuffix(String value) {
+        return value.endsWith(".class") ? value.substring(0, value.length() - ".class".length()) : value;
+    }
+
+    private String determineValueType(String value) {
+        Class<?> type = BeanHelper.getValidParameterType(value);
+        return type == null ? null : type.getName();
+    }
+
 
     /**
      * Return only the method name in free text from an {@link PsiElement}

--- a/src/main/java/com/github/cameltooling/idea/util/JavaMethodUtils.java
+++ b/src/main/java/com/github/cameltooling/idea/util/JavaMethodUtils.java
@@ -105,13 +105,15 @@ public class JavaMethodUtils implements Disposable {
     }
 
     /**
-     * Return all methods expect the constructor
+     * Filter methods suitable for being a bean method invoked from a route.
+     * Private methods are not suitable, but are returned anyway - so that we can show an explicit error message on them
+     *
      * @param methods - List of methods to filter
      * @return - List of filtered methods
      */
     public Collection<PsiMethod> getBeanMethods(Collection<PsiMethod> methods) {
         return methods.stream()
-            .filter(method -> !method.isConstructor())
+            .filter(method -> !method.isConstructor() && !method.getModifierList().hasModifierProperty(PsiModifier.ABSTRACT))
             .collect(Collectors.toList());
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -145,7 +145,7 @@
 
     <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.CamelBeanReferenceContributor"/>
     <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.endpoint.direct.DirectEndpointReferenceContributor"/>
-    <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.blueprint.BlueprintReferenceContributor"/>
+    <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.blueprint.BlueprintReferenceContributor" language="XML"/>
     <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.CamelBeanInjectReferenceContributor"/>
     <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.CamelPropertyPlaceholderReferenceContributor"/>
     <renameHandler implementation="com.github.cameltooling.idea.reference.CamelBeanReferenceRenameHandler"/>

--- a/src/test/java/com/github/cameltooling/idea/CamelLightCodeInsightFixtureTestCaseIT.java
+++ b/src/test/java/com/github/cameltooling/idea/CamelLightCodeInsightFixtureTestCaseIT.java
@@ -65,6 +65,7 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightJavaCo
     protected static String CAMEL_VERSION;
     protected static String CAMEL_CORE_MAVEN_ARTIFACT = "org.apache.camel:camel-core:%s";
     protected static String CAMEL_CORE_MODEL_MAVEN_ARTIFACT = "org.apache.camel:camel-core-model:%s";
+    protected static String CAMEL_API_MAVEN_ARTIFACT = "org.apache.camel:camel-api:%s";
     protected static String CAMEL_ENDPOINTDSL_MAVEN_ARTIFACT = "org.apache.camel:camel-endpointdsl:%s";
 
 
@@ -75,6 +76,7 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightJavaCo
             gradleProperties.load(is);
             CAMEL_VERSION = gradleProperties.getProperty("camelVersion");
             CAMEL_CORE_MAVEN_ARTIFACT = String.format(CAMEL_CORE_MAVEN_ARTIFACT, CAMEL_VERSION);
+            CAMEL_API_MAVEN_ARTIFACT = String.format(CAMEL_API_MAVEN_ARTIFACT, CAMEL_VERSION);
             CAMEL_CORE_MODEL_MAVEN_ARTIFACT = String.format(CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_VERSION);
             CAMEL_ENDPOINTDSL_MAVEN_ARTIFACT = String.format(CAMEL_ENDPOINTDSL_MAVEN_ARTIFACT, CAMEL_VERSION);
         } catch (IOException e) {

--- a/src/test/java/com/github/cameltooling/idea/CamelLightCodeInsightFixtureTestCaseIT.java
+++ b/src/test/java/com/github/cameltooling/idea/CamelLightCodeInsightFixtureTestCaseIT.java
@@ -49,7 +49,6 @@ import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.PsiTestUtil;
 import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -81,7 +80,7 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightJavaCo
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        mavenArtifacts = getMavenArtifacts(CAMEL_CORE_MAVEN_ARTIFACT);
+        mavenArtifacts = CamelTestDependencyUtil.getMavenArtifacts(CAMEL_CORE_MAVEN_ARTIFACT);
     }
 
     @Override
@@ -115,21 +114,6 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightJavaCo
     @Override
     protected String getTestDataPath() {
         return TEST_DATA_BASE;
-    }
-
-    /**
-     * Get a list of artifact declared as dependencies in the pom.xml file.
-     * <p>
-     *   The method take a String arrays off "G:A:P:C:?" "org.apache.camel:camel-core:2.22.0"
-     * </p>
-     * @param mavenArtifact - Array of maven artifact to resolve
-     * @return Array of artifact files
-     */
-    protected static File[] getMavenArtifacts(String... mavenArtifact) {
-        return Maven.configureResolver()
-            .withRemoteRepo("snapshot", "https://repository.apache.org/snapshots/", "default")
-            .resolve(mavenArtifact)
-            .withoutTransitivity().asFile();
     }
 
     protected PsiElement getElementAtCaret() {
@@ -180,24 +164,14 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightJavaCo
 
             @Override
             public void configureModule(@NotNull Module module, @NotNull ModifiableRootModel model, @NotNull ContentEntry contentEntry) {
-                loadDependencies(model);
+                CamelTestDependencyUtil.loadDependencies(model, getMavenDependencies());
+                loadCustomDependencies(model);
                 model.getModuleExtension( LanguageLevelModuleExtension.class ).setLanguageLevel( LanguageLevel.JDK_11 );
             }
         };
     }
 
-    /**
-     * Loads the maven dependencies into the given model.
-     * @param model the model into which the dependencies are added.
-     */
-    protected void loadDependencies(@NotNull ModifiableRootModel model) {
-        String[] dependencies = getMavenDependencies();
-        if (dependencies != null && dependencies.length > 0) {
-            File[] artifacts = getMavenArtifacts(dependencies);
-            for (int i = 0; i < artifacts.length; i++) {
-                File artifact = artifacts[i];
-                PsiTestUtil.addLibrary(model, dependencies[i], artifact.getParent(), artifact.getName());
-            }
-        }
+    protected void loadCustomDependencies(@NotNull ModifiableRootModel model) {
     }
+
 }

--- a/src/test/java/com/github/cameltooling/idea/CamelTestDependencyUtil.java
+++ b/src/test/java/com/github/cameltooling/idea/CamelTestDependencyUtil.java
@@ -1,0 +1,43 @@
+package com.github.cameltooling.idea;
+
+import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.testFramework.PsiTestUtil;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+
+public class CamelTestDependencyUtil {
+
+    /**
+     * TODO: there's com.intellij.testFramework.fixtures.MavenDependencyUtil#addFromMaven, but it does not work as well
+     *       as this one for some reason - when attached via it, the lib classes are not searchable via psi tree. Find out why.
+     * Loads the maven dependencies into the given model.
+     * @param model the model into which the dependencies are added.
+     */
+    public static void loadDependencies(@NotNull ModifiableRootModel model, String ... dependencies) {
+        if (dependencies != null && dependencies.length > 0) {
+            File[] artifacts = getMavenArtifacts(dependencies);
+            for (int i = 0; i < artifacts.length; i++) {
+                File artifact = artifacts[i];
+                PsiTestUtil.addLibrary(model, dependencies[i], artifact.getParent(), artifact.getName());
+            }
+        }
+    }
+
+    /**
+     * Get a list of artifact declared as dependencies in the pom.xml file.
+     * <p>
+     *   The method take a String arrays off "G:A:P:C:?" "org.apache.camel:camel-core:2.22.0"
+     * </p>
+     * @param mavenArtifact - Array of maven artifact to resolve
+     * @return Array of artifact files
+     */
+    protected static File[] getMavenArtifacts(String... mavenArtifact) {
+        return Maven.configureResolver()
+                .withRemoteRepo("snapshot", "https://repository.apache.org/snapshots/", "default")
+                .resolve(mavenArtifact)
+                .withoutTransitivity().asFile();
+    }
+
+}

--- a/src/test/java/com/github/cameltooling/idea/annotator/BeanReferenceTypeAnnotatorIT.java
+++ b/src/test/java/com/github/cameltooling/idea/annotator/BeanReferenceTypeAnnotatorIT.java
@@ -23,8 +23,14 @@ import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.lang.annotation.HighlightSeverity;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BeanReferenceTypeAnnotatorIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    @Override
+    protected @Nullable String[] getMavenDependencies() {
+        return new String[] {CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_API_MAVEN_ARTIFACT};
+    }
 
     @Override
     protected String getTestDataPath() {
@@ -45,18 +51,17 @@ public class BeanReferenceTypeAnnotatorIT extends CamelLightCodeInsightFixtureTe
         assertEquals("Bean must be of 'TestClass2' type", highlight.getDescription());
     }
 
-//    @Ignore
-//    public void testAnnotations() {
-//        List<HighlightInfo> highlights = getHighlights("TestClass1.java", "TestClass2.java", "beans.xml");
-//        List<HighlightInfo> testClass1BeanErrors = highlights.stream()
-//                .filter(h -> h.getText().equals("testClass1Bean"))
-//                .collect(Collectors.toList());
-//        assertEquals(1, testClass1BeanErrors.size());
-//        assertEquals("Bean must be of 'TestClass2' type", testClass1BeanErrors.get(0).getDescription());
-//
-//        assertEmpty(highlights.stream().filter(h -> h.getText().equals("testClass2Bean")).collect(Collectors.toList()));
-//        assertEmpty(highlights.stream().filter(h -> h.getText().equals("someEndpoint")).collect(Collectors.toList()));
-//    }
+    public void testAnnotations() {
+        List<HighlightInfo> highlights = getHighlights("TestClass1.java", "TestClass2.java", "beans.xml");
+        List<HighlightInfo> testClass1BeanErrors = highlights.stream()
+                .filter(h -> h.getText().equals("testClass1Bean"))
+                .collect(Collectors.toList());
+        assertEquals(1, testClass1BeanErrors.size());
+        assertEquals("Bean must be of 'TestClass2' type", testClass1BeanErrors.get(0).getDescription());
+
+        assertEmpty(highlights.stream().filter(h -> h.getText().equals("testClass2Bean")).collect(Collectors.toList()));
+        assertEmpty(highlights.stream().filter(h -> h.getText().equals("someEndpoint")).collect(Collectors.toList()));
+    }
 
     @NotNull
     private List<HighlightInfo> getHighlights(String ... filePaths) {

--- a/src/test/java/com/github/cameltooling/idea/annotator/CamelBeanMethodAnnotatorTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/annotator/CamelBeanMethodAnnotatorTestIT.java
@@ -1,118 +1,116 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *      http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package com.github.cameltooling.idea.annotator;
-//
-//import java.util.List;
-//import java.util.Optional;
-//
-//import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
-//import com.intellij.codeInsight.daemon.impl.HighlightInfo;
-//import com.intellij.lang.annotation.HighlightSeverity;
-//import org.junit.Ignore;
-//
-//
-///**
-// * Test if the {@link CamelBeanMethodAnnotator} work as expected with private, overload and none exiting bean reference calls
-// * <pre>
-// * if this test run with the "-Didea.home.path=/Users/home/work/idea/" it will report 2 as error count, because the idea.home
-// * path point to the SDK and it able to resolve basic JDK classes.
-// * </pre>
-// */
-//public class CamelBeanMethodAnnotatorTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
-//
-//    @Override
-//    protected String getTestDataPath() {
-//        return "src/test/resources/testData/annotator/method";
-//    }
-//
-//    /**
-//     * Test if the annotator mark the bean call "thisIsVeryPrivate","methodDoesNotExist" as errors
-//     */
-//    @Ignore
-//    public void testAnnotatorJavaBeanWithPrivateAndNoneExistingMethod() {
-//        myFixture.configureByFiles("AnnotatorJavaBeanRoute1TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
-//        myFixture.checkHighlighting(false, false, false, true);
-//
-//        List<HighlightInfo> list = myFixture.doHighlighting();
-//        verifyHighlight(list, "\"thisIsVeryPrivate\"", "'thisIsVeryPrivate' has private access in bean 'testData.annotator.method.AnnotatorJavaBeanTestData'", HighlightSeverity.ERROR);
-//        verifyHighlight(list, "\"methodDoesNotExist\"", "Can not resolve method 'methodDoesNotExist' in bean 'testData.annotator.method.AnnotatorJavaBeanTestData'", HighlightSeverity.ERROR);
-//        verifyHighlight(list, "(AnnotatorJavaBeanTestData.class, \"letsDoThis\")", "Cannot resolve method 'bean(java.lang.Class, java.lang.String)'", HighlightSeverity.ERROR);
-//    }
-//
-//    /**
-//     * Test if the annotator mark the bean call "thisIsVeryPrivate","methodDoesNotExist" as errors
-//     */
-//    @Ignore
-//    public void testAnnotatorJavaBeanWithAbstractMethod() {
-//        myFixture.configureByFiles("AnnotatorJavaBeanRoute2TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
-//        myFixture.checkHighlighting(false, false, false, true);
-//
-//        List<HighlightInfo> list = myFixture.doHighlighting();
-//
-//        verifyHighlight(list, "\"letsDoThis\"", "Can not resolve method 'letsDoThis' in bean 'testData.annotator.method.AnnotatorJavaBeanSuperClassTestData'", HighlightSeverity.ERROR);
-//        verifyHighlight(list, "(beanTestData, \"mySuperAbstractMethod\")", "Cannot resolve method 'bean(testData.annotator.method.AnnotatorJavaBeanSuperClassTestData, java.lang.String)'", HighlightSeverity.ERROR);
-//        verifyHighlight(list, "\"thisIsVeryPrivate\"", "Can not resolve method 'thisIsVeryPrivate' in bean 'testData.annotator.method.AnnotatorJavaBeanSuperClassTestData'", HighlightSeverity.ERROR);
-//    }
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.annotator;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.lang.annotation.HighlightSeverity;
+import org.jetbrains.annotations.Nullable;
+
+
+/**
+ * Test if the {@link CamelBeanMethodAnnotator} work as expected with private, overload and none exiting bean reference calls
+ * <pre>
+ * if this test run with the "-Didea.home.path=/Users/home/work/idea/" it will report 2 as error count, because the idea.home
+ * path point to the SDK and it able to resolve basic JDK classes.
+ * </pre>
+ */
+public class CamelBeanMethodAnnotatorTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    @Override
+    protected @Nullable String[] getMavenDependencies() {
+        return new String[] {CAMEL_CORE_MODEL_MAVEN_ARTIFACT};
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources/testData/annotator/method";
+    }
+
+    /**
+     * Test if the annotator mark the bean call "thisIsVeryPrivate","methodDoesNotExist" as errors
+     */
+    public void testAnnotatorJavaBeanWithPrivateAndNoneExistingMethod() {
+        myFixture.configureByFiles("AnnotatorJavaBeanRoute1TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
+        myFixture.checkHighlighting(false, false, false, true);
+    }
+
+    /**
+     * Test if the annotator mark the bean call "thisIsVeryPrivate","methodDoesNotExist" as errors
+     */
+    public void testAnnotatorJavaBeanWithAbstractMethod() {
+        myFixture.configureByFiles("AnnotatorJavaBeanRoute2TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
+        myFixture.checkHighlighting(false, false, false, true);
+
+        List<HighlightInfo> list = myFixture.doHighlighting();
+
+        verifyHighlight(list, "\"letsDoThis\"", "Can not resolve method 'letsDoThis' in bean 'AnnotatorJavaBeanSuperClassTestData'", HighlightSeverity.ERROR);
+        verifyHighlight(list, "\"mySuperAbstractMethod\"", "Can not resolve method 'mySuperAbstractMethod' in bean 'AnnotatorJavaBeanSuperClassTestData'", HighlightSeverity.ERROR);
+        verifyHighlight(list, "\"thisIsVeryPrivate\"", "Can not resolve method 'thisIsVeryPrivate' in bean 'AnnotatorJavaBeanSuperClassTestData'", HighlightSeverity.ERROR);
+    }
+//  TODO: matching by parameter count / types needs to be implemented for this to work
 //
 //    /**
 //     * Test if the annotator mark the bean call "myOverLoadedBean" as errors because it's Ambiguous. This test also test if the scenario where one of the
 //     * overloaded methods is private and the other is public
 //     */
-//    @Ignore
 //    public void testAnnotatorJavaBeanAmbiguousMatch() {
 //        myFixture.configureByFiles("AnnotatorJavaBeanRoute3TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
 //        myFixture.checkHighlighting(false, false, false, true);
 //
 //        List<HighlightInfo> list = myFixture.doHighlighting();
-//        verifyHighlight(list, "(beanTestData, \"myOverLoadedBean2\")", "Cannot resolve method 'bean(testData.annotator.method.AnnotatorJavaBeanTestData, java.lang.String)'", HighlightSeverity.ERROR);
-//        verifyHighlight(list, "(beanTestData, \"myOverLoadedBean(${body})\")", "Cannot resolve method 'bean(testData.annotator.method.AnnotatorJavaBeanTestData, java.lang.String)'", HighlightSeverity.ERROR);
-//        verifyHighlight(list, "\"myOverLoadedBean\"", "Ambiguous matches 'myOverLoadedBean' in bean 'testData.annotator.method.AnnotatorJavaBeanTestData'", HighlightSeverity.ERROR);
+//        verifyHighlight(list, "\"myOverLoadedBean2\"", "Cannot resolve method 'bean(AnnotatorJavaBeanTestData, java.lang.String)'", HighlightSeverity.ERROR);
+//        verifyHighlight(list, "\"myOverLoadedBean(${body})\"", "Cannot resolve method 'bean(AnnotatorJavaBeanTestData, java.lang.String)'", HighlightSeverity.ERROR);
+//        verifyHighlight(list, "\"myOverLoadedBean\"", "Ambiguous matches 'myOverLoadedBean' in bean 'AnnotatorJavaBeanTestData'", HighlightSeverity.ERROR);
 //    }
-//
-//    /**
-//     * Test if the annotator is false and don't mark any methods even it's ambiguous, but one of the methods are marked as @Handle
-//     */
-//    @Ignore
-//    public void testAnnotatorJavaBeanWithHandlerAnnotation() {
-//        myFixture.configureByFiles("AnnotatorJavaBeanRoute4TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
-//        myFixture.checkHighlighting(false, false, false, true);
-//
-//        List<HighlightInfo> list = myFixture.doHighlighting();
-//        verifyHighlight(list, "(beanTestData, \"myOverLoadedBean3\")", "Cannot resolve method 'bean(testData.annotator.method.AnnotatorJavaBeanTestData, java.lang.String)'", HighlightSeverity.ERROR);
-//    }
+
+    /**
+     * Test if the annotator is false and don't mark any methods even it's ambiguous, but one of the methods are marked as @Handle
+     */
+    public void testAnnotatorJavaBeanWithHandlerAnnotation() {
+        myFixture.configureByFiles("AnnotatorJavaBeanRoute4TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
+        myFixture.checkHighlighting(false, false, false, true);
+
+        List<HighlightInfo> list = myFixture.doHighlighting();
+        list.stream().noneMatch(info -> info.getText().contains("myOverLoadedBean3"));
+    }
+
+//  TODO: matching by parameter count / types needs to be implemented for this to work
 //
 //    /**
 //     * Test if the calling methods is ambiguous and the Camel DSL bean calling method is with parameters
 //     */
-//    @Ignore
 //    public void testAnnotatorJavaBeanAmbiguousMatchWithParameter() {
 //        myFixture.configureByFiles("AnnotatorJavaBeanRoute5TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
 //        myFixture.checkHighlighting(false, false, false, true);
 //
 //        List<HighlightInfo> list = myFixture.doHighlighting();
-//        verifyHighlight(list, "(beanTestData, \"myOverLoadedBean(${body})\")", "Cannot resolve method 'bean(testData.annotator.method.AnnotatorJavaBeanTestData, java.lang.String)'", HighlightSeverity.ERROR);
+//        verifyHighlight(list, "\"myOverLoadedBean(${body})\"", "Cannot resolve method 'bean(AnnotatorJavaBeanTestData, java.lang.String)'", HighlightSeverity.ERROR);
 //    }
-//
-//    private void verifyHighlight(List<HighlightInfo> list, String actualText, String actualErrorDescription, HighlightSeverity actualServerity) {
-//        final Optional<HighlightInfo> error1 = list.stream().filter(highlightInfo -> highlightInfo.getText().equals(actualText)).findFirst();
-//        assertTrue(String.format("Expect to find the %s in the list of highlight", actualText), error1.isPresent());
-//        assertEquals(error1.get().getDescription(), actualErrorDescription);
-//        assertEquals(error1.get().getSeverity(), actualServerity);
-//    }
-//
-//
-//}
+
+    private void verifyHighlight(List<HighlightInfo> list, String actualText, String actualErrorDescription, HighlightSeverity actualServerity) {
+        final Optional<HighlightInfo> error1 = list.stream().filter(highlightInfo -> highlightInfo.getText().equals(actualText)).findFirst();
+        assertTrue(String.format("Expect to find the %s in the list of highlight", actualText), error1.isPresent());
+        assertEquals(error1.get().getDescription(), actualErrorDescription);
+        assertEquals(error1.get().getSeverity(), actualServerity);
+    }
+
+
+}

--- a/src/test/java/com/github/cameltooling/idea/annotator/CamelBeanMethodAnnotatorTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/annotator/CamelBeanMethodAnnotatorTestIT.java
@@ -65,21 +65,19 @@ public class CamelBeanMethodAnnotatorTestIT extends CamelLightCodeInsightFixture
         verifyHighlight(list, "\"mySuperAbstractMethod\"", "Can not resolve method 'mySuperAbstractMethod' in bean 'AnnotatorJavaBeanSuperClassTestData'", HighlightSeverity.ERROR);
         verifyHighlight(list, "\"thisIsVeryPrivate\"", "Can not resolve method 'thisIsVeryPrivate' in bean 'AnnotatorJavaBeanSuperClassTestData'", HighlightSeverity.ERROR);
     }
-//  TODO: matching by parameter count / types needs to be implemented for this to work
-//
-//    /**
-//     * Test if the annotator mark the bean call "myOverLoadedBean" as errors because it's Ambiguous. This test also test if the scenario where one of the
-//     * overloaded methods is private and the other is public
-//     */
-//    public void testAnnotatorJavaBeanAmbiguousMatch() {
-//        myFixture.configureByFiles("AnnotatorJavaBeanRoute3TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
-//        myFixture.checkHighlighting(false, false, false, true);
-//
-//        List<HighlightInfo> list = myFixture.doHighlighting();
-//        verifyHighlight(list, "\"myOverLoadedBean2\"", "Cannot resolve method 'bean(AnnotatorJavaBeanTestData, java.lang.String)'", HighlightSeverity.ERROR);
-//        verifyHighlight(list, "\"myOverLoadedBean(${body})\"", "Cannot resolve method 'bean(AnnotatorJavaBeanTestData, java.lang.String)'", HighlightSeverity.ERROR);
-//        verifyHighlight(list, "\"myOverLoadedBean\"", "Ambiguous matches 'myOverLoadedBean' in bean 'AnnotatorJavaBeanTestData'", HighlightSeverity.ERROR);
-//    }
+
+    /**
+     * Test if the annotator mark the bean call "myOverLoadedBean" as errors because it's Ambiguous.
+     * This test also test if the scenario where one of the overloaded methods is private and the other is public - the public
+     * method should be chosen and there should be no ambiguity.
+     */
+    public void testAnnotatorJavaBeanAmbiguousMatch() {
+        myFixture.configureByFiles("AnnotatorJavaBeanRoute3TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
+        myFixture.checkHighlighting(false, false, false, true);
+
+        List<HighlightInfo> list = myFixture.doHighlighting();
+        verifyHighlight(list, "\"myOverLoadedBean\"", "Ambiguous matches 'myOverLoadedBean' in bean 'AnnotatorJavaBeanTestData'", HighlightSeverity.ERROR);
+    }
 
     /**
      * Test if the annotator is false and don't mark any methods even it's ambiguous, but one of the methods are marked as @Handle
@@ -92,23 +90,23 @@ public class CamelBeanMethodAnnotatorTestIT extends CamelLightCodeInsightFixture
         list.stream().noneMatch(info -> info.getText().contains("myOverLoadedBean3"));
     }
 
-//  TODO: matching by parameter count / types needs to be implemented for this to work
-//
-//    /**
-//     * Test if the calling methods is ambiguous and the Camel DSL bean calling method is with parameters
-//     */
-//    public void testAnnotatorJavaBeanAmbiguousMatchWithParameter() {
-//        myFixture.configureByFiles("AnnotatorJavaBeanRoute5TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
-//        myFixture.checkHighlighting(false, false, false, true);
-//
-//        List<HighlightInfo> list = myFixture.doHighlighting();
-//        verifyHighlight(list, "\"myOverLoadedBean(${body})\"", "Cannot resolve method 'bean(AnnotatorJavaBeanTestData, java.lang.String)'", HighlightSeverity.ERROR);
-//    }
+    /**
+     * Test if the calling methods is ambiguous and the Camel DSL bean calling method is with parameters
+     */
+    public void testAnnotatorJavaBeanAmbiguousMatchWithParameter() {
+        myFixture.configureByFiles("AnnotatorJavaBeanRoute5TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
+        myFixture.checkHighlighting(false, false, false, true);
+    }
 
-    private void verifyHighlight(List<HighlightInfo> list, String actualText, String actualErrorDescription, HighlightSeverity actualServerity) {
-        final Optional<HighlightInfo> error1 = list.stream().filter(highlightInfo -> highlightInfo.getText().equals(actualText)).findFirst();
-        assertTrue(String.format("Expect to find the %s in the list of highlight", actualText), error1.isPresent());
-        assertEquals(error1.get().getDescription(), actualErrorDescription);
+    public void testAnnotatorJavaBeanWithTypeParameters() {
+        myFixture.configureByFiles("AnnotatorJavaBeanRoute6TestData.java", "AnnotatorJavaBeanTestData.java", "AnnotatorJavaBeanSuperClassTestData.java");
+        myFixture.checkHighlighting(false, false, false, true);
+    }
+
+    private void verifyHighlight(List<HighlightInfo> list, String expectedText, String expectedDescription, HighlightSeverity actualServerity) {
+        final Optional<HighlightInfo> error1 = list.stream().filter(highlightInfo -> highlightInfo.getText().equals(expectedText)).findFirst();
+        assertTrue(String.format("Expect to find the %s in the list of highlight", expectedText), error1.isPresent());
+        assertEquals(expectedDescription, error1.get().getDescription());
         assertEquals(error1.get().getSeverity(), actualServerity);
     }
 

--- a/src/test/java/com/github/cameltooling/idea/annotator/CamelJSonPathAnnotatorTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/annotator/CamelJSonPathAnnotatorTestIT.java
@@ -1,122 +1,122 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *      http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package com.github.cameltooling.idea.annotator;
-//
-//import java.io.File;
-//import java.io.IOException;
-//
-//import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
-//import com.github.cameltooling.idea.service.CamelCatalogService;
-//import com.github.cameltooling.idea.service.CamelService;
-//import com.intellij.openapi.application.ApplicationManager;
-//import com.intellij.openapi.roots.ModuleRootModificationUtil;
-//import com.intellij.openapi.roots.OrderRootType;
-//import com.intellij.openapi.roots.libraries.Library;
-//import com.intellij.openapi.roots.libraries.LibraryTable;
-//import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
-//import com.intellij.openapi.vfs.LocalFileSystem;
-//import com.intellij.openapi.vfs.VirtualFile;
-//import org.jboss.shrinkwrap.resolver.api.maven.Maven;
-//
-///**
-// * Test Camel jsonpath validation and the expected value is highlighted
-// *
-// * @see CamelSimpleAnnotatorTestIT
-// */
-//public class CamelJSonPathAnnotatorTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
-//
-//    public static final String CAMEL_JSONPATH_MAVEN_ARTIFACT = "org.apache.camel:camel-jsonpath:2.22.0";
-//
-//    public CamelJSonPathAnnotatorTestIT() {
-//        setIgnoreCamelCoreLib(true);
-//    }
-//
-//    @Override
-//    protected void setUp() throws Exception {
-//        super.setUp();
-//        File[] mavenArtifacts = getMavenArtifacts(CAMEL_JSONPATH_MAVEN_ARTIFACT);
-//        for (File file : mavenArtifacts) {
-//            final VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
-//            final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(getModule().getProject());
-//            ApplicationManager.getApplication().runWriteAction(() -> {
-//                String name = file.getName();
-//                // special for camel JARs
-//                if (name.contains("camel-core")) {
-//                    name = "org.apache.camel:camel-core:2.22.0";
-//                } else if (name.contains("camel-jsonpath")) {
-//                    name = "org.apache.camel:camel-jsonpath:2.22.0";
-//                } else {
-//                    // need to fix the name
-//                    if (name.endsWith(".jar")) {
-//                        name = name.substring(0, name.length() - 4);
-//                    }
-//                    int lastDash = name.lastIndexOf('-');
-//                    name = name.substring(0, lastDash) + ":" + name.substring(lastDash + 1);
-//                    // add bogus groupid
-//                    name = "com.foo:" + name;
-//                }
-//
-//                Library library = projectLibraryTable.createLibrary("maven: " + name);
-//                final Library.ModifiableModel libraryModifiableModel = library.getModifiableModel();
-//                libraryModifiableModel.addRoot(virtualFile, OrderRootType.CLASSES);
-//                libraryModifiableModel.commit();
-//                ModuleRootModificationUtil.addDependency(getModule(), library);
-//            });
-//        }
-//
-//        disposeOnTearDown(getModule().getProject().getService(CamelCatalogService.class));
-//        disposeOnTearDown(getModule().getProject().getService(CamelService.class));
-//        getModule().getProject().getProject(CamelService.class).setCamelPresent(true);
-//    }
-//
-//    @Override
-//    protected void tearDown() throws Exception {
-//        try {
-//            super.tearDown();
-//        } catch (Throwable e) {
-//            // ignore
-//        }
-//    }
-//
-//    protected static File[] getMavenArtifacts(String... mavenAritfiact) throws IOException {
-//        File[] libs = Maven.resolver().resolve(mavenAritfiact).withTransitivity().asFile();
-//        return libs;
-//    }
-//
-//    @Override
-//    protected String getTestDataPath() {
-//        return "src/test/resources/testData/annotator";
-//    }
-//
-//    @Ignore
-//    public void testAnnotatorJSonPathValidation() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaWithJSonPath());
-//        myFixture.checkHighlighting(false, false, true, true);
-//    }
-//
-//    private String getJavaWithJSonPath() {
-//        return "import org.apache.camel.builder.RouteBuilder;\n"
-//            + "public class MyRouteBuilder extends RouteBuilder {\n"
-//            + "        public void configure() throws Exception {\n"
-//            + "            from(\"direct:start\")\n"
-//            + "            .transform()\n"
-//            + "            .jsonpath(<error descr=\"Illegal syntax: $.store.book[* xxxxxxx]\">\"$.store.book[* xxxxxxx]\"</error>);"
-//            + "        }\n"
-//            + "    }";
-//    }
-//
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.annotator;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.github.cameltooling.idea.service.CamelCatalogService;
+import com.github.cameltooling.idea.service.CamelService;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.libraries.Library;
+import com.intellij.openapi.roots.libraries.LibraryTable;
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+/**
+ * Test Camel jsonpath validation and the expected value is highlighted
+ *
+ * @see CamelSimpleAnnotatorTestIT
+ */
+public class CamelJSonPathAnnotatorTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    public static final String CAMEL_JSONPATH_MAVEN_ARTIFACT = "org.apache.camel:camel-jsonpath:2.22.0";
+
+    public CamelJSonPathAnnotatorTestIT() {
+        setIgnoreCamelCoreLib(true);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        File[] mavenArtifacts = getMavenArtifacts(CAMEL_JSONPATH_MAVEN_ARTIFACT);
+        for (File file : mavenArtifacts) {
+            final VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
+            final LibraryTable projectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(getModule().getProject());
+            ApplicationManager.getApplication().runWriteAction(() -> {
+                String name = file.getName();
+                // special for camel JARs
+                if (name.contains("camel-core")) {
+                    name = "org.apache.camel:camel-core:2.22.0";
+                } else if (name.contains("camel-jsonpath")) {
+                    name = "org.apache.camel:camel-jsonpath:2.22.0";
+                } else {
+                    // need to fix the name
+                    if (name.endsWith(".jar")) {
+                        name = name.substring(0, name.length() - 4);
+                    }
+                    int lastDash = name.lastIndexOf('-');
+                    name = name.substring(0, lastDash) + ":" + name.substring(lastDash + 1);
+                    // add bogus groupid
+                    name = "com.foo:" + name;
+                }
+
+                Library library = projectLibraryTable.createLibrary("maven: " + name);
+                final Library.ModifiableModel libraryModifiableModel = library.getModifiableModel();
+                libraryModifiableModel.addRoot(virtualFile, OrderRootType.CLASSES);
+                libraryModifiableModel.commit();
+                ModuleRootModificationUtil.addDependency(getModule(), library);
+            });
+        }
+
+        disposeOnTearDown(getModule().getProject().getService(CamelCatalogService.class));
+        disposeOnTearDown(getModule().getProject().getService(CamelService.class));
+        getModule().getProject().getService(CamelService.class).setCamelPresent(true);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            super.tearDown();
+        } catch (Throwable e) {
+            // ignore
+        }
+    }
+
+    protected static File[] getMavenArtifacts(String... mavenAritfiact) throws IOException {
+        File[] libs = Maven.resolver().resolve(mavenAritfiact).withTransitivity().asFile();
+        return libs;
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources/testData/annotator";
+    }
+
+    public void testAnnotatorJSonPathValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaWithJSonPath());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
+
+    private String getJavaWithJSonPath() {
+        return """
+                import org.apache.camel.builder.RouteBuilder;
+                public class MyRouteBuilder extends RouteBuilder {
+                        public void configure() throws Exception {
+                            from("direct:start")
+                            .transform()
+                            .jsonpath(<error descr="Expected wildcard token to end with ']' on position 14">"$.store.book[* xxxxxxx]"</error>);\
+                        }
+                    }""";
+    }
+
+}

--- a/src/test/java/com/github/cameltooling/idea/annotator/CamelSimpleAnnotatorTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/annotator/CamelSimpleAnnotatorTestIT.java
@@ -42,11 +42,10 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
         return "src/test/resources/testData/annotator";
     }
 
-//    @Ignore
-//    public void testAnnotatorSimpleValidation() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaWithSimple());
-//        myFixture.checkHighlighting(false, false, true, true);
-//    }
+    public void testAnnotatorSimpleValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaWithSimple());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
 
     public void testAnnotatorLogValidation() {
         myFixture.configureByText("AnnotatorTestData.java", getJavaWithLog());
@@ -58,17 +57,15 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
         myFixture.checkHighlighting(false, false, true, true);
     }
 
-//    @Ignore
-//    public void testAnnotatorOpenBracketSimpleValidation() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaOpenBracketWithSimple());
-//        myFixture.checkHighlighting(false, false, true, true);
-//    }
+    public void testAnnotatorOpenBracketSimpleValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaOpenBracketWithSimple());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
 
-//    @Ignore
-//    public void testAnnotatorMultipleOpenBracketSimpleValidation() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaMutlipleOpenBracketWithSimple());
-//        myFixture.checkHighlighting(false, false, true, true);
-//    }
+    public void testAnnotatorMultipleOpenBracketSimpleValidation() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaMutlipleOpenBracketWithSimple());
+        myFixture.checkHighlighting(false, false, true, true);
+    }
 
     public void testAnnotatorCamelPredicateValidation() {
         myFixture.configureByText("AnnotatorTestData.java", getJavaWithCamelPredicate());
@@ -80,11 +77,10 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
         myFixture.checkHighlighting(false, false, false, true);
     }
 
-//    @Ignore
-//    public void testAnnotatorCamelPredicateValidation2() {
-//        myFixture.configureByText("AnnotatorTestData.java", getJavaWithCamelPredicate2());
-//        myFixture.checkHighlighting(false, false, false, true);
-//    }
+    public void testAnnotatorCamelPredicateValidation2() {
+        myFixture.configureByText("AnnotatorTestData.java", getJavaWithCamelPredicate2());
+        myFixture.checkHighlighting(false, false, false, true);
+    }
 
     public void testXmlAnnotatorSimpleValidation2() {
         myFixture.configureByText("AnnotatorTestData.xml", getXmlWithSimple());
@@ -98,7 +94,6 @@ public class CamelSimpleAnnotatorTestIT extends CamelLightCodeInsightFixtureTest
 //         myFixture.checkHighlighting(false, false, false, true);
 //    }
 
-//    @Ignore
     public void testXmlAnnotatorWithLogValidation() {
         myFixture.configureByText("AnnotatorTestData.xml", getXmlWithLog());
         myFixture.checkHighlighting(false, false, false, true);

--- a/src/test/java/com/github/cameltooling/idea/completion/CustomKameletEndpointSmartCompletionTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/completion/CustomKameletEndpointSmartCompletionTestIT.java
@@ -33,8 +33,7 @@ import static com.github.cameltooling.idea.completion.JavaEndpointSmartCompletio
 public class CustomKameletEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
     @Override
-    protected void loadDependencies(@NotNull ModifiableRootModel model) {
-        super.loadDependencies(model);
+    protected void loadCustomDependencies(@NotNull ModifiableRootModel model) {
         File rootFolder = new File("src/test/resources/testData/kamelet/kamelets-with-jar-catalog/");
         PsiTestUtil.addLibrary(model, "com.foo:custom-kamelets:1.0", rootFolder.getPath(), "custom-kamelets.jar");
         PsiTestUtil.addLibrary(model, "org.apache.camel.kamelets:camel-kamelets:0-SNAPSHOT", rootFolder.getPath(), "specific-camel-kamelets.jar");

--- a/src/test/java/com/github/cameltooling/idea/completion/FullCustomKameletEndpointSmartCompletionTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/completion/FullCustomKameletEndpointSmartCompletionTestIT.java
@@ -37,8 +37,7 @@ import static com.github.cameltooling.idea.completion.JavaEndpointSmartCompletio
 public class FullCustomKameletEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
     @Override
-    protected void loadDependencies(@NotNull ModifiableRootModel model) {
-        super.loadDependencies(model);
+    protected void loadCustomDependencies(@NotNull ModifiableRootModel model) {
         File rootFolder = new File("src/test/resources/testData/kamelet/kamelets-with-jar-catalog-resources/");
         PsiTestUtil.addLibrary(model, "com.foo:custom-kamelets:1.0", rootFolder.getPath(), "lib/custom-kamelets.jar");
         PsiTestUtil.addLibrary(model, "org.apache.camel.kamelets:camel-kamelets:0-SNAPSHOT", rootFolder.getPath(), "lib/specific-camel-kamelets.jar");

--- a/src/test/java/com/github/cameltooling/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/completion/JavaCamelBeanReferenceSmartCompletionTestIT.java
@@ -120,7 +120,7 @@ public class JavaCamelBeanReferenceSmartCompletionTestIT extends CamelLightCodeI
     @Nullable
     @Override
     protected String[] getMavenDependencies() {
-        return new String[]{SPRING_CONTEXT_MAVEN_ARTIFACT};
+        return new String[]{SPRING_CONTEXT_MAVEN_ARTIFACT, CAMEL_CORE_MODEL_MAVEN_ARTIFACT};
     }
 
     public void testJavaBeanTestDataCompletionWithIncorrectBeanRef() {
@@ -160,39 +160,38 @@ public class JavaCamelBeanReferenceSmartCompletionTestIT extends CamelLightCodeI
         assertThat(strings, Matchers.not(Matchers.contains("thisIsVeryPrivate")));
     }
 
-// Should be fixed by https://github.com/camel-tooling/camel-idea-plugin/issues/1047
-//    public void testJavaBeanTestDataCompletionWithCaretInsideMultipleMethodRef() {
-//        myFixture.configureByFiles("CompleteJavaBeanRoute5TestData.java", "CompleteJavaBeanMultipleMethodTestData.java",
-//            "CompleteJavaBeanSuperClassTestData.java", "CompleteJavaBeanMethodPropertyTestData.properties");
-//        myFixture.complete(CompletionType.BASIC, 1);
-//        List<String> strings = myFixture.getLookupElementStrings();
-//        assertEquals(3, strings.size());
-//        assertThat(strings, Matchers.hasItems("multipleMethodsWithAnotherName", "multipleMethodsWithSameName", "multipleMethodsWithSameName"));
-//    }
-//
-//    public void testJavaBeanWithClassHierarchy() {
-//        myFixture.configureByFiles("CompleteJavaBeanRouteTestData.java", "CompleteJavaBeanTestData.java", "CompleteJavaBeanSuperClassTestData.java");
-//        myFixture.complete(CompletionType.BASIC, 1);
-//        List<String> strings = myFixture.getLookupElementStrings();
-//        assertThat(strings, Matchers.not(Matchers.contains("thisIsVeryPrivate")));
-//        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod", "mySuperMethod", "myOverLoadedBean", "myOverLoadedBean"));
-//        assertEquals("There is many options", 6, strings.size());
-//    }
-//
-//    public void testJavaBeanTestDataCompletion2File() {
-//        myFixture.configureByFiles("CompleteJavaBeanRoute2TestData.java", "CompleteJavaBeanTestData.java", "CompleteJavaBeanSuperClassTestData.java");
-//        myFixture.complete(CompletionType.BASIC, 1);
-//        myFixture.checkResultByFile("CompleteJavaBeanRoute2ResultData.java", true);
-//    }
-//
-//    public void testJavaFieldBeanReference() {
-//        myFixture.configureByFiles("CompleteJavaBeanRoute1TestData.java", "CompleteJavaBeanTestData.java");
-//        myFixture.complete(CompletionType.BASIC, 1);
-//        List<String> strings = myFixture.getLookupElementStrings();
-//        assertThat(strings, Matchers.not(Matchers.contains("thisIsVeryPrivate")));
-//        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod", "myOverLoadedBean", "myOverLoadedBean"));
-//        assertEquals("There is many options", 5, strings.size());
-//    }
+    public void testJavaBeanTestDataCompletionWithCaretInsideMultipleMethodRef() {
+        myFixture.configureByFiles("CompleteJavaBeanRoute5TestData.java", "CompleteJavaBeanMultipleMethodTestData.java",
+            "CompleteJavaBeanSuperClassTestData.java", "CompleteJavaBeanMethodPropertyTestData.properties");
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertEquals(3, strings.size());
+        assertThat(strings, Matchers.hasItems("multipleMethodsWithAnotherName", "multipleMethodsWithSameName", "multipleMethodsWithSameName"));
+    }
+
+    public void testJavaBeanWithClassHierarchy() {
+        myFixture.configureByFiles("CompleteJavaBeanRouteTestData.java", "CompleteJavaBeanTestData.java", "CompleteJavaBeanSuperClassTestData.java");
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertThat(strings, Matchers.not(Matchers.contains("thisIsVeryPrivate")));
+        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod", "mySuperMethod", "myOverLoadedBean", "myOverLoadedBean"));
+        assertEquals("There is many options", 6, strings.size());
+    }
+
+    public void testJavaBeanTestDataCompletion2File() {
+        myFixture.configureByFiles("CompleteJavaBeanRoute2TestData.java", "CompleteJavaBeanTestData.java", "CompleteJavaBeanSuperClassTestData.java");
+        myFixture.complete(CompletionType.BASIC, 1);
+        myFixture.checkResultByFile("CompleteJavaBeanRoute2ResultData.java", true);
+    }
+
+    public void testJavaFieldBeanReference() {
+        myFixture.configureByFiles("CompleteJavaBeanRoute1TestData.java", "CompleteJavaBeanTestData.java");
+        myFixture.complete(CompletionType.BASIC, 1);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertThat(strings, Matchers.not(Matchers.contains("thisIsVeryPrivate")));
+        assertThat(strings, Matchers.hasItems("letsDoThis", "anotherBeanMethod", "mySuperAbstractMethod", "myOverLoadedBean", "myOverLoadedBean"));
+        assertEquals("There is many options", 5, strings.size());
+    }
 
     public void testJavaFieldBeanWithNoReference() {
         myFixture.configureByFiles("CompleteJavaBeanRoute5TestData.java", "CompleteJavaBeanTestData.java");

--- a/src/test/java/com/github/cameltooling/idea/completion/ProjectKameletEndpointSmartCompletionTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/completion/ProjectKameletEndpointSmartCompletionTestIT.java
@@ -32,8 +32,7 @@ import static com.github.cameltooling.idea.completion.JavaEndpointSmartCompletio
 public class ProjectKameletEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
     @Override
-    protected void loadDependencies(@NotNull ModifiableRootModel model) {
-        super.loadDependencies(model);
+    protected void loadCustomDependencies(@NotNull ModifiableRootModel model) {
         File rootFolder = new File("src/test/resources/testData/kamelet/kamelets-with-jar/");
         PsiTestUtil.addLibrary(model, "com.foo:custom-kamelets:1.0", rootFolder.getPath(), "custom-kamelets.jar");
     }

--- a/src/test/java/com/github/cameltooling/idea/completion/PropertyValueCompletionTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/completion/PropertyValueCompletionTestIT.java
@@ -315,47 +315,47 @@ public class PropertyValueCompletionTestIT extends CamelLightCodeInsightFixtureT
         assertContainsElements(strings, "false");
         assertDoesntContain(strings,  "true");
     }
-// Should be fixed by https://github.com/camel-tooling/camel-idea-plugin/issues/975
-//    /**
-//     * Ensures that no suggestions are provided when the first key is unknown.
-//     */
-//    public void testNoSuggestionOnUnknownFirstKey() {
-//        for (FileType type : FileType.values()) {
-//            testNoSuggestionOnUnknownFirstKey(type);
-//        }
-//    }
-//
-//    private void testNoSuggestionOnUnknownFirstKey(FileType type) {
-//        myFixture.configureByFiles(getFileName(type, "value-unknown-first-key"));
-//        myFixture.completeBasic();
-//        List<String> strings = myFixture.getLookupElementStrings();
-//        assertNullOrEmpty(strings);
-//    }
-//
-//    /**
-//     * Ensures that no suggestions are provided when the second key is unknown.
-//     */
-//    public void testNoSuggestionOnUnknownSecondKey() {
-//        for (FileType type : FileType.values()) {
-//            testNoSuggestionOnUnknownSecondKey(type);
-//        }
-//    }
-//
-//    private void testNoSuggestionOnUnknownSecondKey(FileType type) {
-//        myFixture.configureByFiles(getFileName(type, "value-unknown-second-key"));
-//        myFixture.completeBasic();
-//        List<String> strings = myFixture.getLookupElementStrings();
-//        assertNullOrEmpty(strings);
-//    }
-//
-//    /**
-//     * Ensures that no suggestions are provided when the component is unknown.
-//     */
-//    public void testNoSuggestionOnUnknownComponent() {
-//        for (FileType type : FileType.values()) {
-//            testNoSuggestionOnUnknownComponent(type);
-//        }
-//    }
+
+    /**
+     * Ensures that no suggestions are provided when the first key is unknown.
+     */
+    public void testNoSuggestionOnUnknownFirstKey() {
+        for (FileType type : FileType.values()) {
+            testNoSuggestionOnUnknownFirstKey(type);
+        }
+    }
+
+    private void testNoSuggestionOnUnknownFirstKey(FileType type) {
+        myFixture.configureByFiles(getFileName(type, "value-unknown-first-key"));
+        myFixture.completeBasic();
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNullOrEmpty(strings);
+    }
+
+    /**
+     * Ensures that no suggestions are provided when the second key is unknown.
+     */
+    public void testNoSuggestionOnUnknownSecondKey() {
+        for (FileType type : FileType.values()) {
+            testNoSuggestionOnUnknownSecondKey(type);
+        }
+    }
+
+    private void testNoSuggestionOnUnknownSecondKey(FileType type) {
+        myFixture.configureByFiles(getFileName(type, "value-unknown-second-key"));
+        myFixture.completeBasic();
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNullOrEmpty(strings);
+    }
+
+    /**
+     * Ensures that no suggestions are provided when the component is unknown.
+     */
+    public void testNoSuggestionOnUnknownComponent() {
+        for (FileType type : FileType.values()) {
+            testNoSuggestionOnUnknownComponent(type);
+        }
+    }
 
     private void testNoSuggestionOnUnknownComponent(FileType type) {
         myFixture.configureByFiles(getFileName(type, "value-unknown-component"));

--- a/src/test/java/com/github/cameltooling/idea/completion/SimpleProjectKameletEndpointSmartCompletionTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/completion/SimpleProjectKameletEndpointSmartCompletionTestIT.java
@@ -32,8 +32,7 @@ import static com.github.cameltooling.idea.completion.JavaEndpointSmartCompletio
 public class SimpleProjectKameletEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
     @Override
-    protected void loadDependencies(@NotNull ModifiableRootModel model) {
-        super.loadDependencies(model);
+    protected void loadCustomDependencies(@NotNull ModifiableRootModel model) {
         File artifact = new File("src/test/resources/testData/kamelet/kamelets-with-custom-jar/custom-kamelets.jar");
         PsiTestUtil.addLibrary(model, "foo/custom-kamelets.jar", artifact.getParent(), artifact.getName());
     }

--- a/src/test/java/com/github/cameltooling/idea/completion/SpecificVersionKameletEndpointSmartCompletionTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/completion/SpecificVersionKameletEndpointSmartCompletionTestIT.java
@@ -32,8 +32,7 @@ import static com.github.cameltooling.idea.completion.JavaEndpointSmartCompletio
 public class SpecificVersionKameletEndpointSmartCompletionTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
     @Override
-    protected void loadDependencies(@NotNull ModifiableRootModel model) {
-        super.loadDependencies(model);
+    protected void loadCustomDependencies(@NotNull ModifiableRootModel model) {
         File artifact = new File("src/test/resources/testData/kamelet/kamelets-with-catalog/specific-camel-kamelets.jar");
         PsiTestUtil.addLibrary(model, "org.apache.camel.kamelets:camel-kamelets:0-SNAPSHOT", artifact.getParent(), artifact.getName());
     }

--- a/src/test/java/com/github/cameltooling/idea/completion/extension/BeanReferenceCompletionExtensionIT.java
+++ b/src/test/java/com/github/cameltooling/idea/completion/extension/BeanReferenceCompletionExtensionIT.java
@@ -21,11 +21,17 @@ import java.util.List;
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.codeInsight.completion.CompletionType;
 import org.intellij.lang.annotations.Language;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Testing bean reference completion in blueprint files
  */
 public class BeanReferenceCompletionExtensionIT extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    @Override
+    protected @Nullable String[] getMavenDependencies() {
+        return new String[] {CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_API_MAVEN_ARTIFACT};
+    }
 
     @Override
     protected String getTestDataPath() {
@@ -86,15 +92,14 @@ public class BeanReferenceCompletionExtensionIT extends CamelLightCodeInsightFix
         "  </camelContext>" +
         "</blueprint>";
 
-//    @Ignore
-//    public void testBeanInjectValue() {
-//        myFixture.configureByFiles("TestClass1.java", "TestClass2.java", "TestClass3.java", "beans.xml");
-//        myFixture.complete(CompletionType.BASIC);
-//        List<String> strings = myFixture.getLookupElementStrings();
-//        assertNotNull(strings);
-//        assertEquals(2, strings.size());
-//        assertContainsElements(strings, "testClass2Bean", "testClass2Bean2");
-//    }
+    public void testBeanInjectValue() {
+        myFixture.configureByFiles("TestClass1.java", "TestClass2.java", "TestClass3.java", "beans.xml");
+        myFixture.complete(CompletionType.BASIC);
+        List<String> strings = myFixture.getLookupElementStrings();
+        assertNotNull(strings);
+        assertEquals(2, strings.size());
+        assertContainsElements(strings, "testClass2Bean", "testClass2Bean2");
+    }
 
     public void testPropertyReference() {
         List<String> strings = doTestCompletionAtCaret(PROPERTY_REFERENCE);

--- a/src/test/java/com/github/cameltooling/idea/formatter/CamelPostFormatProcessorIT.java
+++ b/src/test/java/com/github/cameltooling/idea/formatter/CamelPostFormatProcessorIT.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.codeStyle.CodeStyleManager;
+import com.intellij.testFramework.DumbModeTestUtils;
 import com.intellij.testFramework.PlatformTestUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -92,6 +93,15 @@ public class CamelPostFormatProcessorIT extends CamelLightCodeInsightFixtureTest
      */
     public void testPartialFormatWithRoute() {
         doTest("PartialFormatWithRoute", new TextRange(1400, 1757));
+    }
+
+    public void testRunningInDumbMode() {
+        myFixture.configureByFile("before/RouteWithDataFormatDSL.java");
+        DumbModeTestUtils.computeInDumbModeSynchronously(getProject(), () -> {
+            performReformatting(null);
+            return null;
+        });
+        myFixture.checkResultByFile("before/RouteWithDataFormatDSL.java");
     }
 
     @Nullable

--- a/src/test/java/com/github/cameltooling/idea/gutter/BeanInjectLineMarkerProviderTest.java
+++ b/src/test/java/com/github/cameltooling/idea/gutter/BeanInjectLineMarkerProviderTest.java
@@ -29,9 +29,16 @@ import com.intellij.navigation.GotoRelatedItem;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 
 public class BeanInjectLineMarkerProviderTest extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    @Nullable
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_API_MAVEN_ARTIFACT};
+    }
 
     @Override
     protected String getTestDataPath() {
@@ -44,18 +51,17 @@ public class BeanInjectLineMarkerProviderTest extends CamelLightCodeInsightFixtu
         assertEmpty(beanInjectMarkers);
     }
 
-//    @Ignore TODO:!
-//    public void testBeanInjectGutter() {
-//        myFixture.configureByFiles("TestClass1.java", "TestClass2.java", "TestClass3.java", "beans.xml");
-//
-//        List<RelatedItemLineMarkerInfo<? extends PsiElement>> beanInjectMarkers = findBeanInjectMarkers();
-//        assertEquals(4, beanInjectMarkers.size());
-//
-//        validateBeanInjectWithValue(beanInjectMarkers.get(0));
-//        validateBeanInjectWithMultipleTargets(beanInjectMarkers.get(1));
-//        validateBeanInjectWithMultipleTargets(beanInjectMarkers.get(2));
-//        assertEquals(0, beanInjectMarkers.get(3).createGotoRelatedItems().size());
-//    }
+    public void testBeanInjectGutter() {
+        myFixture.configureByFiles("TestClass1.java", "TestClass2.java", "TestClass3.java", "beans.xml");
+
+        List<RelatedItemLineMarkerInfo<? extends PsiElement>> beanInjectMarkers = findBeanInjectMarkers();
+        assertEquals(4, beanInjectMarkers.size());
+
+        validateBeanInjectWithValue(beanInjectMarkers.get(0));
+        validateBeanInjectWithMultipleTargets(beanInjectMarkers.get(1));
+        validateBeanInjectWithMultipleTargets(beanInjectMarkers.get(2));
+        assertEquals(0, beanInjectMarkers.get(3).createGotoRelatedItems().size());
+    }
 
     @NotNull
     private List<RelatedItemLineMarkerInfo<? extends PsiElement>> findBeanInjectMarkers() {

--- a/src/test/java/com/github/cameltooling/idea/gutter/BeanInjectLineMarkerProviderTest.java
+++ b/src/test/java/com/github/cameltooling/idea/gutter/BeanInjectLineMarkerProviderTest.java
@@ -44,7 +44,7 @@ public class BeanInjectLineMarkerProviderTest extends CamelLightCodeInsightFixtu
         assertEmpty(beanInjectMarkers);
     }
 
-//    @Ignore
+//    @Ignore TODO:!
 //    public void testBeanInjectGutter() {
 //        myFixture.configureByFiles("TestClass1.java", "TestClass2.java", "TestClass3.java", "beans.xml");
 //

--- a/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectJavaJSonPathTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectJavaJSonPathTestIT.java
@@ -16,7 +16,6 @@
  */
 package com.github.cameltooling.idea.inspection;
 
-/*
 import com.intellij.codeInspection.ex.LocalInspectionToolWrapper;
 import com.intellij.testFramework.PsiTestUtil;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
@@ -42,4 +41,3 @@ public class CamelInspectJavaJSonPathTestIT extends CamelInspectionTestHelper {
         doTest("testData/barroute/", new LocalInspectionToolWrapper(inspection));
     }
 }
-*/

--- a/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectionTestHelper.java
+++ b/src/test/java/com/github/cameltooling/idea/inspection/CamelInspectionTestHelper.java
@@ -4,6 +4,7 @@ package com.github.cameltooling.idea.inspection;
 
 import java.io.File;
 
+import com.github.cameltooling.idea.CamelTestDependencyUtil;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ContentEntry;
@@ -40,7 +41,7 @@ public abstract class CamelInspectionTestHelper extends JavaInspectionTestCase {
 
             @Override
             public void configureModule(@NotNull Module module, @NotNull ModifiableRootModel model, @NotNull ContentEntry contentEntry) {
-                loadDependencies(model);
+                CamelTestDependencyUtil.loadDependencies(model, getMavenDependencies());
                 model.getModuleExtension( LanguageLevelModuleExtension.class ).setLanguageLevel( LanguageLevel.JDK_11 );
             }
         };
@@ -53,36 +54,6 @@ public abstract class CamelInspectionTestHelper extends JavaInspectionTestCase {
     @Nullable
     protected String[] getMavenDependencies() {
         return null;
-    }
-
-    /**
-     * Loads the maven dependencies into the given model.
-     * @param model the model into which the dependencies are added.
-     */
-    protected void loadDependencies(@NotNull ModifiableRootModel model) {
-        String[] dependencies = getMavenDependencies();
-        if (dependencies != null && dependencies.length > 0) {
-            File[] artifacts = getMavenArtifacts(dependencies);
-            for (int i = 0; i < artifacts.length; i++) {
-                File artifact = artifacts[i];
-                PsiTestUtil.addLibrary(model, dependencies[i], artifact.getParent(), artifact.getName());
-            }
-        }
-    }
-
-    /**
-     * Get a list of artifact declared as dependencies in the pom.xml file.
-     * <p>
-     *   The method take a String arrays off "G:A:P:C:?" "org.apache.camel:camel-core:2.22.0"
-     * </p>
-     * @param mavenArtifact - Array of maven artifact to resolve
-     * @return Array of artifact files
-     */
-    protected static File[] getMavenArtifacts(String... mavenArtifact) {
-        return Maven.configureResolver()
-            .withRemoteRepo("snapshot", "https://repository.apache.org/snapshots/", "default")
-            .resolve(mavenArtifact)
-            .withoutTransitivity().asFile();
     }
 
     @Override

--- a/src/test/java/com/github/cameltooling/idea/reference/CamelBeanMethodReferenceTest.java
+++ b/src/test/java/com/github/cameltooling/idea/reference/CamelBeanMethodReferenceTest.java
@@ -18,8 +18,18 @@ package com.github.cameltooling.idea.reference;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLiteralExpression;
 import com.intellij.psi.PsiPolyVariantReference;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.usageView.UsageInfo;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 
 /**
  * Test method reference link between the Java Camel DSL bean reference method @{code bean(MyClass.class,"myMethodName")}
@@ -30,7 +40,7 @@ public class CamelBeanMethodReferenceTest extends CamelLightCodeInsightFixtureTe
     @Nullable
     @Override
     protected String[] getMavenDependencies() {
-        return new String[]{SPRING_CONTEXT_MAVEN_ARTIFACT};
+        return new String[]{SPRING_CONTEXT_MAVEN_ARTIFACT, CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_API_MAVEN_ARTIFACT};
     }
 
     @Override
@@ -38,25 +48,28 @@ public class CamelBeanMethodReferenceTest extends CamelLightCodeInsightFixtureTe
         return "src/test/resources/testData/completion/method";
     }
 
-//    @Ignore
-//    public void testCamelMethodReference() {
-//        myFixture.configureByFiles("CompleteJavaBeanRoute3TestData.java", "CompleteJavaBeanTestData.java",
-//            "CompleteJavaBeanSuperClassTestData.java", "CompleteJavaBeanMethodPropertyTestData.properties");
-//        PsiElement element = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
-//        final ResolveResult[] resolveResults = ((CamelBeanMethodReference) element.getReferences()[0]).multiResolve(false);
-//        assertEquals(1, resolveResults.length);
-//        assertEquals("public void letsDoThis() {}",  resolveResults[0].getElement().getText());
-//    }
+    public void testCamelMethodReference() {
+        myFixture.configureByFiles("CompleteJavaBeanRoute3TestData.java", "CompleteJavaBeanTestData.java",
+            "CompleteJavaBeanSuperClassTestData.java", "CompleteJavaBeanMethodPropertyTestData.properties");
+        PsiElement element = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
+        final ResolveResult[] resolveResults = ((CamelBeanMethodReference) element.getReferences()[0]).multiResolve(false);
+        assertEquals(1, resolveResults.length);
+        assertEquals("public void letsDoThis() {}",  resolveResults[0].getElement().getText());
+    }
 
-//    @Ignore
-//    public void testCamelMultipleMethodReference() {
-//        myFixture.configureByFiles("CompleteJavaBeanRoute4TestData.java", "CompleteJavaBeanMultipleMethodTestData.java", "CompleteJavaBeanSuperClassTestData.java");
-//        PsiElement element = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
-//        final ResolveResult[] resolveResults = ((CamelBeanMethodReference) element.getReferences()[0]).multiResolve(false);
-//        assertEquals(2, resolveResults.length);
-//        assertEquals("public void multipleMethodsWithSameName() { }",  resolveResults[0].getElement().getText());
-//        assertEquals("public void multipleMethodsWithSameName(int data) { }",  resolveResults[1].getElement().getText());
-//    }
+    public void testCamelMultipleMethodReference() {
+        myFixture.configureByFiles("CompleteJavaBeanRoute4TestData.java", "CompleteJavaBeanMultipleMethodTestData.java", "CompleteJavaBeanSuperClassTestData.java");
+        PsiElement element = PsiTreeUtil.getParentOfType(myFixture.getFile().findElementAt(myFixture.getCaretOffset()), false, PsiLiteralExpression.class);
+        assertNotNull(element);
+        PsiReference[] references = element.getReferences();
+        assertEquals(1, references.length);
+        assertTrue(references[0] instanceof CamelBeanMethodReference);
+        CamelBeanMethodReference reference = (CamelBeanMethodReference) references[0];
+        final ResolveResult[] resolveResults = reference.multiResolve(false);
+        assertEquals(2, resolveResults.length);
+        assertEquals("public void multipleMethodsWithSameName() { }",  resolveResults[0].getElement().getText());
+        assertEquals("public void multipleMethodsWithSameName(int data) { }",  resolveResults[1].getElement().getText());
+    }
 
     public void testCamelNoMethodReference() {
         myFixture.configureByFiles("CompleteJavaBeanRoute4TestData.java");
@@ -64,69 +77,64 @@ public class CamelBeanMethodReferenceTest extends CamelLightCodeInsightFixtureTe
         assertEquals(0, ((PsiPolyVariantReference) element.getReferences()[0]).multiResolve(false).length);
     }
 
-//    @Ignore
-//    public void testFindUsageFromMethodToBeanDSL() {
-//        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaBeanTestData.java", "CompleteJavaBeanRoute1TestData.java");
-//        assertEquals(1, usageInfos.size());
-//
-//        final UsageInfo usageInfo = usageInfos.iterator().next();
-//        final PsiElement referenceElement = usageInfo.getElement();
-//        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
-//        assertEquals("(beanTestData, \"anotherBeanMethod\")", referenceElement.getParent().getText());
-//    }
+    public void testFindUsageFromMethodToBeanDSL() {
+        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaBeanTestData.java", "CompleteJavaBeanRoute1TestData.java");
+        assertEquals(1, usageInfos.size());
+
+        final UsageInfo usageInfo = usageInfos.iterator().next();
+        final PsiElement referenceElement = usageInfo.getElement();
+        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
+        assertEquals("(beanTestData, \"anotherBeanMethod\")", referenceElement.getParent().getText());
+    }
 
     /**
      * Test if it can find usage from a Spring Service bean method to it's Camel routes bean method
      */
-//    @Ignore
-//    public void testFindUsageFromSpringServiceMethodToBeanDSL() {
-//        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaSpringServiceBeanTestData.java", "CompleteJavaSpringServiceBeanRouteTestData.java");
-//        assertEquals(1, usageInfos.size());
-//
-//        final UsageInfo usageInfo = usageInfos.iterator().next();
-//        final PsiElement referenceElement = usageInfo.getElement();
-//        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
-//        assertEquals("(\"myServiceBean\", \"anotherBeanMethod\")", referenceElement.getParent().getText());
-//    }
+    public void testFindUsageFromSpringServiceMethodToBeanDSL() {
+        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaSpringServiceBeanTestData.java", "CompleteJavaSpringServiceBeanRouteTestData.java");
+        assertEquals(1, usageInfos.size());
+
+        final UsageInfo usageInfo = usageInfos.iterator().next();
+        final PsiElement referenceElement = usageInfo.getElement();
+        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
+        assertEquals("(\"myServiceBean\", \"anotherBeanMethod\")", referenceElement.getParent().getText());
+    }
 
     /**
      * Test if it can find usage from a Spring Component bean method to it's Camel routes bean method
      */
-//    @Ignore
-//    public void testFindUsageFromSpringComponentMethodToBeanDSL() {
-//        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaSpringComponentBeanTestData.java", "CompleteJavaSpringComponentBeanRouteTestData.java");
-//        assertEquals(1, usageInfos.size());
-//
-//        final UsageInfo usageInfo = usageInfos.iterator().next();
-//        final PsiElement referenceElement = usageInfo.getElement();
-//        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
-//        assertEquals("(\"myComponentBean\", \"anotherBeanMethod\")", referenceElement.getParent().getText());
-//    }
+    public void testFindUsageFromSpringComponentMethodToBeanDSL() {
+        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaSpringComponentBeanTestData.java", "CompleteJavaSpringComponentBeanRouteTestData.java");
+        assertEquals(1, usageInfos.size());
+
+        final UsageInfo usageInfo = usageInfos.iterator().next();
+        final PsiElement referenceElement = usageInfo.getElement();
+        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
+        assertEquals("(\"myComponentBean\", \"anotherBeanMethod\")", referenceElement.getParent().getText());
+    }
 
     /**
      * Test if it can find usage from a Spring Repository bean method to it's Camel routes bean method
      */
-//    @Ignore
-//    public void testFindUsageFromSpringRepositoryMethodToBeanDSL() {
-//        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaSpringRepositoryBeanTestData.java", "CompleteJavaSpringRepositoryBeanRouteTestData.java");
-//        assertEquals(1, usageInfos.size());
-//
-//        final UsageInfo usageInfo = usageInfos.iterator().next();
-//        final PsiElement referenceElement = usageInfo.getElement();
-//        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
-//        assertEquals("(\"myRepositoryBean\", \"anotherBeanMethod\")", referenceElement.getParent().getText());
-//    }
+    public void testFindUsageFromSpringRepositoryMethodToBeanDSL() {
+        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaSpringRepositoryBeanTestData.java", "CompleteJavaSpringRepositoryBeanRouteTestData.java");
+        assertEquals(1, usageInfos.size());
 
-//    @Ignore
-//    public void testFindUsageFromWithOverloadedMethodToBeanDSL() {
-//        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaBeanTest2Data.java", "CompleteJavaBeanRoute7TestData.java");
-//        assertEquals(1, usageInfos.size());
-//
-//        final UsageInfo usageInfo = usageInfos.iterator().next();
-//        final PsiElement referenceElement = usageInfo.getElement();
-//        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
-//        assertEquals("(beanTestData, \"myOverLoadedBean\")", referenceElement.getParent().getText());
-//    }
+        final UsageInfo usageInfo = usageInfos.iterator().next();
+        final PsiElement referenceElement = usageInfo.getElement();
+        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
+        assertEquals("(\"myRepositoryBean\", \"anotherBeanMethod\")", referenceElement.getParent().getText());
+    }
+
+    public void testFindUsageFromWithOverloadedMethodToBeanDSL() {
+        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaBeanTest2Data.java", "CompleteJavaBeanRoute7TestData.java");
+        assertEquals(1, usageInfos.size());
+
+        final UsageInfo usageInfo = usageInfos.iterator().next();
+        final PsiElement referenceElement = usageInfo.getElement();
+        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
+        assertEquals("(beanTestData, \"myOverLoadedBean\")", referenceElement.getParent().getText());
+    }
 
 
     /**
@@ -150,14 +158,13 @@ public class CamelBeanMethodReferenceTest extends CamelLightCodeInsightFixtureTe
     /**
      * Test if the find usage is working with camel DSL bean method call with parameters
      */
-//    @Ignore
-//    public void testFindUsageFromWithAmbiguousToBeanDSLWithParameters() {
-//        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaBeanTest3Data.java", "CompleteJavaBeanRoute8TestData.java");
-//        assertEquals(1, usageInfos.size());
-//
-//        final UsageInfo usageInfo = usageInfos.iterator().next();
-//        final PsiElement referenceElement = usageInfo.getElement();
-//        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
-//        assertEquals("(beanTestData, \"myAmbiguousMethod(${body})\")", referenceElement.getParent().getText());
-//    }
+    public void testFindUsageFromWithAmbiguousToBeanDSLWithParameters() {
+        Collection<UsageInfo> usageInfos = myFixture.testFindUsages("CompleteJavaBeanTest3Data.java", "CompleteJavaBeanRoute8TestData.java");
+        assertEquals(1, usageInfos.size());
+
+        final UsageInfo usageInfo = usageInfos.iterator().next();
+        final PsiElement referenceElement = usageInfo.getElement();
+        assertThat(referenceElement, instanceOf(PsiLiteralExpression.class));
+        assertEquals("(beanTestData, \"myAmbiguousMethod(${body})\")", referenceElement.getParent().getText());
+    }
 }

--- a/src/test/java/com/github/cameltooling/idea/reference/CamelDirectEndpointReferencesBetweenModulesIT.java
+++ b/src/test/java/com/github/cameltooling/idea/reference/CamelDirectEndpointReferencesBetweenModulesIT.java
@@ -1,0 +1,119 @@
+package com.github.cameltooling.idea.reference;
+
+import com.github.cameltooling.idea.CamelTestDependencyUtil;
+import com.github.cameltooling.idea.reference.endpoint.direct.DirectEndpointReference;
+import com.github.cameltooling.idea.reference.endpoint.direct.DirectEndpointStartSelfReference;
+import com.intellij.codeInsight.JavaCodeInsightTestCase;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.module.JavaModuleType;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.LanguageLevelModuleExtension;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
+import com.intellij.pom.java.LanguageLevel;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLiteralExpression;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.testFramework.IdeaTestUtil;
+import com.intellij.testFramework.IndexingTestUtil;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Objects;
+
+@RunWith(JUnit4.class)
+public class CamelDirectEndpointReferencesBetweenModulesIT extends JavaCodeInsightTestCase {
+
+    private Module moduleA;
+    private Module moduleB;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        Path path = Paths.get(getTestDataPath());
+        VfsRootAccess.allowRootAccess(getTestRootDisposable(), path.toAbsolutePath().toString());
+
+        moduleA = initModule("module-a");
+        moduleB = initModule("module-b");
+    }
+
+    private Module initModule(String name) throws IOException {
+        return WriteAction.computeAndWait(() -> {
+            Module module = createModuleFromTestData(getTestDataPath() + name + "/", name + ".iml", JavaModuleType.getModuleType(), true);
+
+            ModuleRootModificationUtil.updateModel(module, modifiableRootModel -> {
+                modifiableRootModel.setSdk(IdeaTestUtil.getMockJdk21());
+                modifiableRootModel.getModuleExtension(LanguageLevelModuleExtension.class).setLanguageLevel(LanguageLevel.JDK_17);
+
+                CamelTestDependencyUtil.loadDependencies(modifiableRootModel, "org.apache.camel:camel-core-model:4.13.0");
+            });
+            IndexingTestUtil.waitUntilIndexesAreReady(module.getProject());
+
+            return module;
+        });
+    }
+
+    @Override
+    protected @NotNull String getTestDataPath() {
+        return "src/test/resources/testData/reference/multi-module/";
+    }
+
+    @Override
+    protected Sdk getTestProjectJdk() {
+        return IdeaTestUtil.getMockJdk21();
+    }
+
+    @Test
+    public void findFromEndpointInModuleDependency() throws Exception {
+        ModuleRootModificationUtil.updateModel(moduleA, modifiableRootModel -> {
+            modifiableRootModel.addModuleOrderEntry(moduleB);
+        });
+
+        configureByModuleFile(moduleB, "src/RouteB.java");
+        PsiElement fromRouteBElement = findElementAtText("direct:routeB");
+        assertHasReference(fromRouteBElement, DirectEndpointStartSelfReference.class);
+
+        configureByModuleFile(moduleA, "src/RouteA.java");
+        PsiElement toRouteBElement = findElementAtText("direct:routeB");
+        DirectEndpointReference toRef = assertHasReference(toRouteBElement, DirectEndpointReference.class);
+        PsiElement target = toRef.resolve();
+        assertNotNull(target);
+        assertEquals(fromRouteBElement, target.getNavigationElement());
+    }
+
+    @Test
+    public void fromEndpointNotFoundIfNotInModuleDependency() throws Exception {
+        configureByModuleFile(moduleA, "src/RouteA.java");
+        PsiElement toRouteBElement = findElementAtText("direct:routeB");
+        DirectEndpointReference toRef = assertHasReference(toRouteBElement, DirectEndpointReference.class);
+        assertNull(toRef.resolve());
+    }
+
+    private void configureByModuleFile(Module moduleB, String relPath) throws IOException {
+        configureByExistingFile(Objects.requireNonNull(getOrCreateModuleDir(moduleB).findFileByRelativePath(relPath)));
+    }
+
+    private PsiLiteralExpression findElementAtText(String elementText) {
+        PsiLiteralExpression element = PsiTreeUtil.getParentOfType(getFile().findElementAt(getFile().getText().indexOf(elementText)), PsiLiteralExpression.class);
+        assertNotNull(element);
+        return element;
+    }
+
+    private <T extends PsiReference> T assertHasReference(PsiElement element, Class<T> referenceClass) {
+        T reference = Arrays.stream(element.getReferences())
+                .filter(referenceClass::isInstance)
+                .map(referenceClass::cast)
+                .findFirst().orElse(null);
+        assertNotNull(reference);
+        return reference;
+    }
+
+}

--- a/src/test/java/com/github/cameltooling/idea/rename/RenameCamelBeanMethodRefTestIT.java
+++ b/src/test/java/com/github/cameltooling/idea/rename/RenameCamelBeanMethodRefTestIT.java
@@ -18,7 +18,6 @@ package com.github.cameltooling.idea.rename;
 
 import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import org.jetbrains.annotations.Nullable;
-import org.junit.Ignore;
 
 public class RenameCamelBeanMethodRefTestIT extends CamelLightCodeInsightFixtureTestCaseIT {
 
@@ -32,7 +31,6 @@ public class RenameCamelBeanMethodRefTestIT extends CamelLightCodeInsightFixture
         return "src/test/resources/testData/rename";
     }
 
-    @Ignore
     public void testCamelBeanMethodRefRename() {
         myFixture.configureByFiles("RenameCamelBeanMethodRefTestData.java", "RenameCompleteJavaBeanTestData.java");
         myFixture.renameElementAtCaretUsingHandler("letNotDoThis");

--- a/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute1TestData.java
+++ b/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute1TestData.java
@@ -14,18 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData.annotator.method;
-
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.main.Main;
-import testData.annotator.method.AnnotatorJavaBeanTestData;
 
 public final class AnnotatorJavaBeanRoute1TestData extends RouteBuilder {
 
     public void configure() {
         from("file:inbox")
-            .bean(AnnotatorJavaBeanTestData.class, <error descr="'thisIsVeryPrivate' has private access in bean 'testData.annotator.method.AnnotatorJavaBeanTestData'">"thisIsVeryPrivate"</error>)
-            .bean(AnnotatorJavaBeanTestData.class, <error descr="Can not resolve method 'methodDoesNotExist' in bean 'testData.annotator.method.AnnotatorJavaBeanTestData'">"methodDoesNotExist"</error>)
+            .bean(AnnotatorJavaBeanTestData.class, <error descr="'thisIsVeryPrivate' has private access in bean 'AnnotatorJavaBeanTestData'">"thisIsVeryPrivate"</error>)
+            .bean(AnnotatorJavaBeanTestData.class, <error descr="Can not resolve method 'methodDoesNotExist' in bean 'AnnotatorJavaBeanTestData'">"methodDoesNotExist"</error>)
             .bean(AnnotatorJavaBeanTestData.class, "letsDoThis")
             .to("log:out");
     }

--- a/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute2TestData.java
+++ b/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute2TestData.java
@@ -14,12 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData.annotator.method;
-
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.main.Main;
-import testData.annotator.method.AnnotatorJavaBeanTestData;
-import testData.annotator.method.AnnotatorJavaBeanSuperClassTestData;
 
 public final class AnnotatorJavaBeanRoute2TestData extends RouteBuilder {
 
@@ -28,8 +23,8 @@ public final class AnnotatorJavaBeanRoute2TestData extends RouteBuilder {
     public void configure() {
         from("file:inbox")
             .bean(beanTestData, "mySuperAbstractMethod")
-            .bean(beanTestData, <error descr="Can not resolve method 'letsDoThis' in bean 'testData.annotator.method.AnnotatorJavaBeanSuperClassTestData'">"letsDoThis"</error>)
-            .bean(beanTestData, <error descr="Can not resolve method 'thisIsVeryPrivate' in bean 'testData.annotator.method.AnnotatorJavaBeanSuperClassTestData'">"thisIsVeryPrivate"</error>)
+            .bean(beanTestData, <error descr="Can not resolve method 'letsDoThis' in bean 'AnnotatorJavaBeanSuperClassTestData'">"letsDoThis"</error>)
+            .bean(beanTestData, <error descr="Can not resolve method 'thisIsVeryPrivate' in bean 'AnnotatorJavaBeanSuperClassTestData'">"thisIsVeryPrivate"</error>)
             .to("log:out");
     }
 }

--- a/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute3TestData.java
+++ b/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute3TestData.java
@@ -14,12 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData.annotator.method;
-
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.main.Main;
-import testData.annotator.method.AnnotatorJavaBeanTestData;
-import testData.annotator.method.AnnotatorJavaBeanSuperClassTestData;
 
 public final class AnnotatorJavaBeanRoute3TestData extends RouteBuilder {
 
@@ -29,7 +24,7 @@ public final class AnnotatorJavaBeanRoute3TestData extends RouteBuilder {
         from("file:inbox")
             .bean(beanTestData, "myOverLoadedBean2")
             .bean(beanTestData, "myOverLoadedBean(${body})")
-            .bean(beanTestData, <error descr="Ambiguous matches 'myOverLoadedBean' in bean 'testData.annotator.method.AnnotatorJavaBeanTestData'">"myOverLoadedBean"</error>)
+            .bean(beanTestData, <error descr="Ambiguous matches 'myOverLoadedBean' in bean 'AnnotatorJavaBeanTestData'">"myOverLoadedBean"</error>)
             .to("log:out");
     }
 }

--- a/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute4TestData.java
+++ b/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute4TestData.java
@@ -14,12 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData.annotator.method;
-
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.annotator.method.AnnotatorJavaBeanTestData;
-import testData.annotator.method.AnnotatorJavaBeanSuperClassTestData;
 
 public final class AnnotatorJavaBeanRoute4TestData extends RouteBuilder {
 

--- a/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute5TestData.java
+++ b/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute5TestData.java
@@ -14,12 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData.annotator.method;
-
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.annotator.method.AnnotatorJavaBeanTestData;
-import testData.annotator.method.AnnotatorJavaBeanSuperClassTestData;
 
 public final class AnnotatorJavaBeanRoute4TestData extends RouteBuilder {
 

--- a/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute6TestData.java
+++ b/src/test/resources/testData/annotator/method/AnnotatorJavaBeanRoute6TestData.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.camel.builder.RouteBuilder;
+
+public final class AnnotatorJavaBeanRoute6TestData extends RouteBuilder {
+
+    public void configure() {
+        from("file:inbox")
+            .bean(AnnotatorJavaBeanTestData.class, <error descr="Can not resolve method 'myOverLoadedBean(java.lang.Long.class' in bean 'AnnotatorJavaBeanTestData'">"myOverLoadedBean(java.lang.Long.class"</error>)
+            .bean(AnnotatorJavaBeanTestData.class, <error descr="Can not resolve method 'myOverLoadedBean(java.lang.Long.class)' in bean 'AnnotatorJavaBeanTestData'">"myOverLoadedBean(java.lang.Long.class)"</error>)
+            .bean(AnnotatorJavaBeanTestData.class, <error descr="Can not resolve method 'myOverLoadedBean(java.lang.Object.class)' in bean 'AnnotatorJavaBeanTestData'">"myOverLoadedBean(java.lang.Object.class)"</error>)
+            .bean(AnnotatorJavaBeanTestData.class, "myOverLoadedBean(java.lang.String.class)")
+            .bean(AnnotatorJavaBeanTestData.class, "myOverLoadedBean2(java.lang.String.class, int.class)")
+            .bean(AnnotatorJavaBeanTestData.class, "myOverLoadedBean2(java.lang.String.class, ${body})")
+            .bean(AnnotatorJavaBeanTestData.class, "myOverLoadedBean2(*, *)")
+            .bean(AnnotatorJavaBeanTestData.class, "myOverLoadedBean2(*, int.class)")
+            .bean(AnnotatorJavaBeanTestData.class, "myOverLoadedBean2(*, -5)")
+            .bean(AnnotatorJavaBeanTestData.class, "myOverLoadedBean2('abc', -5)")
+            .bean(AnnotatorJavaBeanTestData.class, <error descr="Can not resolve method 'myOverLoadedBean2('abc', 'abc')' in bean 'AnnotatorJavaBeanTestData'">"myOverLoadedBean2('abc', 'abc')"</error>)
+            .bean(AnnotatorJavaBeanTestData.class, "letsDoThis")
+            .to("log:out");
+    }
+}

--- a/src/test/resources/testData/annotator/method/AnnotatorJavaBeanSuperClassTestData.java
+++ b/src/test/resources/testData/annotator/method/AnnotatorJavaBeanSuperClassTestData.java
@@ -14,9 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData.annotator.method;
-
-public class AnnotatorJavaBeanSuperClassTestData {
+public abstract class AnnotatorJavaBeanSuperClassTestData {
 
     public boolean mySuperMethod() {
         mySuperAbstractMethod();

--- a/src/test/resources/testData/annotator/method/AnnotatorJavaBeanTestData.java
+++ b/src/test/resources/testData/annotator/method/AnnotatorJavaBeanTestData.java
@@ -14,10 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData.annotator.method;
-
 import org.apache.camel.Handler;
-import testData.annotator.method.AnnotatorJavaBeanSuperClassTestData;
 
 public class AnnotatorJavaBeanTestData extends AnnotatorJavaBeanSuperClassTestData {
 

--- a/src/test/resources/testData/barroute/expected.xml
+++ b/src/test/resources/testData/barroute/expected.xml
@@ -3,6 +3,6 @@
   <problem>
     <file>BarRoute.java</file>
     <line>34</line>
-    <description>Illegal syntax: $.store.book[* xxxxxxx]</description>
+    <description>Expected wildcard token to end with ']' on position 14</description>
   </problem>
 </problems>

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanMultipleMethodTestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanMultipleMethodTestData.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import testData.CompleteJavaBeanSuperClassTestData;
 
 public class CompleteJavaBeanMultipleMethodTestData extends CompleteJavaBeanSuperClassTestData {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute10TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute10TestData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaSpringServiceBeanTestData;
 
 /**
  * Test route for testing code completion with empty bean name as reference

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute11TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute11TestData.java
@@ -16,7 +16,7 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaSpringRepositoryBeanTestData.*;
+import CompleteJavaSpringRepositoryBeanTestData.*;
 
 /**
  * Test route for testing find usage from Route bean DSL to the bean method where the

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute1TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute1TestData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanTestData;
 
 public final class CompleteJavaBeanRoute1TestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute2ResultData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute2ResultData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanTestData;
 
 public final class CompleteJavaBeanRoute2TestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute2TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute2TestData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanTestData;
 
 public final class CompleteJavaBeanRoute2TestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute3TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute3TestData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanTestData;
 
 public final class CompleteJavaBeanRoute3TestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute4TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute4TestData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanMultipleMethodTestData;
 
 public final class CompleteJavaBeanRoute4TestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute5TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute5TestData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanMultipleMethodTestData;
 
 public final class CompleteJavaBeanRoute5TestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute6TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute6TestData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanTestData;
 
 public final class CompleteJavaBeanRoute6TestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute7TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute7TestData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanTest2Data;
 
 /**
  * Test route for testing find usage from bean method "myOverLoadedBean" to the route Camel bean DSL.

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute8TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute8TestData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanTest2Data;
 
 /**
  * Test route for testing find usage from bean method "myOverLoadedBean" to the route Camel bean DSL.

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRoute9TestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRoute9TestData.java
@@ -16,7 +16,7 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaSpringServiceBeanTestData.*;
+import CompleteJavaSpringServiceBeanTestData.*;
 
 /**
  * Test route for testing find usage from Route bean DSL to the bean method where the

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanRouteTestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanRouteTestData.java
@@ -16,7 +16,7 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaBeanTestData;
+import CompleteJavaBeanTestData;
 
 public final class CompleteJavaBeanRouteTestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanSuperClassTestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanSuperClassTestData.java
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData;
-
 public class CompleteJavaBeanSuperClassTestData {
 
     public boolean mySuperMethod() {

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanTest2Data.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanTest2Data.java
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import testData.CompleteJavaBeanSuperClassTestData;
-
 /**
  * Use for testing find usage with overload methods
  */

--- a/src/test/resources/testData/completion/method/CompleteJavaBeanTestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaBeanTestData.java
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import testData.CompleteJavaBeanSuperClassTestData;
-
 
 public class CompleteJavaBeanTestData extends CompleteJavaBeanSuperClassTestData {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaSpringComponentBeanRouteTestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaSpringComponentBeanRouteTestData.java
@@ -1,4 +1,3 @@
-package testData;
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,7 +16,6 @@ package testData;
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaSpringBeanTestData;
 
 public final class CompleteJavaBeanRoute9TestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaSpringComponentBeanTestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaSpringComponentBeanTestData.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData;
 import org.springframework.stereotype.Component;
 
 @Component(value = "myComponentBean")

--- a/src/test/resources/testData/completion/method/CompleteJavaSpringRepositoryBeanRouteTestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaSpringRepositoryBeanRouteTestData.java
@@ -14,10 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaSpringServiceBeanTestData;
 
 public final class CompleteJavaSpringRepositoryBeanRouteTestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaSpringRepositoryBeanTestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaSpringRepositoryBeanTestData.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 

--- a/src/test/resources/testData/completion/method/CompleteJavaSpringServiceBeanRouteTestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaSpringServiceBeanRouteTestData.java
@@ -16,7 +16,6 @@
  */
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.main.Main;
-import testData.CompleteJavaSpringServiceBeanTestData;
 
 public final class CompleteJavaSpringServiceBeanRouteTestData extends RouteBuilder {
 

--- a/src/test/resources/testData/completion/method/CompleteJavaSpringServiceBeanTestData.java
+++ b/src/test/resources/testData/completion/method/CompleteJavaSpringServiceBeanTestData.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package testData;
 import org.springframework.stereotype.Service;
 
 @Service(value = "myServiceBean")

--- a/src/test/resources/testData/reference/multi-module/module-a/src/RouteA.java
+++ b/src/test/resources/testData/reference/multi-module/module-a/src/RouteA.java
@@ -1,0 +1,9 @@
+import org.apache.camel.builder.RouteBuilder;
+
+public class RouteA extends RouteBuilder {
+    @Override
+    public void configure() {
+        from("direct:routeA")
+                .to("direct:routeB");
+    }
+}

--- a/src/test/resources/testData/reference/multi-module/module-b/src/RouteB.java
+++ b/src/test/resources/testData/reference/multi-module/module-b/src/RouteB.java
@@ -1,0 +1,9 @@
+import org.apache.camel.builder.RouteBuilder;
+
+public class RouteB extends RouteBuilder {
+    @Override
+    public void configure() {
+        from("direct:routeB")
+                .to("direct:routeC");
+    }
+}


### PR DESCRIPTION
* I've uncommented all the tests I could find, and fixed them - problems were mainly wrong packages / imports between test data files (maybe after some refactoring where the files were moved), and in not including camel-model jar in the test project fixture (which causes RouteBuilder, BeanInject and similar classes not to be recognized)
* fixed some bugs
* bean method references (`.bean(xxx, "thisIsMethodReference")`) now recognize parameter types, for example when there are overloaded methods in a bean, and you do `.bean(xxx, "methodCall(*, *)")`, this only matches method with the name and with 2 arguments. Inspired by `BeanInfo#matchMethod`