### PR TITLE
specify correct groupId of camel-debug for KARAF runtime for version …

### DIFF
--- a/src/main/java/com/github/cameltooling/idea/runner/CamelJBangRunProfileState.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/CamelJBangRunProfileState.java
@@ -18,8 +18,6 @@ package com.github.cameltooling.idea.runner;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -177,7 +175,7 @@ public class CamelJBangRunProfileState extends CommandLineState implements Targe
         if (debug) {
             CamelProjectPreferenceService preferenceService = CamelProjectPreferenceService.getService(project);
             CamelRuntime runtime = preferenceService.getCamelCatalogProvider().getRuntime();
-            dependencies.add(runtime.getDebugArtifact().getArtifactId());
+            dependencies.add(runtime.getDebugArtifact(version).getArtifactId());
             dependencies.add(runtime.getManagementArtifact().getArtifactId());
             ArtifactCoordinates additionalArtifact = runtime.getAdditionalArtifact();
             if (additionalArtifact != null) {

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerPatcher.java
@@ -577,7 +577,7 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
             runtime = CamelRuntime.DEFAULT;
             if (LOG.isDebugEnabled()) {
                 LOG.debug(
-                    String.format("Using the default %s component as dependency", runtime.getDebugArtifact())
+                    String.format("Using the default %s component as dependency", runtime.getDebugArtifact(version))
                 );
             }
         }
@@ -603,7 +603,7 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
     @NotNull
     private static List<URL> downloadCamelDebugger(Project project, @NotNull CamelRuntime runtime, @NotNull String version) throws IOException {
         try (MavenArtifactRetrieverContext context = new MavenArtifactRetrieverContext(project)) {
-            ArtifactCoordinates debugArtifact = runtime.getDebugArtifact();
+            ArtifactCoordinates debugArtifact = runtime.getDebugArtifact(version);
             if (LOG.isDebugEnabled()) {
                 LOG.debug(String.format("Trying to download %s %s with all its dependencies", debugArtifact, version));
             }
@@ -903,7 +903,7 @@ public class CamelDebuggerPatcher extends JavaProgramPatcher {
          * {@code camel-debug}.
          */
         Dependency createCamelDebugDependency(Project project, String version) {
-            return createDependency(project, version, CamelRuntime::getDebugArtifact);
+            return createDependency(project, version, runtime -> runtime.getDebugArtifact(version));
         }
 
         /**


### PR DESCRIPTION
…in [3.15.0, 4.7.0), where there was no org.apache.camel.karaf:camel-debug artifact, as mentioned in #1092