### PR TITLE
Fix YAML Camel file detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,11 +61,11 @@ publishing {
 }
 
 test {
-    addTestListener(new TestListener() {
-        void afterTest(TestDescriptor desc, TestResult result) {
-            logger.quiet "Executing test ${desc.name} [${desc.className}] with result: ${result.resultType}"
-        }
-    })
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = true
+        exceptionFormat = 'full'
+    }
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/java/com/github/cameltooling/idea/service/extension/camel/YamlCamelIdeaUtils.java
+++ b/src/main/java/com/github/cameltooling/idea/service/extension/camel/YamlCamelIdeaUtils.java
@@ -40,7 +40,6 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.yaml.YAMLElementTypes;
-import org.jetbrains.yaml.YAMLFileType;
 import org.jetbrains.yaml.YAMLTokenTypes;
 import org.jetbrains.yaml.psi.YAMLDocument;
 import org.jetbrains.yaml.psi.YAMLFile;
@@ -48,17 +47,21 @@ import org.jetbrains.yaml.psi.YAMLKeyValue;
 import org.jetbrains.yaml.psi.YAMLMapping;
 import org.jetbrains.yaml.psi.YAMLScalar;
 import org.jetbrains.yaml.psi.YAMLSequence;
-import org.jetbrains.yaml.psi.YAMLSequenceItem;
 import org.jetbrains.yaml.psi.YAMLValue;
 
 public class YamlCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtilsExtension {
 
+    /**
+     * Top-level keys of the Camel YAML DSL that mark a file as a Camel file.
+     * {@code templatedRoute} is deliberately omitted: it only instantiates a template
+     * (route template ref + parameters, no steps), so a file containing nothing else
+     * has nothing to validate or debug.
+     */
     private static final List<String> YAML_ROUTES = Arrays.asList(
         "from",
-        "routes",
-        "routeConfigurations",
         "route",
-        "routeConfiguration");
+        "routeConfiguration",
+        "routeTemplate");
     /**
      * All keys representing the potential producers.
      */
@@ -189,35 +192,24 @@ public class YamlCamelIdeaUtils extends CamelIdeaUtils implements CamelIdeaUtils
             return yamlDocuments.stream().anyMatch(document -> {
                 YAMLValue value = document.getTopLevelValue();
 
-                Collection<YAMLKeyValue> keysValues;
-                switch (value) {
-                    case YAMLMapping mapping:
-                        keysValues = mapping.getKeyValues();
-                        break;
-                    case YAMLSequence sequence:
-                        List<YAMLSequenceItem> sequenceItems = sequence.getItems();
-                        if (sequenceItems.isEmpty()) {
-                            return false;
-                        }
-                        YAMLSequenceItem firstItem = sequenceItems.getFirst();
-                        keysValues = firstItem.getKeysValues();
-                        break;
-                    case null, default:
-                        return false;
-                }
-
-                if (keysValues.isEmpty()) {
-                    return false;
-                }
-                YAMLKeyValue firstKeyValue = keysValues.iterator().next();
-                if (firstKeyValue == null) {
-                    return false;
-                }
-                return YAML_ROUTES.contains(firstKeyValue.getKeyText());
+                return switch (value) {
+                    case YAMLMapping mapping -> hasCamelRouteKey(mapping.getKeyValues());
+                    case YAMLSequence sequence -> sequence.getItems().stream()
+                        .anyMatch(item -> hasCamelRouteKey(item.getKeysValues()));
+                    case null, default -> false;
+                };
             });
         }
 
         return false;
+    }
+
+    private static boolean hasCamelRouteKey(Collection<YAMLKeyValue> keysValues) {
+        if (keysValues.isEmpty()) {
+            return false;
+        }
+        YAMLKeyValue firstKeyValue = keysValues.iterator().next();
+        return firstKeyValue != null && YAML_ROUTES.contains(firstKeyValue.getKeyText());
     }
 
     @Override

--- a/src/test/resources/testData/completion/propertyplaceholder/routes.yaml
+++ b/src/test/resources/testData/completion/propertyplaceholder/routes.yaml
@@ -14,28 +14,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ---------------------------------------------------------------------------
-routes:
-  - route:
-      from:
-        uri: "direct:start"
-        steps:
-          - to:
-              uri: "direct:{{prop1}}"
-  - route:
-      from:
-        uri: "file:outbox"
-        steps:
-          - to: file:inbox
-  - rest:
-      get:
-        - path: "/hello"
-          to:
-            uri: "direct:hello"
-        - consumes: "application/json"
-          path: "/bye"
-          to:
-            uri: "direct:bye"
-      post:
-        - path: "/bye"
-          to:
-            uri: "mock:update"
+- route:
+    from:
+      uri: "direct:start"
+      steps:
+        - to:
+            uri: "direct:{{prop1}}"
+- route:
+    from:
+      uri: "file:outbox"
+      steps:
+        - to: file:inbox
+- rest:
+    get:
+      - path: "/hello"
+        to:
+          uri: "direct:hello"
+      - consumes: "application/json"
+        path: "/bye"
+        to:
+          uri: "direct:bye"
+    post:
+      - path: "/bye"
+        to:
+          uri: "mock:update"

--- a/src/test/resources/testData/rename/endpoint/routes.yaml
+++ b/src/test/resources/testData/rename/endpoint/routes.yaml
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ---------------------------------------------------------------------------
-routes:
-  - from:
-      uri: direct:test
-    to:
-      uri: direct:abc
+- from:
+    uri: direct:test
+  to:
+    uri: direct:abc

--- a/src/test/resources/testData/rename/endpoint/routes_after.yaml
+++ b/src/test/resources/testData/rename/endpoint/routes_after.yaml
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ---------------------------------------------------------------------------
-routes:
-  - from:
-      uri: direct:test
-    to:
-      uri: direct:abcNew
+- from:
+    uri: direct:test
+  to:
+    uri: direct:abcNew


### PR DESCRIPTION
### Motivation

Currently, only the first top-level item in a YAML file is checked when determining if it is a Camel file. This causes valid Camel files to go unrecognized (for example, if the first item is not a route), which prevents setting breakpoints anywhere within them.

Furthermore, the list of accepted keys identifying a Camel file (`YAML_ROUTES`) was not fully aligned with the actual Camel YAML DSL top-level keys.

### Modifications

* **Check all top-level items:** Iterates through all top-level items to check for a valid Camel route key, rather than just the first one.
* **Align `YAML_ROUTES` with the actual YAML DSL:**
  * Added `routeTemplate`: Templates deep-copy their steps with source location/line numbers preserved, meaning breakpoints inside them work correctly.
  * Removed `routes` and `routeConfigurations`: These plural forms exist only in the XML DSL; the YAML DSL schema and loader do not accept them.
  * Omitted `templatedRoute` intentionally (documented in a comment in the code), since it only instantiates a template without actual steps.

<!-- Uncomment and fill in if applicable: -->
<!-- **Fixes:** #<issue_number> -->