### PR TITLE
Add JMX-over-Jolokia support to the remote Camel debugger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ dependencies {
     implementation "org.apache.maven.resolver:maven-resolver-impl:${mavenResolverVersion}"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.22.1"
     implementation "io.fabric8:kubernetes-model-apiextensions:7.8.0"
+    implementation "org.jolokia:jolokia-client-jmx-adapter:2.6.0"
     testImplementation "org.apache.camel:camel-core:${camelVersion}"
     testImplementation "org.apache.camel.springboot:camel-spring-boot:${camelVersion}"
     testImplementation "org.apache.camel.springboot:camel-file-starter:${camelVersion}"

--- a/src/main/java/com/github/cameltooling/idea/runner/CamelRemoteRunConfigurationOptions.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/CamelRemoteRunConfigurationOptions.java
@@ -18,13 +18,26 @@ package com.github.cameltooling.idea.runner;
 
 import java.util.Objects;
 
+import com.github.cameltooling.idea.runner.debugger.JmxProtocol;
 import com.intellij.execution.configurations.RunConfigurationOptions;
 import com.intellij.openapi.components.StoredProperty;
 
 public class CamelRemoteRunConfigurationOptions extends RunConfigurationOptions {
 
-    private final StoredProperty<String> host = string("localhost").provideDelegate(this, "host");
-    private final StoredProperty<Integer> port = property(1099).provideDelegate(this, "port");
+    private final StoredProperty<String> host = string("").provideDelegate(this, "host");
+    private final StoredProperty<Integer> port = property(0).provideDelegate(this, "port");
+    private final StoredProperty<JmxProtocol> protocol = doEnum(JmxProtocol.getDefault(), JmxProtocol.class).provideDelegate(this, "protocol");
+
+    /**
+     * Whether the Jolokia endpoint is reached over TLS. Meaningful only when {@link #getProtocol()} is
+     * {@link JmxProtocol#JOLOKIA}; ignored for the other protocols.
+     */
+    private final StoredProperty<Boolean> ssl = property(false).provideDelegate(this, "ssl");
+
+    /**
+     * The user-supplied JMX service URL, meaningful only when {@link #getProtocol()} is {@link JmxProtocol#CUSTOM}.
+     */
+    private final StoredProperty<String> serviceUrl = string("").provideDelegate(this, "serviceUrl");
 
     public String getHost() {
         return host.getValue(this);
@@ -34,12 +47,60 @@ public class CamelRemoteRunConfigurationOptions extends RunConfigurationOptions 
         this.host.setValue(this, host);
     }
 
+    public String getResolvedHost() {
+        String h = getHost();
+        return h == null || h.isEmpty() ? "localhost" : h;
+    }
+
     public Integer getPort() {
         return port.getValue(this);
     }
 
     public void setPort(Integer port) {
         this.port.setValue(this, port);
+    }
+
+    public JmxProtocol getProtocol() {
+        return protocol.getValue(this);
+    }
+
+    public void setProtocol(JmxProtocol protocol) {
+        this.protocol.setValue(this, protocol);
+    }
+
+    public int getResolvedPort() {
+        int p = getPort();
+        return p > 0 ? p : getProtocol().getDefaultPort(isSsl());
+    }
+
+    public boolean isSsl() {
+        return ssl.getValue(this);
+    }
+
+    public void setSsl(boolean ssl) {
+        this.ssl.setValue(this, ssl);
+    }
+
+    public String getServiceUrl() {
+        return serviceUrl.getValue(this);
+    }
+
+    public void setServiceUrl(String serviceUrl) {
+        this.serviceUrl.setValue(this, serviceUrl == null ? "" : serviceUrl);
+    }
+
+    /**
+     * @return {@link #getServiceUrl()} if {@link #getProtocol()} is {@link JmxProtocol#CUSTOM},
+     * otherwise the JMX service URL derived from
+     * {@link #getProtocol()}, {@link #getHost()} and {@link #getPort()}.
+     */
+    public String getEffectiveServiceUrl() {
+        if (getProtocol() != JmxProtocol.CUSTOM) {
+            Boolean useSsl = getProtocol() == JmxProtocol.JOLOKIA ? isSsl() : null;
+            return JmxProtocol.buildServiceUrl(getProtocol(), getResolvedHost(), getResolvedPort(), useSsl);
+        } else {
+            return getServiceUrl();
+        }
     }
 
     @Override
@@ -54,11 +115,15 @@ public class CamelRemoteRunConfigurationOptions extends RunConfigurationOptions 
             return false;
         }
         CamelRemoteRunConfigurationOptions that = (CamelRemoteRunConfigurationOptions) o;
-        return Objects.equals(host, that.host) && Objects.equals(port, that.port);
+        return Objects.equals(host, that.host)
+            && Objects.equals(port, that.port)
+            && Objects.equals(protocol, that.protocol)
+            && Objects.equals(ssl, that.ssl)
+            && Objects.equals(serviceUrl, that.serviceUrl);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), host, port);
+        return Objects.hash(super.hashCode(), host, port, protocol, ssl, serviceUrl);
     }
 }

