### PR TITLE
add references from endpoint uri parameters to their corresponding setters in camel classes (*Endpoint, *Configuration)

### DIFF
--- a/src/main/java/com/github/cameltooling/idea/reference/endpoint/parameter/CamelEndpointParameterReferenceContributor.java
+++ b/src/main/java/com/github/cameltooling/idea/reference/endpoint/parameter/CamelEndpointParameterReferenceContributor.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.reference.endpoint.parameter;
+
+import com.github.cameltooling.idea.reference.endpoint.CamelEndpointPsiReferenceProvider;
+import com.github.cameltooling.idea.service.CamelCatalogService;
+import com.github.cameltooling.idea.util.CamelIdeaUtils;
+import com.github.cameltooling.idea.util.IdeaUtils;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.patterns.ElementPattern;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.PsiReferenceContributor;
+import com.intellij.psi.PsiReferenceRegistrar;
+import com.intellij.util.ProcessingContext;
+import org.apache.camel.catalog.CamelCatalog;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Contributor for {@link EndpointParameterReference}, which is a reference from endpoint uri query parameter to its setter method in the corresponding camel class
+ * E.g. from the 'synchronous' substring in endpoint uri "direct:abc?synchronous=true" to {@link org.apache.camel.component.direct.DirectEndpoint#setSynchronous}
+ */
+public class CamelEndpointParameterReferenceContributor extends PsiReferenceContributor {
+
+    @Override
+    public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
+        List<ElementPattern<? extends PsiElement>> patterns = CamelIdeaUtils.getService().getAllowedEndpointUriLocations();
+        if (!patterns.isEmpty()) {
+            CamelEndpointPsiReferenceProvider provider = createProvider();
+            patterns.forEach(pattern -> {
+                registrar.registerReferenceProvider(pattern, provider);
+            });
+        }
+    }
+
+    @NotNull
+    private CamelEndpointPsiReferenceProvider createProvider() {
+        return new CamelEndpointPsiReferenceProvider() {
+            @Override
+            protected PsiReference[] getEndpointReferencesByElement(String endpointUri, PsiElement element, ProcessingContext context) {
+                Project project = element.getProject();
+
+                CamelCatalogService catalogService = project.getService(CamelCatalogService.class);
+                CamelCatalog catalog = catalogService.get();
+                String component = catalog.endpointComponentName(endpointUri);
+                if (component == null) {
+                    return PsiReference.EMPTY_ARRAY;
+                }
+
+                Map<String, String> params;
+                try {
+                    String unescapedUri = IdeaUtils.getService().isXmlLanguage(element) ? StringUtil.unescapeXmlEntities(endpointUri) : endpointUri;
+                    params = catalog.endpointProperties(unescapedUri);
+                } catch (Exception e) {
+                    return PsiReference.EMPTY_ARRAY;
+                }
+
+                return createParameterReferences(endpointUri, element, component, params);
+            }
+
+            private PsiReference[] createParameterReferences(String endpointUri, PsiElement endpointElement, String component, Map<String, String> params) {
+                return params.keySet().stream()
+                        .map(param -> {
+                            int paramStartIndex = endpointUri.indexOf(param + "=");
+                            if (paramStartIndex < 0) {
+                                return null;
+                            }
+                            if (endpointElement.getText().startsWith("\"")) {
+                                paramStartIndex++;
+                            }
+                            return new EndpointParameterReference(endpointElement, component, param, new TextRange(paramStartIndex, paramStartIndex + param.length()));
+                        })
+                        .filter(Objects::nonNull)
+                        .toArray(PsiReference[]::new);
+            }
+
+            @Override
+            protected boolean isEndpoint(String endpointUri) {
+                return true;
+            }
+        };
+    }
+
+}

