### PR TITLE
Ref #1100: Java DSL Formatter - Format Java DSL when it's at start of route

### DIFF
--- a/src/test/java/com/github/cameltooling/idea/formatter/CamelPostFormatProcessorIT.java
+++ b/src/test/java/com/github/cameltooling/idea/formatter/CamelPostFormatProcessorIT.java
@@ -22,7 +22,6 @@ import com.github.cameltooling.idea.CamelLightCodeInsightFixtureTestCaseIT;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.psi.PsiFile;
 import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.testFramework.DumbModeTestUtils;
 import com.intellij.testFramework.PlatformTestUtil;
@@ -49,6 +48,20 @@ public class CamelPostFormatProcessorIT extends CamelLightCodeInsightFixtureTest
      */
     public void testRouteWithDataFormatDSL() {
         doTest("RouteWithDataFormatDSL", null);
+    }
+
+    /**
+     * Ensures that a route using only the Java DSL is supported.
+     */
+    public void testRouteWithOnlyJavaDSL() {
+        doTest("RouteWithOnlyJavaDSL", null);
+    }
+
+    /**
+     * Ensures that a route template is supported.
+     */
+    public void testRouteTemplate() {
+        doTest("RouteTemplate", null);
     }
 
     /**

--- a/src/test/resources/testData/formatter/after/RouteTemplate.txt
+++ b/src/test/resources/testData/formatter/after/RouteTemplate.txt
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.kamelet;
+
+public class RouteTemplate extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        routeTemplate("template")
+            .templateParameter("v1")
+            .from(kamelet("source"))
+                .setProperty("version", constant("{{version}}"));
+    }
+}

--- a/src/test/resources/testData/formatter/after/RouteWithOnlyJavaDSL.txt
+++ b/src/test/resources/testData/formatter/after/RouteWithOnlyJavaDSL.txt
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Map;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.dataformat.CsvDataFormat;
+
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.direct;
+
+public class RouteWithOnlyJavaDSL extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        CsvDataFormat dataFormat = new CsvDataFormat();
+        dataFormat.setDelimiter("|");
+
+        from(direct("format"))
+            .setBody(constant(Map.of("foo", "abc", "bar", 123)))
+            .marshal(dataFormat);
+
+        from(direct("format"))
+            .setBody(constant(Map.of("foo", "abc", "bar", 123)))
+            .marshal()
+            .csv();
+
+        from(direct("format"))
+            .setBody(constant(Map.of("foo", "abc", "bar", 123)))
+            .marshal(
+                dataFormat()
+                    .csv()
+                    .delimiter(",")
+                .end());
+    }
+}

--- a/src/test/resources/testData/formatter/before/RouteTemplate.java
+++ b/src/test/resources/testData/formatter/before/RouteTemplate.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.kamelet;
+
+public class RouteTemplate extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        routeTemplate("template").templateParameter("v1").from(kamelet("source")).setProperty("version", constant("{{version}}"));
+    }
+}

--- a/src/test/resources/testData/formatter/before/RouteWithOnlyJavaDSL.java
+++ b/src/test/resources/testData/formatter/before/RouteWithOnlyJavaDSL.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Map;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.dataformat.CsvDataFormat;
+
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.direct;
+
+public class RouteWithOnlyJavaDSL extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        CsvDataFormat dataFormat = new CsvDataFormat();
+        dataFormat.setDelimiter("|");
+
+        from(direct("format")).setBody(constant(Map.of("foo", "abc", "bar", 123))).marshal(dataFormat);
+
+        from(direct("format")).setBody(constant(Map.of("foo", "abc", "bar", 123))).marshal().csv();
+
+        from(direct("format")).setBody(constant(Map.of("foo", "abc", "bar", 123))).marshal(dataFormat().csv().delimiter(",").end());
+    }
+}


### PR DESCRIPTION
Fixes #1100

### Motivation

A route beginning with the Java DSL does not get formatted, but the plug-in should format it.

### Modifications

- Include method call expressions when finding the start of a route.

### Results
Example of formatted code:
``` java
  from(direct("format"))
      .setBody(constant(Map.of("foo", "abc", "bar", 123)))
      .marshal(dataFormat);
  
  from(direct("format"))
      .setBody(constant(Map.of("foo", "abc", "bar", 123)))
      .marshal()
      .csv();
  
  from(direct("format"))
      .setBody(constant(Map.of("foo", "abc", "bar", 123)))
      .marshal(
          dataFormat()
              .csv()
              .delimiter(",")
          .end());

  routeTemplate("template")
      .templateParameter("v1")
      .from(kamelet("source"))
          .setProperty("version", constant("{{version}}"));
```