--- a/src/main/java/com/github/cameltooling/idea/runner/CamelRemoteRunProfileState.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/CamelRemoteRunProfileState.java
@@ -25,7 +25,7 @@ public class CamelRemoteRunProfileState extends RemoteStateState {
     private final CamelRemoteRunConfiguration configuration;
 
     CamelRemoteRunProfileState(Project project, CamelRemoteRunConfiguration configuration) {
-        super(project, new RemoteConnection(true, configuration.getOptions().getHost(), Integer.toString(configuration.getOptions().getPort()), false));
+        super(project, new RemoteConnection(true, configuration.getOptions().getResolvedHost(), Integer.toString(configuration.getOptions().getResolvedPort()), false));
         this.configuration = configuration;
     }
 

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerConnectionException.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerConnectionException.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+import java.net.UnknownHostException;
+
+/**
+ * A failure of a single Camel debugger connection attempt, classified by how it is worth reacting to. The concrete
+ * type carries the <em>nature</em> of the failure; deciding how long and how often to keep retrying is left to the
+ * {@link ConnectionRetryPolicy}.
+ */
+abstract sealed class CamelDebuggerConnectionException extends Exception
+        permits CamelDebuggerConnectionException.Transient,
+                CamelDebuggerConnectionException.Recoverable,
+                CamelDebuggerConnectionException.Permanent {
+
+    private CamelDebuggerConnectionException(String message) {
+        super(message);
+    }
+
+    private CamelDebuggerConnectionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Classifies a connect-time failure. The actual cause is often wrapped several levels deep by the RMI or Jolokia
+     * connector, so the whole cause chain is inspected: an {@link UnknownHostException} (wrong host) or a
+     * {@link SecurityException} (authentication failure) cannot be fixed by retrying and is reported as
+     * {@link Permanent}, while anything else (typically a connection refused because the target is not listening yet)
+     * is assumed to be a {@link Transient} "not up yet" failure.
+     *
+     * @param jmxEndpoint a human-readable description of the JMX endpoint, used in the failure message.
+     * @param failure     the exception raised while trying to obtain the connection.
+     * @return the classified {@link CamelDebuggerConnectionException}.
+     */
+    static CamelDebuggerConnectionException fromConnectFailure(String jmxEndpoint, Exception failure) {
+        for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+            if (cause instanceof UnknownHostException) {
+                return new Permanent("Unknown host for the JMX endpoint " + jmxEndpoint, failure);
+            } else if (cause instanceof SecurityException) {
+                return new Permanent("Authentication failed for the JMX endpoint " + jmxEndpoint, failure);
+            }
+        }
+        return new Transient("Could not connect to the JMX endpoint " + jmxEndpoint, failure);
+    }
+
+    /**
+     * The target could not be reached or is not ready yet (connection refused, or the BacklogDebugger MBean not
+     * registered yet). Retrying is expected to eventually succeed once the debugged application has started up.
+     */
+    static final class Transient extends CamelDebuggerConnectionException {
+        Transient(String message) {
+            super(message);
+        }
+
+        Transient(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        static Transient noBacklogDebuggerMBeanFound(String objectName) {
+            return new Transient("No BacklogDebugger MBean found via " + objectName + ". "
+                    + "Make sure camel-debug, camel-debug-starter or camel-quarkus-debug is on the classpath "
+                    + "of the debugged application and that the Camel Debugger is enabled.");
+        }
+    }
+
+    /**
+     * A connection was successfully established but then lost while initializing the debugger (for instance the
+     * application was restarted or redeployed mid-setup). The stale connection must be dropped and a new one opened.
+     */
+    static final class Recoverable extends CamelDebuggerConnectionException {
+        Recoverable(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /**
+     * The failure cannot possibly be fixed by retrying (wrong host, authentication failure, malformed URL), so there
+     * is no point in keeping the connection attempts going.
+     */
+    static final class Permanent extends CamelDebuggerConnectionException {
+        Permanent(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
@@ -18,7 +18,9 @@ package com.github.cameltooling.idea.runner.debugger;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.github.cameltooling.idea.runner.CamelJBangRunConfiguration;
 import com.github.cameltooling.idea.runner.CamelJBangRunProfileState;
+import com.github.cameltooling.idea.runner.CamelRemoteRunConfiguration;
 import com.github.cameltooling.idea.runner.CamelRemoteRunConfigurationOptions;
 import com.github.cameltooling.idea.runner.CamelRemoteRunProfileState;
 import com.github.cameltooling.idea.runner.debugger.breakpoint.CamelBreakpointHandler;
@@ -67,6 +69,13 @@ public class CamelDebuggerRunner extends GenericDebuggerRunner {
 
     @Override
     public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
+        if (profile instanceof CamelRemoteRunConfiguration || profile instanceof CamelJBangRunConfiguration) {
+            // The plugin's own configurations can only be debugged by this runner (their Run action is either
+            // suppressed or handled elsewhere), so they must not be gated on the Camel project detection and
+            // pre-existing Camel breakpoints used below to decide whether to hijack generic configurations.
+            // Without this, the Debug button stays disabled until at least one Camel breakpoint is set.
+            return executorId.equals(DefaultDebugExecutor.EXECUTOR_ID);
+        }
         if (profile instanceof GradleRunConfiguration) {
             // GradleRunConfiguration must be excluded otherwise it won't be possible to debug a gradle task
             // see https://github.com/camel-tooling/camel-idea-plugin/issues/824

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
@@ -178,12 +178,16 @@ public class CamelDebuggerRunner extends GenericDebuggerRunner {
             throws ExecutionException {
         LOG.debug("Attaching Remote Server...");
         Project project = env.getProject();
-        return XDebuggerManager.getInstance(project).startSession(env, new XDebugProcessStarter() {
-            @NotNull
-            public XDebugProcess start(@NotNull XDebugSession session) {
-                CamelRemoteRunConfigurationOptions options = state.getConfiguration().getOptions();
-                return ContextAwareDebugProcess.createRemoteDebugProcess(session, project, options.getHost(), options.getPort());
-            }
-        }).getRunContentDescriptor();
+        return XDebuggerManager.getInstance(project)
+            .newSessionBuilder(new XDebugProcessStarter() {
+                @NotNull
+                public XDebugProcess start(@NotNull XDebugSession session) {
+                    CamelRemoteRunConfigurationOptions options = state.getConfiguration().getOptions();
+                    return ContextAwareDebugProcess.createRemoteDebugProcess(session, project, options.getHost(), options.getPort());
+                }
+            })
+            .environment(env)
+            .startSession()
+            .getRunContentDescriptor();
     }
 }

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerRunner.java
@@ -192,7 +192,7 @@ public class CamelDebuggerRunner extends GenericDebuggerRunner {
                 @NotNull
                 public XDebugProcess start(@NotNull XDebugSession session) {
                     CamelRemoteRunConfigurationOptions options = state.getConfiguration().getOptions();
-                    return ContextAwareDebugProcess.createRemoteDebugProcess(session, project, options.getHost(), options.getPort());
+                    return ContextAwareDebugProcess.createRemoteDebugProcess(session, project, options.getEffectiveServiceUrl());
                 }
             })
             .environment(env)

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerSession.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerSession.java
@@ -123,47 +123,40 @@ public class CamelDebuggerSession implements AbstractDebuggerSession {
     private volatile String temporaryBreakpointId;
 
     private final XDebugSession xDebugSession;
-    private final String jmxHost;
-    private final int jmxPort;
+    private final String jmxServiceUrl;
 
     /**
      * Strategy deciding how long it is worth retrying a failed connection and what to do once that stops being
      * explainable by the debugged application still starting up, chosen once at construction time depending on
-     * what is actually being watched: a locally launched process, or, in the case of a genuinely remote attach, the
-     * {@link XDebugSession} itself since there is no local process to watch.
+     * what is actually being watched: a locally launched process, or, in the case of a genuinely remote attach,
+     * the {@link XDebugSession} itself since there is no local process to watch.
      */
     private final ConnectionRetryPolicy connectionRetryPolicy;
 
     /**
      * Strategy used to obtain a {@link JMXConnector}, chosen once at construction time
-     * depending on how the debugged
-     * Camel application is being run.
+     * depending on
+     * how the debugged Camel application is being run.
      */
     private final JmxConnectorProvider jmxConnectorProvider;
 
     public CamelDebuggerSession(Project project, XDebugSession session, @NotNull ProcessHandler javaProcessHandler) {
         this.project = project;
         this.xDebugSession = session;
-        this.jmxHost = "localhost";
-        this.jmxPort = 1099;
+        this.jmxServiceUrl = JmxProtocol.buildServiceUrl(JmxProtocol.RMI, "localhost", 1099, null);
         this.connectionRetryPolicy = new ProcessHandlerRetryPolicy(javaProcessHandler, session);
-        JmxConnectorProvider serviceUrlProvider = new ServiceUrlJmxConnectorProvider(getJMXServiceURL());
+        JmxConnectorProvider serviceUrlProvider = new ServiceUrlJmxConnectorProvider(jmxServiceUrl);
         this.jmxConnectorProvider = requiresServiceUrlConnector()
             ? serviceUrlProvider
             : new LocalProcessJmxConnectorProvider(javaProcessHandler, serviceUrlProvider);
     }
 
-    public CamelDebuggerSession(Project project, XDebugSession session, String jmxHost, int jmxPort) {
+    public CamelDebuggerSession(Project project, XDebugSession session, String jmxServiceUrl) {
         this.project = project;
         this.xDebugSession = session;
-        this.jmxHost = jmxHost;
-        this.jmxPort = jmxPort;
+        this.jmxServiceUrl = jmxServiceUrl;
         this.connectionRetryPolicy = new SessionRetryPolicy(session);
-        this.jmxConnectorProvider = new ServiceUrlJmxConnectorProvider(getJMXServiceURL());
-    }
-
-    public String getJMXServiceURL() {
-        return "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi/camel".formatted(jmxHost, jmxPort);
+        this.jmxConnectorProvider = new ServiceUrlJmxConnectorProvider(jmxServiceUrl);
     }
 
     public boolean isConnected() {

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerSession.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerSession.java
@@ -24,9 +24,7 @@ import com.github.cameltooling.idea.runner.debugger.util.DebuggerUtils;
 import com.github.cameltooling.idea.service.CamelRuntime;
 import com.github.cameltooling.idea.util.IdeaUtils;
 import com.github.cameltooling.idea.util.StringUtils;
-import com.intellij.execution.process.OSProcessUtil;
 import com.intellij.execution.process.ProcessHandler;
-import com.intellij.execution.process.ProcessInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ApplicationNamesInfo;
 import com.intellij.openapi.diagnostic.Logger;
@@ -48,7 +46,6 @@ import com.intellij.xdebugger.XExpression;
 import com.intellij.xdebugger.XSourcePosition;
 import com.intellij.xdebugger.breakpoints.XBreakpointProperties;
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint;
-import com.sun.tools.attach.VirtualMachine;
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
 import org.apache.camel.api.management.mbean.ManagedCamelContextMBean;
 import org.jetbrains.annotations.NotNull;
@@ -65,8 +62,6 @@ import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -98,7 +93,6 @@ import static com.github.cameltooling.idea.runner.debugger.CamelDebuggerTarget.M
 public class CamelDebuggerSession implements AbstractDebuggerSession {
     private static final Logger LOG = Logger.getInstance(CamelDebuggerSession.class);
 
-    private static final int MAX_RETRIES = 30;
     private static final String BACKLOG_DEBUGGER_LOGGING_LEVEL = "TRACE";
     private static final long FALLBACK_TIMEOUT = Long.MAX_VALUE - 1;
     private static final String MAIN_RESOURCES_RELATIVE_PATH = "src/main/resources/";
@@ -129,25 +123,43 @@ public class CamelDebuggerSession implements AbstractDebuggerSession {
     private volatile String temporaryBreakpointId;
 
     private final XDebugSession xDebugSession;
-    @Nullable
-    private final ProcessHandler javaProcessHandler;
     private final String jmxHost;
     private final int jmxPort;
+
+    /**
+     * Strategy deciding how long it is worth retrying a failed connection and what to do once that stops being
+     * explainable by the debugged application still starting up, chosen once at construction time depending on
+     * what is actually being watched: a locally launched process, or, in the case of a genuinely remote attach, the
+     * {@link XDebugSession} itself since there is no local process to watch.
+     */
+    private final ConnectionRetryPolicy connectionRetryPolicy;
+
+    /**
+     * Strategy used to obtain a {@link JMXConnector}, chosen once at construction time
+     * depending on how the debugged
+     * Camel application is being run.
+     */
+    private final JmxConnectorProvider jmxConnectorProvider;
 
     public CamelDebuggerSession(Project project, XDebugSession session, @NotNull ProcessHandler javaProcessHandler) {
         this.project = project;
         this.xDebugSession = session;
-        this.javaProcessHandler = javaProcessHandler;
         this.jmxHost = "localhost";
         this.jmxPort = 1099;
+        this.connectionRetryPolicy = new ProcessHandlerRetryPolicy(javaProcessHandler, session);
+        JmxConnectorProvider serviceUrlProvider = new ServiceUrlJmxConnectorProvider(getJMXServiceURL());
+        this.jmxConnectorProvider = requiresServiceUrlConnector()
+            ? serviceUrlProvider
+            : new LocalProcessJmxConnectorProvider(javaProcessHandler, serviceUrlProvider);
     }
 
     public CamelDebuggerSession(Project project, XDebugSession session, String jmxHost, int jmxPort) {
         this.project = project;
         this.xDebugSession = session;
-        this.javaProcessHandler = null;
         this.jmxHost = jmxHost;
         this.jmxPort = jmxPort;
+        this.connectionRetryPolicy = new SessionRetryPolicy(session);
+        this.jmxConnectorProvider = new ServiceUrlJmxConnectorProvider(getJMXServiceURL());
     }
 
     public String getJMXServiceURL() {
@@ -160,7 +172,7 @@ public class CamelDebuggerSession implements AbstractDebuggerSession {
             isConnected = backlogDebugger != null && backlogDebugger.isEnabled();
         } catch (Exception e) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Unable to know if the BacklogDebugger is enabled: {}", e.getMessage());
+                LOG.debug("Could not know if the BacklogDebugger is enabled: {}", e.getMessage());
             }
         }
         return isConnected;
@@ -201,6 +213,21 @@ public class CamelDebuggerSession implements AbstractDebuggerSession {
                 backlogDebugger = null;
             }
         }
+        closeConnector();
+    }
+
+    /**
+     * Drops a half-open or lost connection so that the next attempt starts from scratch, closing the underlying
+     * {@link JMXConnector} without attempting any further remote call on the connection that just failed (unlike
+     * {@link #disconnect()}, which first tries to gracefully detach and disable the debugger).
+     */
+    private void resetConnection() {
+        backlogDebugger = null;
+        debuggerMBeanObjectName = null;
+        closeConnector();
+    }
+
+    private void closeConnector() {
         if (connector != null) {
             try {
                 connector.close();
@@ -483,17 +510,47 @@ public class CamelDebuggerSession implements AbstractDebuggerSession {
     }
 
     /**
-     * Tries to connect to the JMX connector server. In case of failure, it retries every 2 seconds several times, and if
-     * after {@link #MAX_RETRIES}, it still cannot connect, it stops trying.
+     * Tries to connect to the JMX connector server, retrying every 2 seconds
+     * for as long as {@link ConnectionRetryPolicy#canRetry()} says it is still worth it.
+     * Failures within the policy's {@link ConnectionRetryPolicy#gracePeriodAttempts()}
+     * are considered normal (the target may still be starting up) and are only logged at debug level.
+     * Every failure past that grace period is reported to {@link ConnectionRetryPolicy#onGracePeriodExceeded(int, String)},
+     * which decides how often that is actually surfaced to the user.
      *
      * @return {@code true} if it could connect to the JMX connector server, {@code false} otherwise.
      */
     private boolean tryToConnect() {
-        for (int i = 0; i < MAX_RETRIES && canConnect(); i++) {
+        int consecutiveFailedAttempts = 0;
+        while (connectionRetryPolicy.canRetry()) {
             LOG.debug("Trying to connect to the JMX connector server");
-            if (doConnect()) {
+            try {
+                doConnect();
                 LOG.debug("Connected with success to the JMX connector server");
                 return true;
+            } catch (CamelDebuggerConnectionException failure) {
+                switch (failure) {
+                    case CamelDebuggerConnectionException.Permanent e -> {
+                        // Retrying cannot help: surface the failure and give up for good.
+                        connectionRetryPolicy.onPermanentFailure(e.getMessage());
+                        return false;
+                    }
+                    case CamelDebuggerConnectionException.Recoverable e -> {
+                        // A connection was established but then lost: drop the stale one before reconnecting.
+                        LOG.warn("Lost the connection while initializing the Camel Debugger, reconnecting", e);
+                        resetConnection();
+                        consecutiveFailedAttempts++;
+                        if (consecutiveFailedAttempts >= connectionRetryPolicy.gracePeriodAttempts()) {
+                            connectionRetryPolicy.onGracePeriodExceeded(consecutiveFailedAttempts, e.getMessage());
+                        }
+                    }
+                    case CamelDebuggerConnectionException.Transient e -> {
+                        // The target may still be starting up: keep retrying, patiently within the grace period.
+                        consecutiveFailedAttempts++;
+                        if (consecutiveFailedAttempts >= connectionRetryPolicy.gracePeriodAttempts()) {
+                            connectionRetryPolicy.onGracePeriodExceeded(consecutiveFailedAttempts, e.getMessage());
+                        }
+                    }
+                }
             }
             try {
                 Thread.sleep(1000L * 2);
@@ -505,164 +562,109 @@ public class CamelDebuggerSession implements AbstractDebuggerSession {
         return false;
     }
 
-    private boolean canConnect() {
-        if (javaProcessHandler == null) {
-            return !xDebugSession.isStopped();
-        }
-        return !javaProcessHandler.isProcessTerminated() && !javaProcessHandler.isProcessTerminating();
-    }
-
-    private boolean doConnect() {
+    /**
+     * Performs a single connection attempt to the JMX connector server and initializes the debugger.
+     *
+     * @throws CamelDebuggerConnectionException classifying the failure so the caller can decide whether, and how
+     *                                          patiently, it is worth retrying.
+     */
+    private void doConnect() throws CamelDebuggerConnectionException {
         final ClassLoader current = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(ClasspathUtils.getProjectClassLoader(project, this.getClass().getClassLoader()));
 
-            this.connector = getJMXConnector();
-            if (connector == null) {
-                return false;
-            } else {
-                this.serverConnection = connector.getMBeanServerConnection();
-            }
+            this.connector = jmxConnectorProvider.getJMXConnector();
+            this.serverConnection = connector.getMBeanServerConnection();
             //init debugger
             // org.apache.camel:context=camel-1,type=tracer,name=BacklogDebugger
             ObjectName objectName = new ObjectName("org.apache.camel:context=*,type=tracer,name=BacklogDebugger");
 
             Set<ObjectName> names = serverConnection.queryNames(objectName, null);
+            if (names == null || names.isEmpty()) {
+                // The connection is healthy but the MBean is not there: it may simply not be registered yet, or the
+                // Camel Debugger may be missing altogether. The two cannot be told apart at a single point in time,
+                // so this is treated as transient and left to the retry policy to eventually give up on.
+                throw CamelDebuggerConnectionException.Transient.noBacklogDebuggerMBeanFound(objectName.toString());
+            }
+            this.debuggerMBeanObjectName = names.iterator().next();
+            backlogDebugger = JMX.newMBeanProxy(serverConnection, debuggerMBeanObjectName, ManagedBacklogDebuggerMBean.class);
+            backlogDebugger.enableDebugger();
+            backlogDebugger.setLoggingLevel(BACKLOG_DEBUGGER_LOGGING_LEVEL); //By default it's INFO and a bit too noisy
+            backlogDebugger.setFallbackTimeout(FALLBACK_TIMEOUT);
+            //Lookup camel context
+            objectName = new ObjectName("org.apache.camel:context=*,type=context,name=*");
+            names = serverConnection.queryNames(objectName, null);
             if (names != null && !names.isEmpty()) {
-                this.debuggerMBeanObjectName = names.iterator().next();
-                backlogDebugger = JMX.newMBeanProxy(serverConnection, debuggerMBeanObjectName, ManagedBacklogDebuggerMBean.class);
-                backlogDebugger.enableDebugger();
-                backlogDebugger.setLoggingLevel(BACKLOG_DEBUGGER_LOGGING_LEVEL); //By default it's INFO and a bit too noisy
-                backlogDebugger.setFallbackTimeout(FALLBACK_TIMEOUT);
-                //Lookup camel context
-                objectName = new ObjectName("org.apache.camel:context=*,type=context,name=*");
-                names = serverConnection.queryNames(objectName, null);
-                if (names != null && !names.isEmpty()) {
-                    ObjectName mbeanName = names.iterator().next();
-                    ManagedCamelContextMBean camelContext = JMX.newMBeanProxy(serverConnection, mbeanName, ManagedCamelContextMBean.class);
+                ObjectName mbeanName = names.iterator().next();
+                ManagedCamelContextMBean camelContext = JMX.newMBeanProxy(serverConnection, mbeanName, ManagedCamelContextMBean.class);
 
-                    while (!"Started".equals(camelContext.getState())) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Waiting for the context to start");
-                        }
-                        Thread.onSpinWait();
+                while (!"Started".equals(camelContext.getState())) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Waiting for the context to start");
                     }
-
-                    //Init DOM Documents
-                    String routes = camelContext.dumpRoutesAsXml(false);
-                    DocumentBuilder documentBuilder = DebuggerUtils.createDocumentBuilder();
-                    InputStream targetStream = new ByteArrayInputStream(routes.getBytes());
-                    this.routesDOMDocument = documentBuilder.parse(targetStream);
-
-                    //TODO get list of loaded expression languages
-
+                    Thread.onSpinWait();
                 }
 
-                //Toggle all pending breakpoints
-                for (XLineBreakpoint<XBreakpointProperties<?>> breakpoint : breakpointsRemove) {
-                    ApplicationManager.getApplication().runReadAction(() -> {
-                        try {
-                            toggleBreakpoint(breakpoint, false);
-                        } catch (Exception e) {
-                            LOG.error(e);
-                        }
-                    });
-                }
-                for (XLineBreakpoint<XBreakpointProperties<?>> breakpoint : breakpointsAdd) {
-                    ApplicationManager.getApplication().runReadAction(() -> {
-                        try {
-                            toggleBreakpoint(breakpoint, true);
-                        } catch (Exception e) {
-                            LOG.error(e);
-                        }
-                    });
-                }
-                try {
-                    backlogDebugger.attach();
-                } catch (Exception e) {
-                    LOG.warn("Could not attach the debugger: " + e.getMessage());
-                }
-                return true;
+                //Init DOM Documents
+                String routes = camelContext.dumpRoutesAsXml(false);
+                DocumentBuilder documentBuilder = DebuggerUtils.createDocumentBuilder();
+                InputStream targetStream = new ByteArrayInputStream(routes.getBytes());
+                this.routesDOMDocument = documentBuilder.parse(targetStream);
+
+                //TODO get list of loaded expression languages
+
             }
-            return false;
+
+            //Toggle all pending breakpoints
+            for (XLineBreakpoint<XBreakpointProperties<?>> breakpoint : breakpointsRemove) {
+                ApplicationManager.getApplication().runReadAction(() -> {
+                    try {
+                        toggleBreakpoint(breakpoint, false);
+                    } catch (Exception e) {
+                        LOG.error(e);
+                    }
+                });
+            }
+            for (XLineBreakpoint<XBreakpointProperties<?>> breakpoint : breakpointsAdd) {
+                ApplicationManager.getApplication().runReadAction(() -> {
+                    try {
+                        toggleBreakpoint(breakpoint, true);
+                    } catch (Exception e) {
+                        LOG.error(e);
+                    }
+                });
+            }
+            // Best-effort: attach() is a no-op unless the target runs in suspend mode, and the debugger itself is
+            // already enabled above, so a failure here must not tear down an otherwise working connection.
+            // Caveat: if the target IS in suspend mode, a failed attach() leaves the application holding all
+            // messages until a debugger attaches, which this swallow does not recover from.
+            try {
+                backlogDebugger.attach();
+            } catch (Exception e) {
+                LOG.warn("Could not attach the debugger: " + e.getMessage());
+            }
+        } catch (CamelDebuggerConnectionException e) {
+            throw e; // Already classified (from the connector provider or the missing MBean): do not re-wrap it.
         } catch (Exception e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Could not initialize the BackLogDebugger", e);
-            }
-            return false;
+            // The JMX handshake had succeeded, so a failure here means the connection was established and then lost
+            // while setting the debugger up (e.g. the application was restarted or redeployed): recoverable.
+            throw new CamelDebuggerConnectionException.Recoverable("Could not initialize the BacklogDebugger: " + e.getMessage(), e);
         } finally {
             Thread.currentThread().setContextClassLoader(current);
         }
     }
 
     /**
-     * @return the {@link JMXConnector} corresponding to the Java process. In case the process id
-     * cannot be found, it calls {@link #getJMXConnectorFromServiceURL()} as fallback.
-     */
-    private JMXConnector getJMXConnectorFromLocalJavaProcess() {
-        final String javaProcessPID = getPID(javaProcessHandler);
-        if (javaProcessPID == null) {
-            return getJMXConnectorFromServiceURL();
-        }
-        try {
-            final VirtualMachine vm = VirtualMachine.attach(javaProcessPID);
-            vm.startLocalManagementAgent();
-            final String connectorAddress = vm.getAgentProperties().getProperty("com.sun.management.jmxremote.localConnectorAddress");
-            vm.detach();
-            return JMXConnectorFactory.connect(new JMXServiceURL(connectorAddress));
-        } catch (Exception e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Could not retrieve the JMX API connector of the java process " + javaProcessPID, e);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * @return the {@link JMXConnector} that matches the best with the current context.
-     */
-    private JMXConnector getJMXConnector() {
-        if (remoteAccess()) {
-            return getJMXConnectorFromServiceURL();
-        }
-        return getJMXConnectorFromLocalJavaProcess();
-    }
-
-    /**
-     * Indicates whether the {@link JMXConnector} should be built from a JMX Service URL.
+     * Indicates whether the {@link JMXConnector} must be built from a JMX Service URL rather than from a local
+     * process id attach.
      *
-     * @return {@code true} if it is a remote access, {@code false} otherwise.
+     * @return {@code true} if it is a forked or remote process, {@code false} otherwise.
      */
-    private boolean remoteAccess() {
+    private boolean requiresServiceUrlConnector() {
         // In case of Quarkus and Camel SpringBoot 4, the application runs in a forked process such
         // that the JMXConnector needs to be retrieved from a URL corresponding to a remote process
         CamelRuntime camelRuntime = CamelRuntime.getCamelRuntime(project);
         return camelRuntime == CamelRuntime.QUARKUS || camelRuntime == CamelRuntime.SPRING_BOOT;
-    }
-
-    @Nullable
-    private JMXConnector getJMXConnectorFromServiceURL() {
-        try {
-            return JMXConnectorFactory.connect(new JMXServiceURL(getJMXServiceURL()));
-        } catch (Exception e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Could not retrieve the JMX API connector", e);
-            }
-        }
-        return null;
-    }
-
-    private static String getPID(ProcessHandler handler) {
-        if (handler == null) {
-            return null;
-        }
-        String cmdLine = handler.toString();
-        for (ProcessInfo info : OSProcessUtil.getProcessList()) {
-            if (info.getCommandLine().equals(cmdLine)) {
-                return String.valueOf(info.getPid());
-            }
-        }
-        return null;
     }
 
     private boolean toggleBreakpoint(@NotNull XLineBreakpoint<XBreakpointProperties<?>> xBreakpoint, boolean toggleOn) {

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/ConnectionRetryPolicy.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/ConnectionRetryPolicy.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+import com.intellij.execution.ui.ConsoleView;
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.xdebugger.XDebugSession;
+
+/**
+ * Strategy deciding, for a {@link CamelDebuggerSession}, how long it is worth retrying a failed JMX connection
+ * attempt and what should happen once that becomes a real problem rather than the debugged application still
+ * starting up.
+ */
+interface ConnectionRetryPolicy {
+
+    /**
+     * @return {@code true} if a (re)connection attempt is still worth trying right now, {@code false} once there is
+     * definitely nothing left to connect to (the local process ended, or the debug session was stopped).
+     */
+    boolean canRetry();
+
+    /**
+     * @return the number of consecutive failed attempts still considered a normal "the target is still starting up"
+     * grace period, during which failures are expected and only logged at debug level.
+     */
+    int gracePeriodAttempts();
+
+    /**
+     * Called every time a connection attempt fails once {@code consecutiveFailedAttempts} has reached
+     * {@link #gracePeriodAttempts()}, i.e. as soon as, and for as long as, a failure stops being explainable by the
+     * target still starting up. It is up to the implementation to decide how often that is actually surfaced to the
+     * user (e.g. once only, or as a periodic reminder while retrying keeps failing) so that a persistent problem
+     * cannot go unnoticed for the rest of the session, without spamming on every single failed attempt.
+     *
+     * @param consecutiveFailedAttempts the total number of consecutive failed attempts so far, always
+     *                                  {@code >= gracePeriodAttempts()}.
+     * @param reason                    a human-readable explanation of the last failure.
+     */
+    void onGracePeriodExceeded(int consecutiveFailedAttempts, String reason);
+
+    /**
+     * Called when a connection attempt fails with a permanent error that retrying cannot possibly fix (wrong host,
+     * authentication failure, malformed URL). The connection attempts are given up right after this call, so the
+     * implementation must make sure the failure is surfaced to the user, unconditionally rather than only every so
+     * often like {@link #onGracePeriodExceeded(int, String)} may do.
+     *
+     * @param reason a human-readable explanation of the failure.
+     */
+    void onPermanentFailure(String reason);
+
+    /**
+     * Reports a connection failure both as the usual balloon notification ({@link XDebugSession#reportError(String)})
+     * and, when available, as a line in the Console tab of the Debug tool window, so the failure remains visible
+     * after the balloon disappears rather than only for the few seconds it is shown.
+     */
+    static void reportError(XDebugSession xDebugSession, String reason) {
+        xDebugSession.reportError(reason);
+        if (xDebugSession.getConsoleView() instanceof ConsoleView consoleView) {
+            consoleView.print(reason + "\n", ConsoleViewContentType.ERROR_OUTPUT);
+        }
+    }
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/ContextAwareDebugProcess.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/ContextAwareDebugProcess.java
@@ -227,11 +227,11 @@ public final class ContextAwareDebugProcess extends XDebugProcess {
     }
 
     @NotNull
-    static XDebugProcess createRemoteDebugProcess(@NotNull XDebugSession session, Project project, String jmxHost, int jmxPort) {
+    static XDebugProcess createRemoteDebugProcess(@NotNull XDebugSession session, Project project, String jmxServiceUrl) {
         final Map<CamelDebuggerContext, XDebugProcess> context = new EnumMap<>(CamelDebuggerContext.class);
         final ContextAwareDebugProcess contextAwareDebugProcess = new ContextAwareDebugProcess(session, null, context, CAMEL);
 
-        final CamelDebuggerSession camelDebuggerSession = new CamelDebuggerSession(project, session, jmxHost, jmxPort);
+        final CamelDebuggerSession camelDebuggerSession = new CamelDebuggerSession(project, session, jmxServiceUrl);
         camelDebuggerSession.addMessageReceivedListener(messages -> contextAwareDebugProcess.setContext(CAMEL));
 
         //Init Camel Debug Process

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/JmxConnectorProvider.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/JmxConnectorProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.management.remote.JMXConnector;
+
+/**
+ * Strategy for obtaining a {@link JMXConnector} to the JMX endpoint exposing the Camel Debugger.
+ * <p/>
+ * How a connector can be obtained differs depending on how the debugged Camel application is being run: a directly
+ * launched local process can be attached to by its process id, while a genuinely remote process, or a process forked
+ * by the IDE (such as Camel Quarkus or Camel Spring Boot), can only be reached through a JMX service URL.
+ */
+interface JmxConnectorProvider {
+
+    /**
+     * @return a connected {@link JMXConnector}.
+     * @throws CamelDebuggerConnectionException if the connector could not be obtained, classified so the caller can
+     *                                          decide whether it is worth retrying.
+     */
+    @NotNull
+    JMXConnector getJMXConnector() throws CamelDebuggerConnectionException;
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/JmxProtocol.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/JmxProtocol.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+/**
+ * The transport used to reach the JMX endpoint exposing the Camel Debugger of a remote (or forked) Camel process.
+ */
+public enum JmxProtocol {
+
+    /**
+     * The traditional JMX over RMI registry, as exposed by {@code -Dcom.sun.management.jmxremote} or Spring
+     * Boot/Quarkus dev-mode JMX registries.
+     */
+    RMI,
+    /**
+     * JMX tunneled over the Jolokia HTTP agent (e.g. exposed by {@code camel-management-jolokia} or the Spring Boot
+     * Actuator Jolokia endpoint), useful whenever the RMI registry port cannot be reached (containers, firewalls).
+     */
+    JOLOKIA,
+    /**
+     * Custom protocol.
+     */
+    CUSTOM;
+
+    /**
+      * @param protocol chosen protocol.
+      * @param host the host of the JMX endpoint.
+      * @param port the port of the JMX endpoint.
+      * @param useSsl whether the endpoint is reached over TLS. Only meaningful for {@link #JOLOKIA}, for which it must
+      *               be non-{@code null}; for {@link #RMI} and {@link #CUSTOM} it must be {@code null}, since SSL is
+      *               either configured differently (RMI) or already encoded in the user-supplied URL (CUSTOM).
+      * @return the JMX service URL corresponding to this protocol for the given host/port, or {@code null} for
+      *         {@link #CUSTOM} (whose URL is supplied by the user).
+      * @throws IllegalArgumentException if {@code useSsl} does not match the given protocol.
+     */
+    public static String buildServiceUrl(JmxProtocol protocol, String host, int port, Boolean useSsl) {
+        return switch (protocol) {
+            case RMI -> {
+                requireSslUnset(protocol, useSsl);
+                yield "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi/camel".formatted(host, port);
+            }
+            case JOLOKIA -> {
+                if (useSsl == null) {
+                    throw new IllegalArgumentException("useSsl must be specified for the JOLOKIA protocol");
+                }
+                // Emit the explicit RFC 2609 scheme so the Jolokia agent never falls back to its port-based
+                // https heuristic (a port ending in 443 would otherwise silently force TLS).
+                yield "service:jmx:jolokia+%s://%s:%d/jolokia/".formatted(useSsl ? "https" : "http", host, port);
+            }
+            case CUSTOM -> {
+                requireSslUnset(protocol, useSsl);
+                yield null;
+            }
+        };
+    }
+
+    private static void requireSslUnset(JmxProtocol protocol, Boolean useSsl) {
+        if (useSsl != null) {
+            throw new IllegalArgumentException("useSsl is only applicable to the JOLOKIA protocol, not " + protocol);
+        }
+    }
+
+    public static JmxProtocol getDefault() {
+        return JmxProtocol.RMI;
+    }
+
+    // useSsl is unused today (Jolokia's default port is 8778 regardless of TLS) but is kept in the signature
+    // for API symmetry with buildServiceUrl(), in case a future Jolokia deployment convention differs by scheme.
+    public int getDefaultPort(@SuppressWarnings("unused") Boolean useSsl) {
+        return switch (this) {
+            case RMI     -> 1099;
+            case JOLOKIA -> 8778;
+            case CUSTOM  -> 0;
+        };
+    }
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/LocalProcessJmxConnectorProvider.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/LocalProcessJmxConnectorProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+import com.intellij.execution.process.OSProcessUtil;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessInfo;
+import com.sun.tools.attach.VirtualMachine;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+/**
+ * {@link JmxConnectorProvider} that attaches to the local java process corresponding to the given
+ * {@link ProcessHandler} by its process id. In case the process id cannot be found, it falls back to the given
+ * {@code fallback} provider.
+ */
+class LocalProcessJmxConnectorProvider implements JmxConnectorProvider {
+
+    private final ProcessHandler javaProcessHandler;
+    private final JmxConnectorProvider fallback;
+
+    LocalProcessJmxConnectorProvider(@NotNull ProcessHandler javaProcessHandler, JmxConnectorProvider fallback) {
+        this.javaProcessHandler = javaProcessHandler;
+        this.fallback = fallback;
+    }
+
+    @NotNull
+    @Override
+    public JMXConnector getJMXConnector() throws CamelDebuggerConnectionException {
+        String javaProcessPID = getPID(javaProcessHandler);
+        if (javaProcessPID == null) {
+            return fallback.getJMXConnector();
+        }
+        try {
+            VirtualMachine vm = VirtualMachine.attach(javaProcessPID);
+            vm.startLocalManagementAgent();
+            String connectorAddress = vm.getAgentProperties().getProperty("com.sun.management.jmxremote.localConnectorAddress");
+            vm.detach();
+            return JMXConnectorFactory.connect(new JMXServiceURL(connectorAddress));
+        } catch (Exception e) {
+            throw CamelDebuggerConnectionException.fromConnectFailure("local process " + javaProcessPID, e);
+        }
+    }
+
+    @Nullable
+    private static String getPID(ProcessHandler handler) {
+        String cmdLine = handler.toString();
+        for (ProcessInfo info : OSProcessUtil.getProcessList()) {
+            if (info.getCommandLine().equals(cmdLine)) {
+                return String.valueOf(info.getPid());
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/ProcessHandlerRetryPolicy.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/ProcessHandlerRetryPolicy.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.xdebugger.XDebugSession;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * {@link ConnectionRetryPolicy} used when the debugged application was launched by the IDE and is therefore watched
+ * through its {@link ProcessHandler} (whether the JMX connector itself is then obtained from the local process id or
+ * from a service URL, in case of a process forked by a build tool such as Camel Quarkus or Camel Spring Boot).
+ * <p/>
+ * There is no network involved here (a local process id attach, or a service URL pointing at localhost for a
+ * forked process), so a connection failure is never a network availability problem. It is instead either the Camel
+ * context simply not being started yet, which a generous grace period accounts for, or, once that grace period is
+ * exceeded, most likely a persistent, real problem such as the Camel Debugger component (camel-debug,
+ * camel-debug-starter or camel-quarkus-debug) missing from the debugged application. Since the process is still
+ * running, retrying continues in the background past the grace period, in case it was actually still starting up
+ * after all, but the failure is reported again every {@link #REMINDER_INTERVAL_ATTEMPTS} attempts so that a
+ * persistent problem cannot silently go unnoticed for the rest of the session.
+ */
+class ProcessHandlerRetryPolicy implements ConnectionRetryPolicy {
+
+    private static final Logger LOG = Logger.getInstance(ProcessHandlerRetryPolicy.class);
+
+    /**
+     * At the usual 2-second interval between attempts, this gives the debugged application about a minute to start
+     * up before a failure is considered worth reporting.
+     */
+    private static final int GRACE_PERIOD_ATTEMPTS = 30;
+
+    /**
+     * Once past the grace period, remind the user about the persisting failure about this often, roughly every
+     * minute at the usual 2-second retry interval, instead of only once for the whole session.
+     */
+    private static final int REMINDER_INTERVAL_ATTEMPTS = 30;
+
+    private final ProcessHandler javaProcessHandler;
+    private final XDebugSession xDebugSession;
+
+    ProcessHandlerRetryPolicy(@NotNull ProcessHandler javaProcessHandler, XDebugSession xDebugSession) {
+        this.javaProcessHandler = javaProcessHandler;
+        this.xDebugSession = xDebugSession;
+    }
+
+    @Override
+    public boolean canRetry() {
+        return !javaProcessHandler.isProcessTerminated() && !javaProcessHandler.isProcessTerminating();
+    }
+
+    @Override
+    public int gracePeriodAttempts() {
+        return GRACE_PERIOD_ATTEMPTS;
+    }
+
+    @Override
+    public void onGracePeriodExceeded(int consecutiveFailedAttempts, String reason) {
+        int attemptsPastGracePeriod = consecutiveFailedAttempts - GRACE_PERIOD_ATTEMPTS;
+        if (attemptsPastGracePeriod % REMINDER_INTERVAL_ATTEMPTS == 0) {
+            LOG.warn(reason);
+            xDebugSession.reportError(reason);
+        }
+        // The local process is still running: keep retrying in the background, it might still catch up.
+    }
+
+    @Override
+    public void onPermanentFailure(String reason) {
+        LOG.warn(reason);
+        ConnectionRetryPolicy.reportError(xDebugSession, reason);
+        // Giving up on the polling is done by the caller; the local process itself is left running.
+    }
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/ProcessHandlerRetryPolicy.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/ProcessHandlerRetryPolicy.java
@@ -74,7 +74,7 @@ class ProcessHandlerRetryPolicy implements ConnectionRetryPolicy {
         int attemptsPastGracePeriod = consecutiveFailedAttempts - GRACE_PERIOD_ATTEMPTS;
         if (attemptsPastGracePeriod % REMINDER_INTERVAL_ATTEMPTS == 0) {
             LOG.warn(reason);
-            xDebugSession.reportError(reason);
+            ConnectionRetryPolicy.reportError(xDebugSession, reason);
         }
         // The local process is still running: keep retrying in the background, it might still catch up.
     }

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/ServiceUrlJmxConnectorProvider.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/ServiceUrlJmxConnectorProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+/**
+ * {@link JmxConnectorProvider} that always connects through a fixed JMX service URL. Used both for a genuinely
+ * remote Camel process and for a process forked by the IDE (Camel Quarkus, Camel Spring Boot), for which a local
+ * process id attach is not applicable.
+ */
+class ServiceUrlJmxConnectorProvider implements JmxConnectorProvider {
+
+    private final String serviceUrl;
+
+    ServiceUrlJmxConnectorProvider(String serviceUrl) {
+        this.serviceUrl = serviceUrl;
+    }
+
+    @NotNull
+    @Override
+    public JMXConnector getJMXConnector() throws CamelDebuggerConnectionException {
+        try {
+            return JMXConnectorFactory.connect(new JMXServiceURL(serviceUrl));
+        } catch (Exception e) {
+            throw CamelDebuggerConnectionException.fromConnectFailure(serviceUrl, e);
+        }
+    }
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/SessionRetryPolicy.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/SessionRetryPolicy.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.xdebugger.XDebugSession;
+
+/**
+ * {@link ConnectionRetryPolicy} used when attaching to a genuinely remote, already running Camel process (a
+ * dedicated "Camel Remote" run configuration, with no local {@link com.intellij.execution.process.ProcessHandler} to
+ * watch).
+ * <p/>
+ * Unlike a process launched by the IDE, there is no legitimate "still starting up" phase to wait out here: the
+ * target is assumed to already be running, so this mirrors the behavior of the built-in "Remote JVM Debug" run
+ * configuration, which does not retry either — a single failed attempt is treated as a real, most likely permanent
+ * problem (wrong host/port, unreachable network, or the Camel Debugger not being enabled on the target), and the
+ * debug session is stopped rather than left polling forever.
+ */
+class SessionRetryPolicy implements ConnectionRetryPolicy {
+
+    private static final Logger LOG = Logger.getInstance(SessionRetryPolicy.class);
+
+    private static final int GRACE_PERIOD_ATTEMPTS = 1;
+
+    private final XDebugSession xDebugSession;
+
+    SessionRetryPolicy(XDebugSession xDebugSession) {
+        this.xDebugSession = xDebugSession;
+    }
+
+    @Override
+    public boolean canRetry() {
+        return !xDebugSession.isStopped();
+    }
+
+    @Override
+    public int gracePeriodAttempts() {
+        return GRACE_PERIOD_ATTEMPTS;
+    }
+
+    @Override
+    public void onGracePeriodExceeded(int consecutiveFailedAttempts, String reason) {
+        // Stopping the session makes canRetry() return false right after, so this only ever runs once.
+        LOG.warn(reason);
+        xDebugSession.reportError(reason);
+        xDebugSession.stop();
+    }
+
+    @Override
+    public void onPermanentFailure(String reason) {
+        // Same as giving up after the (single) grace attempt: report the failure and stop the session.
+        onGracePeriodExceeded(0, reason);
+    }
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/SessionRetryPolicy.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/SessionRetryPolicy.java
@@ -56,7 +56,7 @@ class SessionRetryPolicy implements ConnectionRetryPolicy {
     public void onGracePeriodExceeded(int consecutiveFailedAttempts, String reason) {
         // Stopping the session makes canRetry() return false right after, so this only ever runs once.
         LOG.warn(reason);
-        xDebugSession.reportError(reason);
+        ConnectionRetryPolicy.reportError(xDebugSession, reason);
         xDebugSession.stop();
     }
 

--- a/src/main/java/com/github/cameltooling/idea/runner/ui/CamelRemoteRunnerConfPanel.form
+++ b/src/main/java/com/github/cameltooling/idea/runner/ui/CamelRemoteRunnerConfPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.github.cameltooling.idea.runner.ui.CamelRemoteRunnerConfPanel">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="9154b" binding="panel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -8,45 +8,116 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="29ed1" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="a295b" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children>
-          <component id="bb4b0" class="com.intellij.openapi.ui.LabeledComponent" binding="hostComponent">
+          <component id="cef2c" class="javax.swing.JRadioButton" binding="rmiRadioButton">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="1" use-parent-layout="false">
-                <preferred-size width="350" height="-1"/>
-              </grid>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <componentClass value="com.intellij.ui.EditorTextField"/>
-              <labelLocation value="West"/>
-              <text value="Host"/>
+              <text value="RMI"/>
             </properties>
           </component>
-          <component id="65567" class="com.intellij.openapi.ui.LabeledComponent" binding="portComponent">
+          <component id="f8322" class="javax.swing.JRadioButton" binding="jolokiaRadioButton" default-binding="true">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="8" fill="0" indent="1" use-parent-layout="false">
-                <preferred-size width="90" height="-1"/>
-              </grid>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <componentClass value="com.intellij.ui.EditorTextField"/>
-              <labelLocation value="West"/>
-              <text value="Port"/>
+              <text value="Jolokia"/>
             </properties>
           </component>
         </children>
       </grid>
+      <grid id="a4c96" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="a58da" class="com.intellij.openapi.ui.LabeledComponent" binding="hostComponent">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <componentClass value="com.intellij.ui.components.JBTextField"/>
+              <labelLocation value="West"/>
+              <text value="Host"/>
+            </properties>
+          </component>
+          <component id="3fbc9" class="com.intellij.openapi.ui.LabeledComponent" binding="portComponent">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="4" fill="0" indent="0" use-parent-layout="false">
+                <minimum-size width="80" height="-1"/>
+                <preferred-size width="100" height="-1"/>
+                <maximum-size width="100" height="-1"/>
+              </grid>
+            </constraints>
+            <properties>
+              <componentClass value="com.intellij.ui.components.JBTextField"/>
+              <labelLocation value="West"/>
+              <text value="Port"/>
+            </properties>
+          </component>
+          <grid id="c7e3f" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                <preferred-size width="120" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="bde15" class="javax.swing.JCheckBox" binding="sslCheckBox">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Use SSL/TLS"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
+        </children>
+      </grid>
+      <component id="71f32" class="javax.swing.JRadioButton" binding="customRadioButton" default-binding="true">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Custom"/>
+        </properties>
+      </component>
+      <component id="ddf98" class="com.intellij.openapi.ui.LabeledComponent" binding="serviceUrlComponent">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <componentClass value="com.intellij.ui.components.JBTextField"/>
+          <labelLocation value="West"/>
+          <text value="JMX Service URL"/>
+        </properties>
+      </component>
       <vspacer id="6bf4f">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
     </children>
   </grid>
+  <buttonGroups>
+    <group name="protocolGroup">
+      <member id="cef2c"/>
+      <member id="f8322"/>
+      <member id="71f32"/>
+    </group>
+  </buttonGroups>
 </form>

--- a/src/main/java/com/github/cameltooling/idea/runner/ui/CamelRemoteRunnerConfPanel.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/ui/CamelRemoteRunnerConfPanel.java
@@ -16,28 +16,123 @@
  */
 package com.github.cameltooling.idea.runner.ui;
 
-import java.awt.Dimension;
-
+import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.event.DocumentEvent;
 
 import com.github.cameltooling.idea.runner.CamelRemoteRunConfiguration;
 import com.github.cameltooling.idea.runner.CamelRemoteRunConfigurationOptions;
+import com.github.cameltooling.idea.runner.debugger.JmxProtocol;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.ui.LabeledComponent;
-import com.intellij.ui.EditorTextField;
+import com.intellij.ui.DocumentAdapter;
 import com.intellij.ui.PanelWithAnchor;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.ui.components.TextComponentEmptyText;
+import com.intellij.util.BooleanFunction;
 import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class CamelRemoteRunnerConfPanel implements PanelWithAnchor {
+
     protected JPanel panel;
     protected JComponent anchor;
-    protected LabeledComponent<EditorTextField> hostComponent;
-    protected LabeledComponent<EditorTextField> portComponent;
+    protected LabeledComponent<JBTextField> hostComponent;
+    protected LabeledComponent<JBTextField> portComponent;
+    protected JRadioButton rmiRadioButton;
+    protected JRadioButton jolokiaRadioButton;
+    protected JRadioButton customRadioButton;
+    protected JCheckBox sslCheckBox;
+    protected LabeledComponent<JBTextField> serviceUrlComponent;
+
+    private JmxProtocol selectedProtocol = JmxProtocol.getDefault();
+    private boolean lastSslState = false;
+    private String lastCustomUrl = "";
 
     public CamelRemoteRunnerConfPanel() {
         this.anchor = UIUtil.mergeComponentsWithAnchor(hostComponent, portComponent);
+
+        rmiRadioButton.addActionListener(e -> onProtocolModeChanged(JmxProtocol.RMI));
+        jolokiaRadioButton.addActionListener(e -> onProtocolModeChanged(JmxProtocol.JOLOKIA));
+        customRadioButton.addActionListener(e -> onProtocolModeChanged(JmxProtocol.CUSTOM));
+
+        sslCheckBox.addActionListener(e -> {
+            lastSslState = sslCheckBox.isSelected();
+            updateModeState();
+        });
+
+        DocumentAdapter hostPortListener = new DocumentAdapter() {
+            @Override
+            protected void textChanged(@NotNull DocumentEvent event) {
+                updateServiceUrlFromFields();
+            }
+        };
+        hostComponent.getComponent().getDocument().addDocumentListener(hostPortListener);
+        portComponent.getComponent().getDocument().addDocumentListener(hostPortListener);
+
+        BooleanFunction<JBTextField> showEmptyTextWhenFocused = tf -> tf.getText().isEmpty();
+        hostComponent.getComponent().putClientProperty(TextComponentEmptyText.STATUS_VISIBLE_FUNCTION, showEmptyTextWhenFocused);
+        portComponent.getComponent().putClientProperty(TextComponentEmptyText.STATUS_VISIBLE_FUNCTION, showEmptyTextWhenFocused);
+    }
+
+    private void onProtocolModeChanged(@Nullable JmxProtocol jmxProtocol) {
+        if (selectedProtocol == JmxProtocol.CUSTOM && jmxProtocol != JmxProtocol.CUSTOM) {
+            lastCustomUrl = serviceUrlComponent.getComponent().getText();
+        }
+        boolean switchingToCustom = selectedProtocol != JmxProtocol.CUSTOM && jmxProtocol == JmxProtocol.CUSTOM;
+        selectedProtocol = jmxProtocol;
+        if (switchingToCustom && !lastCustomUrl.isEmpty()) {
+            serviceUrlComponent.getComponent().setText(lastCustomUrl);
+        }
+        updateModeState();
+    }
+
+    private void updateModeState() {
+        boolean isCustomProtocol = selectedProtocol == JmxProtocol.CUSTOM;
+        hostComponent.setVisible(!isCustomProtocol);
+        portComponent.setVisible(!isCustomProtocol);
+        // SSL is only meaningful for Jolokia: RMI encodes TLS differently and Custom carries it in the raw URL.
+        boolean isJolokia = selectedProtocol == JmxProtocol.JOLOKIA;
+        sslCheckBox.setVisible(isJolokia);
+        if (!isJolokia) {
+            sslCheckBox.setSelected(false);
+        } else {
+            sslCheckBox.setSelected(lastSslState);
+        }
+
+        JBTextField serviceUrlField = serviceUrlComponent.getComponent();
+        serviceUrlField.setEditable(isCustomProtocol);
+        // Stays selectable/copyable (setEditable, not setEnabled); dim the text to signal the computed, read-only
+        // value. The background is not toggled because the text-field LAF paints its own and ignores setBackground().
+        serviceUrlField.setForeground(isCustomProtocol ? UIUtil.getTextFieldForeground() : UIUtil.getInactiveTextColor());
+
+        if (!isCustomProtocol) {
+            hostComponent.getComponent().getEmptyText().setText("localhost");
+            portComponent.getComponent().getEmptyText().setText(String.valueOf(selectedProtocol.getDefaultPort(sslCheckBox.isSelected())));
+        }
+
+        updateServiceUrlFromFields();
+    }
+
+    private void updateServiceUrlFromFields() {
+        if (selectedProtocol == JmxProtocol.CUSTOM) {
+            return;
+        }
+        String hostText = hostComponent.getComponent().getText().trim();
+        String host = hostText.isEmpty() ? "localhost" : hostText;
+        String portText = portComponent.getComponent().getText().trim();
+        int port;
+        try {
+            port = portText.isEmpty() ? selectedProtocol.getDefaultPort(sslCheckBox.isSelected()) : Integer.parseInt(portText);
+        } catch (NumberFormatException e) {
+            port = 0;
+        }
+        Boolean useSsl = selectedProtocol == JmxProtocol.JOLOKIA ? sslCheckBox.isSelected() : null;
+        String serviceUrl = JmxProtocol.buildServiceUrl(selectedProtocol, host, port, useSsl);
+        serviceUrlComponent.getComponent().setText(serviceUrl);
     }
 
     @Override
@@ -48,8 +143,6 @@ public class CamelRemoteRunnerConfPanel implements PanelWithAnchor {
     @Override
     public void setAnchor(JComponent anchor) {
         this.anchor = anchor;
-        hostComponent.setAnchor(anchor);
-        portComponent.setAnchor(anchor);
     }
 
     @Override
@@ -61,34 +154,59 @@ public class CamelRemoteRunnerConfPanel implements PanelWithAnchor {
         return panel;
     }
 
-
     public void fromConfiguration(CamelRemoteRunConfiguration configuration) {
         CamelRemoteRunConfigurationOptions options = configuration.getOptions();
         hostComponent.getComponent().setText(options.getHost());
-        portComponent.getComponent().setText(Integer.toString(options.getPort()));
+        int port = options.getPort();
+        portComponent.getComponent().setText(port <= 0 ? "" : Integer.toString(port));
+        selectedProtocol = options.getProtocol();
+        switch (selectedProtocol) {
+            case RMI     -> rmiRadioButton.setSelected(true);
+            case JOLOKIA -> jolokiaRadioButton.setSelected(true);
+            case CUSTOM  -> customRadioButton.setSelected(true);
+        }
+        sslCheckBox.setSelected(options.isSsl());
+        lastSslState = options.isSsl();
+        if (options.getProtocol() == JmxProtocol.CUSTOM) {
+            lastCustomUrl = options.getServiceUrl();
+        }
+        serviceUrlComponent.getComponent().setText(options.getEffectiveServiceUrl());
+        updateModeState();
     }
 
     public void toConfiguration(CamelRemoteRunConfiguration configuration) throws ConfigurationException {
         CamelRemoteRunConfigurationOptions options = configuration.getOptions();
-        String host = hostComponent.getComponent().getText();
-        if (host.isBlank()) {
-            throw new ConfigurationException("The host name cannot be empty");
-        } else {
-            options.setHost(host.trim());
-        }
-        String port = portComponent.getComponent().getText();
-        if (port.isBlank()) {
-            throw new ConfigurationException("The port cannot be empty");
+
+        String host = hostComponent.getComponent().getText().trim();
+        options.setHost(host);
+
+        String port = portComponent.getComponent().getText().trim();
+        int value;
+        if (port.isEmpty()) {
+            value = 0;
         } else {
             try {
-                Integer value = Integer.valueOf(port.trim());
-                if (value <= 0) {
-                    throw new ConfigurationException("The port must be positive");
-                }
-                options.setPort(value);
+                value = Integer.parseInt(port);
             } catch (NumberFormatException e) {
-                throw new ConfigurationException("The port must be a number");
+                throw new ConfigurationException("The port must be a number between 1 and 65535");
             }
+            if (value < 1 || value > 65535) {
+                throw new ConfigurationException("The port must be between 1 and 65535");
+            }
+        }
+        options.setPort(value);
+
+        options.setProtocol(selectedProtocol);
+        options.setSsl(sslCheckBox.isSelected());
+
+        if (selectedProtocol == JmxProtocol.CUSTOM) {
+            String url = serviceUrlComponent.getComponent().getText().trim();
+            if (url.isEmpty()) {
+                throw new ConfigurationException("The JMX Service URL cannot be empty");
+            }
+            options.setServiceUrl(url);
+        } else {
+            options.setServiceUrl("");
         }
     }
 }

--- a/src/test/java/com/github/cameltooling/idea/runner/debugger/JmxProtocolTest.java
+++ b/src/test/java/com/github/cameltooling/idea/runner/debugger/JmxProtocolTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+public class JmxProtocolTest {
+
+    @Test
+    public void testRmiBuildServiceUrl() {
+        String url = JmxProtocol.buildServiceUrl(JmxProtocol.RMI, "localhost", 1099, null);
+        assertEquals("service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi/camel", url);
+    }
+
+    @Test
+    public void testRmiRejectsSsl() {
+        assertThrows(IllegalArgumentException.class, () -> 
+            JmxProtocol.buildServiceUrl(JmxProtocol.RMI, "localhost", 1099, true)
+        );
+        assertThrows(IllegalArgumentException.class, () -> 
+            JmxProtocol.buildServiceUrl(JmxProtocol.RMI, "localhost", 1099, false)
+        );
+    }
+
+    @Test
+    public void testJolokiaBuildServiceUrlHttp() {
+        String url = JmxProtocol.buildServiceUrl(JmxProtocol.JOLOKIA, "127.0.0.1", 8778, false);
+        assertEquals("service:jmx:jolokia+http://127.0.0.1:8778/jolokia/", url);
+    }
+
+    @Test
+    public void testJolokiaBuildServiceUrlHttps() {
+        String url = JmxProtocol.buildServiceUrl(JmxProtocol.JOLOKIA, "some.host.com", 443, true);
+        assertEquals("service:jmx:jolokia+https://some.host.com:443/jolokia/", url);
+    }
+
+    @Test
+    public void testJolokiaRequiresSslSet() {
+        assertThrows(IllegalArgumentException.class, () -> 
+            JmxProtocol.buildServiceUrl(JmxProtocol.JOLOKIA, "localhost", 8778, null)
+        );
+    }
+
+    @Test
+    public void testCustomBuildServiceUrl() {
+        String url = JmxProtocol.buildServiceUrl(JmxProtocol.CUSTOM, "localhost", 1099, null);
+        assertNull(url);
+    }
+
+    @Test
+    public void testCustomRejectsSsl() {
+        assertThrows(IllegalArgumentException.class, () -> 
+            JmxProtocol.buildServiceUrl(JmxProtocol.CUSTOM, "localhost", 1099, true)
+        );
+    }
+
+    @Test
+    public void testDefaultPorts() {
+        assertEquals(1099, JmxProtocol.RMI.getDefaultPort(null));
+        assertEquals(8778, JmxProtocol.JOLOKIA.getDefaultPort(false));
+        assertEquals(8778, JmxProtocol.JOLOKIA.getDefaultPort(true));
+        assertEquals(0, JmxProtocol.CUSTOM.getDefaultPort(null));
+    }
+}

--- a/src/test/java/com/github/cameltooling/idea/runner/debugger/ProcessHandlerRetryPolicyTest.java
+++ b/src/test/java/com/github/cameltooling/idea/runner/debugger/ProcessHandlerRetryPolicyTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.xdebugger.XDebugSession;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ProcessHandlerRetryPolicyTest {
+
+    @Test
+    public void testProcessHandlerRetryPolicy() {
+        AtomicBoolean isTerminated = new AtomicBoolean(false);
+        AtomicBoolean isTerminating = new AtomicBoolean(false);
+
+        ProcessHandler mockProcessHandler = new ProcessHandler() {
+            @Override
+            protected void destroyProcessImpl() {}
+
+            @Override
+            protected void detachProcessImpl() {}
+
+            @Override
+            public boolean detachIsDefault() {
+                return false;
+            }
+
+            @Override
+            public java.io.OutputStream getProcessInput() {
+                return null;
+            }
+
+            @Override
+            public boolean isProcessTerminated() {
+                return isTerminated.get();
+            }
+
+            @Override
+            public boolean isProcessTerminating() {
+                return isTerminating.get();
+            }
+        };
+
+        XDebugSession mockSession = (XDebugSession) Proxy.newProxyInstance(
+            XDebugSession.class.getClassLoader(),
+            new Class<?>[]{XDebugSession.class},
+            (proxy, method, args) -> null
+        );
+
+        ProcessHandlerRetryPolicy policy = new ProcessHandlerRetryPolicy(mockProcessHandler, mockSession);
+
+        // 1. canRetry should be true if process is not terminated/terminating
+        assertTrue(policy.canRetry());
+        assertEquals(30, policy.gracePeriodAttempts());
+
+        // 2. Terminating process means canRetry is false
+        isTerminating.set(true);
+        assertFalse(policy.canRetry());
+
+        isTerminating.set(false);
+        isTerminated.set(true);
+        assertFalse(policy.canRetry());
+    }
+
+    @Test
+    public void testOnGracePeriodExceededRemindsPeriodically() {
+        ProcessHandler mockProcessHandler = new ProcessHandler() {
+            @Override
+            protected void destroyProcessImpl() {}
+            @Override
+            protected void detachProcessImpl() {}
+            @Override
+            public boolean detachIsDefault() { return false; }
+            @Override
+            public java.io.OutputStream getProcessInput() { return null; }
+            @Override
+            public boolean isProcessTerminated() { return false; }
+            @Override
+            public boolean isProcessTerminating() { return false; }
+        };
+
+        XDebugSession mockSession = (XDebugSession) Proxy.newProxyInstance(
+            XDebugSession.class.getClassLoader(),
+            new Class<?>[]{XDebugSession.class},
+            (proxy, method, args) -> null
+        );
+
+        ProcessHandlerRetryPolicy policy = new ProcessHandlerRetryPolicy(mockProcessHandler, mockSession);
+
+        // This method just logs and reports errors every REMINDER_INTERVAL_ATTEMPTS.
+        // We can't easily verify static LOG calls, but we can verify it executes without errors.
+        policy.onGracePeriodExceeded(30, "Grace period exceeded"); // 30 - 30 = 0 % 30 == 0
+        policy.onGracePeriodExceeded(31, "Not reminded");
+        policy.onGracePeriodExceeded(60, "Reminded again"); // 60 - 30 = 30 % 30 == 0
+    }
+}

--- a/src/test/java/com/github/cameltooling/idea/runner/debugger/SessionRetryPolicyTest.java
+++ b/src/test/java/com/github/cameltooling/idea/runner/debugger/SessionRetryPolicyTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger;
+
+import com.intellij.xdebugger.XDebugSession;
+import org.junit.Test;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SessionRetryPolicyTest {
+
+    @Test
+    public void testSessionRetryPolicy() {
+        AtomicBoolean isStopped = new AtomicBoolean(false);
+        AtomicBoolean stopCalled = new AtomicBoolean(false);
+
+        XDebugSession mockSession = (XDebugSession) Proxy.newProxyInstance(
+            XDebugSession.class.getClassLoader(),
+            new Class<?>[]{XDebugSession.class},
+            (proxy, method, args) -> {
+                if (method.getName().equals("isStopped")) {
+                    return isStopped.get();
+                } else if (method.getName().equals("stop")) {
+                    stopCalled.set(true);
+                    isStopped.set(true);
+                    return null;
+                } else if (method.getName().equals("getProject")) {
+                    // Just return null for getProject to avoid NPE in ConnectionRetryPolicy.reportError
+                    // if it uses the project. Actually, it uses xDebugSession.getProject() which might return null.
+                    return null;
+                }
+                return null;
+            }
+        );
+
+        SessionRetryPolicy policy = new SessionRetryPolicy(mockSession);
+        
+        // 1. Can retry while session is not stopped
+        assertTrue(policy.canRetry());
+        assertEquals(1, policy.gracePeriodAttempts());
+
+        // 2. On grace period exceeded, it should stop the session
+        policy.onGracePeriodExceeded(1, "Grace period failed");
+        assertTrue(stopCalled.get());
+        
+        // 3. Once session is stopped, it can no longer retry
+        assertFalse(policy.canRetry());
+    }
+
+    @Test
+    public void testPermanentFailureStopsSession() {
+        AtomicBoolean isStopped = new AtomicBoolean(false);
+        AtomicBoolean stopCalled = new AtomicBoolean(false);
+
+        XDebugSession mockSession = (XDebugSession) Proxy.newProxyInstance(
+            XDebugSession.class.getClassLoader(),
+            new Class<?>[]{XDebugSession.class},
+            (proxy, method, args) -> {
+                if (method.getName().equals("isStopped")) {
+                    return isStopped.get();
+                } else if (method.getName().equals("stop")) {
+                    stopCalled.set(true);
+                    isStopped.set(true);
+                    return null;
+                }
+                return null;
+            }
+        );
+
+        SessionRetryPolicy policy = new SessionRetryPolicy(mockSession);
+        policy.onPermanentFailure("Permanent fail");
+        assertTrue(stopCalled.get());
+        assertFalse(policy.canRetry());
+    }
+}


### PR DESCRIPTION
### Motivation
Currently, the remote Camel debugger relies on standard JMX RMI connections. Some environments (like specific Kubernetes setups, remote servers, or locked-down networks) do not easily expose RMI ports but do expose HTTP/HTTPS endpoints. Jolokia provides a JMX-to-HTTP bridge, making it much easier to connect in these scenarios. Supporting Jolokia enables attaching the Camel Debugger to these environments.

### Modifications
This PR introduces the following changes logically split into 3 commits:
1. **Fix**: Resolves a bug where the Debug button was incorrectly disabled for the plugin's own configurations without pre-existing breakpoints.
2. **Refactor**: Extracts the JMX connector logic and connection-retry strategies out of `CamelDebuggerSession` into dedicated classes. This cleanly separates responsibilities and correctly categorizes connection failures as transient, recoverable, or permanent, rather than silently failing.
3. **Feature**: Adds JMX-over-Jolokia support. The Remote Debug Camel Application run configuration UI now features a JMX Protocol selector (RMI / Jolokia / Custom) and a JMX service URL text field. Connection failures are now also correctly logged to the run configuration's Console tab.
4. **Testing**: Includes comprehensive unit tests for the extracted retry policies and the newly added JMX protocols.

### Result
Users can now natively select "Jolokia" as the JMX protocol when configuring a Remote Debug Camel Application, allowing debugging over HTTP(S). Additionally, errors during connection are handled more gracefully and reported to the user in the console tab.