--- a/src/main/java/com/github/cameltooling/idea/reference/endpoint/parameter/EndpointParameterReference.java
+++ b/src/main/java/com/github/cameltooling/idea/reference/endpoint/parameter/EndpointParameterReference.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.reference.endpoint.parameter;
+
+import com.github.cameltooling.idea.service.CamelCatalogService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiReferenceBase;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.util.PropertyUtilBase;
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.tooling.model.ComponentModel;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Reference from an endpoint uri query parameter to its setter method in the corresponding camel class
+ * E.g. from the 'synchronous' substring in endpoint uri "direct:abc?synchronous=true" to {@link org.apache.camel.component.direct.DirectEndpoint#setSynchronous}
+ */
+public class EndpointParameterReference extends PsiReferenceBase<PsiElement> {
+
+    private static final List<String> CONFIG_CLASS_SUFFIXES = List.of("Endpoint", "Configuration");
+
+    private final String component;
+    private final String parameterName;
+
+    public EndpointParameterReference(@NotNull PsiElement element, @NotNull String component, @NotNull String parameterName, TextRange parameterTextRange) {
+        super(element, parameterTextRange);
+        this.component = component;
+        this.parameterName = parameterName;
+    }
+
+    @Override
+    public @Nullable PsiElement resolve() {
+        Project project = getElement().getProject();
+        CamelCatalog catalog = project.getService(CamelCatalogService.class).get();
+        ComponentModel model = catalog.componentModel(component);
+        String componentClassName = model.getJavaType();
+        if (componentClassName.endsWith("Component")) {
+            String baseClassName = componentClassName.substring(0, componentClassName.length() - "Component".length());
+            for (String configClassSuffix : CONFIG_CLASS_SUFFIXES) {
+                String configClassName = baseClassName + configClassSuffix;
+                PsiClass configClass = JavaPsiFacade.getInstance(project).findClass(configClassName, GlobalSearchScope.allScope(project));
+                if (configClass != null) {
+                    PsiMethod setter = PropertyUtilBase.findPropertySetter(configClass, parameterName, false, true);
+                    if (setter != null) {
+                        return setter;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,10 @@
       v.1.4.4
       <ul>
         <li>Only IDEA 2025 onwards is supported</li>
+        <li>
+          References from endpoint uri to corresponding setters in camel classes, e.g. from the <code>synchronous</code> substring in endpoint uri <code>"direct:abc?synchronous=true"</code>
+          to <code>DirectEndpoint#setSynchronous</code>
+        </li>
       </ul>
     ]]>
   </change-notes>
@@ -148,6 +152,9 @@
     <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.propertyplaceholder.CamelPropertyPlaceholderReferenceContributor"/>
     <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.propertyplaceholder.GenericXmlPropertyPlaceholderReferenceContributor" language="XML"/>
     <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.propertyplaceholder.ConfigPropertyPlaceholderReferenceContributor" language="JAVA"/>
+    <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.endpoint.parameter.CamelEndpointParameterReferenceContributor" language="JAVA" />
+    <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.endpoint.parameter.CamelEndpointParameterReferenceContributor" language="XML" />
+    <psi.referenceContributor implementation="com.github.cameltooling.idea.reference.endpoint.parameter.CamelEndpointParameterReferenceContributor" language="yaml" />
     <renameHandler implementation="com.github.cameltooling.idea.reference.CamelBeanReferenceRenameHandler"/>
     <postFormatProcessor implementation="com.github.cameltooling.idea.formatter.CamelPostFormatProcessor"/>
 

--- a/src/test/java/com/github/cameltooling/idea/CamelLightCodeInsightFixtureTestCaseIT.java
+++ b/src/test/java/com/github/cameltooling/idea/CamelLightCodeInsightFixtureTestCaseIT.java
@@ -67,6 +67,8 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightJavaCo
     protected static String CAMEL_CORE_MODEL_MAVEN_ARTIFACT = "org.apache.camel:camel-core-model:%s";
     protected static String CAMEL_API_MAVEN_ARTIFACT = "org.apache.camel:camel-api:%s";
     protected static String CAMEL_ENDPOINTDSL_MAVEN_ARTIFACT = "org.apache.camel:camel-endpointdsl:%s";
+    protected static String CAMEL_TIMER_MAVEN_ARTIFACT = "org.apache.camel:camel-timer:%s";
+    protected static String CAMEL_FTP_MAVEN_ARTIFACT = "org.apache.camel:camel-ftp:%s";
 
 
     static {
@@ -79,6 +81,8 @@ public abstract class CamelLightCodeInsightFixtureTestCaseIT extends LightJavaCo
             CAMEL_API_MAVEN_ARTIFACT = String.format(CAMEL_API_MAVEN_ARTIFACT, CAMEL_VERSION);
             CAMEL_CORE_MODEL_MAVEN_ARTIFACT = String.format(CAMEL_CORE_MODEL_MAVEN_ARTIFACT, CAMEL_VERSION);
             CAMEL_ENDPOINTDSL_MAVEN_ARTIFACT = String.format(CAMEL_ENDPOINTDSL_MAVEN_ARTIFACT, CAMEL_VERSION);
+            CAMEL_TIMER_MAVEN_ARTIFACT = String.format(CAMEL_TIMER_MAVEN_ARTIFACT, CAMEL_VERSION);
+            CAMEL_FTP_MAVEN_ARTIFACT = String.format(CAMEL_FTP_MAVEN_ARTIFACT, CAMEL_VERSION);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/test/java/com/github/cameltooling/idea/reference/endpoint/parameter/CamelEndpointParametereferenceContributorTest.java
+++ b/src/test/java/com/github/cameltooling/idea/reference/endpoint/parameter/CamelEndpointParametereferenceContributorTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.reference.endpoint.parameter;
+
+import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
+import com.github.cameltooling.idea.reference.TestReferenceUtil;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiReference;
+
+import java.util.List;
+import java.util.Objects;
+
+public class CamelEndpointParametereferenceContributorTest extends CamelLightCodeInsightFixtureTestCaseIT {
+
+    // language=JAVA
+    private static final String JAVA_ROUTE = """
+            import org.apache.camel.builder.RouteBuilder;
+            public final class MyRoute extends RouteBuilder {
+                @Override
+                public void configure() {
+                    from("time<caret>r:foo?period=1000&delay=50").to("mock:out");
+                }
+            }
+            """;
+
+    @Override
+    protected String getTestDataPath() {
+        return super.getTestDataPath() + "/reference";
+    }
+
+    @Override
+    protected String[] getMavenDependencies() {
+        return new String[]{CAMEL_CORE_MAVEN_ARTIFACT, CAMEL_TIMER_MAVEN_ARTIFACT, CAMEL_FTP_MAVEN_ARTIFACT};
+    }
+
+    public void testPropertyReferencesAtCorrectIndices() {
+        myFixture.configureByText("MyRoute.java", JAVA_ROUTE);
+        PsiElement textElement = TestReferenceUtil.getParentElementAtCaret(myFixture);;
+        List<EndpointParameterReference> refs = TestReferenceUtil.getReferencesOfType(textElement, EndpointParameterReference.class);
+
+        List<String> propNames = refs.stream().map(PsiReference::getCanonicalText).toList();
+        assertSameElements(propNames, List.of("period", "delay"));
+
+        assertParameterTextRange(refs, textElement.getText(), "period");
+        assertParameterTextRange(refs, textElement.getText(), "delay");
+    }
+
+    private void assertParameterTextRange(List<EndpointParameterReference> refs, String endpointUriText, String param) {
+        int index = endpointUriText.indexOf(param + "=");
+        assertTrue(index >= 0);
+        EndpointParameterReference ref = refs.stream().filter(r -> r.getCanonicalText().equals(param)).findFirst().orElse(null);
+        assertNotNull(ref);
+        assertEquals(new TextRange(index, index + param.length()), ref.getRangeInElement());
+    }
+
+    public void testTimerEndpointPeriodReference() {
+        testQueryParameterReference(JAVA_ROUTE, "period", "org.apache.camel.component.timer.TimerEndpoint", "setPeriod");
+    }
+
+    public void testFtpConfigurationAccountReference() {
+        testQueryParameterReference(
+                // language=JAVA
+                """
+                import org.apache.camel.builder.RouteBuilder;
+                public final class MyRoute extends RouteBuilder {
+                    @Override
+                    public void configure() {
+                        from("f<caret>tp:xxxx?account=acc").to("mock:out");
+                    }
+                }
+                """, "account", "org.apache.camel.component.file.remote.FtpConfiguration", "setAccount");
+    }
+
+    private void testQueryParameterReference(String route, String param, String resolvedClass, String resolvedMethod) {
+        List<EndpointParameterReference> refs = getEndpointPropertyReferences(route);
+        assertParameterReferenceResolvesToCorrectMethod(refs, param, resolvedClass, resolvedMethod);
+    }
+
+    private static void assertParameterReferenceResolvesToCorrectMethod(List<EndpointParameterReference> refs, String param, String resolvedClass, String resolvedMethod) {
+        EndpointParameterReference paramReference = refs.stream().filter(r -> r.getCanonicalText().equals(param)).findFirst().orElse(null);
+        assertNotNull(paramReference);
+        PsiElement resolved = paramReference.resolve();
+        assertTrue(resolved instanceof PsiMethod);
+        PsiMethod method = (PsiMethod) resolved;
+        assertEquals(resolvedMethod, method.getName());
+        assertEquals(resolvedClass, Objects.requireNonNull(method.getContainingClass()).getQualifiedName());
+    }
+
+    private List<EndpointParameterReference> getEndpointPropertyReferences(String fileContent) {
+        return getEndpointPropertyReferences("MyRoute.java", fileContent);
+    }
+
+    private List<EndpointParameterReference> getEndpointPropertyReferences(String fileName, String fileContent) {
+        myFixture.configureByText(fileName, fileContent);
+        PsiElement textElement = TestReferenceUtil.getParentElementAtCaret(myFixture);
+        return TestReferenceUtil.getReferencesOfType(textElement, EndpointParameterReference.class);
+    }
+
+    public void testNoReferencesForUnknownComponent() {
+        // language=JAVA
+        List<EndpointParameterReference> refs = getEndpointPropertyReferences("""
+                import org.apache.camel.builder.RouteBuilder;
+                public final class MyRoute extends RouteBuilder {
+                    @Override
+                    public void configure() {
+                        from("xxxunknown:abc?foo=1&bar=2");
+                    }
+                }
+                """);
+        assertTrue(refs.isEmpty());
+    }
+
+    public void testUnknownQueryParamHasReferenceButResolvesToNullInJava() {
+        // language=JAVA
+        List<EndpointParameterReference> refs = getEndpointPropertyReferences("""
+                import org.apache.camel.builder.RouteBuilder;
+                public final class MyRoute extends RouteBuilder {
+                    @Override
+                    public void configure() {
+                        from("time<caret>r:bar?foo=1&delay=2");
+                    }
+                }
+                """);
+        List<String> names = refs.stream().map(PsiReference::getCanonicalText).toList();
+        assertEquals(names, List.of("foo", "delay"));
+        PsiReference fooRef = refs.stream().filter(r -> r.getCanonicalText().equals("foo")).findFirst().orElse(null);
+        assertNotNull(fooRef);
+        assertNull(fooRef.resolve());
+
+        assertParameterReferenceResolvesToCorrectMethod(refs, "delay", "org.apache.camel.component.timer.TimerEndpoint", "setDelay");
+    }
+
+    public void testXmlKnownAndUnknownParams() {
+        List<EndpointParameterReference> refs = getEndpointPropertyReferences("routes.xml",
+                // language=XML
+                """
+                <camelContext xmlns="http://camel.apache.org/schema/spring">
+                    <route>
+                        <from uri="tim<caret>er:abc?foo=1&amp;period=1000"/>
+                        <to uri="mock:out"/>
+                    </route>
+                </root>
+                """);
+        List<String> names = refs.stream().map(PsiReference::getCanonicalText).toList();
+        assertSameElements(names, List.of("foo", "period"));
+
+        assertParameterReferenceResolvesToCorrectMethod(refs, "period", "org.apache.camel.component.timer.TimerEndpoint", "setPeriod");
+    }
+
+    public void testYamlKnownAndUnknownParams() {
+        List<EndpointParameterReference> refs = getEndpointPropertyReferences("routes.yaml",
+                // language=YAML
+                """
+                - route:
+                    from:
+                      uri: "tim<caret>er:abc?foo=1&delay=5&period=1000"
+                    steps:
+                      - to: "mock:out"
+                """);
+        List<String> names = refs.stream().map(PsiReference::getCanonicalText).toList();
+        assertSameElements(names, List.of("foo", "delay", "period"));
+
+        assertParameterReferenceResolvesToCorrectMethod(refs, "period", "org.apache.camel.component.timer.TimerEndpoint", "setPeriod");
+        assertParameterReferenceResolvesToCorrectMethod(refs, "delay", "org.apache.camel.component.timer.TimerEndpoint", "setDelay");
+    }
+    
+    
+}


### PR DESCRIPTION
like so:

<img width="548" height="110" alt="image" src="https://github.com/user-attachments/assets/a99dd839-c75a-4c88-9c6b-6e75e54b8af9" />

pointing to `org.apache.camel.component.file.GenericFileEndpoint#setAppendChars`


I'm not quite sure how to determine which class the query parameter is actually located in, and whether I can determine this programmatically, so I went with the most primitive approach - take the component class name (e.g. DirectComponent), replace Component with Endpoint, or Configuration, and try to find appropriate setter there. If there's a better way, or if there's more possible places to look in, I'll gladly change the logic.


 