### PR TITLE
Set the context class loader when building the Maven downloader

### DIFF
--- a/src/main/java/com/github/cameltooling/idea/maven/MavenArtifactRetrieverContext.java
+++ b/src/main/java/com/github/cameltooling/idea/maven/MavenArtifactRetrieverContext.java
@@ -34,6 +34,7 @@ import org.apache.camel.tooling.maven.MavenDownloader;
 import org.apache.camel.tooling.maven.MavenDownloaderImpl;
 import org.apache.camel.tooling.maven.MavenGav;
 import org.apache.camel.tooling.maven.MavenResolutionException;
+import org.jspecify.annotations.NonNull;
 
 import static com.github.cameltooling.idea.maven.MavenUtil.scanThirdPartyMavenRepositories;
 
@@ -49,8 +50,22 @@ public class MavenArtifactRetrieverContext implements Closeable {
     private final Map<ArtifactCoordinates, URL> allArtifacts = new HashMap<>();
 
     public MavenArtifactRetrieverContext() {
-        this.downloader = new MavenDownloaderImpl();
-        ((MavenDownloaderImpl) downloader).build();
+        this.downloader = initDownloader();
+    }
+
+    private static @NonNull MavenDownloaderImpl initDownloader() {
+        MavenDownloaderImpl downloaderImpl = new MavenDownloaderImpl();
+        // MIMA locates its Runtime implementation with ServiceLoader.load(Runtime.class), which uses the thread
+        // context class loader. On background threads the IDE pins it to the platform class loader, which cannot
+        // see the runtime bundled with this plugin, so it has to be swapped for the duration of the build.
+        final ClassLoader current = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(MavenArtifactRetrieverContext.class.getClassLoader());
+            downloaderImpl.build();
+        } finally {
+            Thread.currentThread().setContextClassLoader(current);
+        }
+        return downloaderImpl;
     }
 
     public MavenArtifactRetrieverContext(Project project) {

--- a/src/test/java/com/github/cameltooling/idea/maven/MavenArtifactRetrieverContextIT.java
+++ b/src/test/java/com/github/cameltooling/idea/maven/MavenArtifactRetrieverContextIT.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.maven;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import com.github.cameltooling.idea.util.ArtifactCoordinates;
+import eu.maveniverse.maven.mima.context.Runtimes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The integration test class for {@link MavenArtifactRetrieverContext}, resolving from Maven Central.
+ */
+public class MavenArtifactRetrieverContextIT {
+
+    private static final String GROUP_ID = "org.apache.camel";
+    private static final String ARTIFACT_ID = "camel-catalog";
+
+    private static final String CAMEL_VERSION;
+
+    static {
+        final String projectRoot = new File(System.getProperty("user.dir")).getPath();
+        try (InputStream is = new FileInputStream(projectRoot + "/gradle.properties")) {
+            Properties gradleProperties = new Properties();
+            gradleProperties.load(is);
+            CAMEL_VERSION = gradleProperties.getProperty("camelVersion");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private ClassLoader originalContextClassLoader;
+
+    @Before
+    public void setUp() {
+        originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        Runtimes.INSTANCE.resetRuntimes();
+    }
+
+    @After
+    public void tearDown() {
+        Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        Runtimes.INSTANCE.resetRuntimes();
+    }
+
+    /**
+     * Unlike the creation of the context, the resolution does not rely on the context class loader. This test is
+     * what confirms that it stays that way, see #1269.
+     */
+    @Test
+    public void shouldResolveArtifactsWithForeignContextClassLoader() throws IOException {
+        Thread.currentThread().setContextClassLoader(ClassLoader.getPlatformClassLoader());
+        try (MavenArtifactRetrieverContext context = new MavenArtifactRetrieverContext()) {
+            context.add(GROUP_ID, ARTIFACT_ID, CAMEL_VERSION);
+
+            Map<ArtifactCoordinates, URL> artifacts = context.getArtifacts();
+            URL artifact = artifacts.get(ArtifactCoordinates.of(GROUP_ID, ARTIFACT_ID, CAMEL_VERSION));
+            assertNotNull(
+                String.format("%s:%s:%s could not be resolved, got %s", GROUP_ID, ARTIFACT_ID, CAMEL_VERSION, artifacts.keySet()),
+                artifact
+            );
+            assertTrue(
+                String.format("%s has not been added to the class loader", artifact),
+                List.of(context.getClassLoader().getURLs()).contains(artifact)
+            );
+        }
+    }
+}

--- a/src/test/java/com/github/cameltooling/idea/maven/MavenArtifactRetrieverContextTest.java
+++ b/src/test/java/com/github/cameltooling/idea/maven/MavenArtifactRetrieverContextTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.maven;
+
+import java.io.IOException;
+
+import eu.maveniverse.maven.mima.context.Runtimes;
+import org.apache.camel.tooling.maven.MavenDownloaderImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The test class for {@link MavenArtifactRetrieverContext}.
+ */
+public class MavenArtifactRetrieverContextTest {
+
+    private ClassLoader originalContextClassLoader;
+
+    @Before
+    public void setUp() {
+        originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        // MIMA caches the resolved runtime in a static registry, clear it so that the lookup really happens
+        Runtimes.INSTANCE.resetRuntimes();
+    }
+
+    @After
+    public void tearDown() {
+        Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        Runtimes.INSTANCE.resetRuntimes();
+    }
+
+    /**
+     * Reproduces #1269: MIMA looks its runtime up with {@code ServiceLoader}, so a context class loader that
+     * cannot see the bundled runtime, as the platform class loader of the IDE, makes the build fail.
+     */
+    @Test
+    public void shouldNotFindTheMavenRuntimeWithForeignContextClassLoader() throws IOException {
+        Thread.currentThread().setContextClassLoader(ClassLoader.getPlatformClassLoader());
+        try (MavenDownloaderImpl downloader = new MavenDownloaderImpl()) {
+            IllegalStateException exception = assertThrows(IllegalStateException.class, downloader::build);
+            assertTrue(
+                String.format("Unexpected failure: %s", exception.getMessage()),
+                exception.getMessage().contains("No Runtime implementation found")
+            );
+        }
+    }
+
+    @Test
+    public void shouldBuildWithForeignContextClassLoader() throws IOException {
+        Thread.currentThread().setContextClassLoader(ClassLoader.getPlatformClassLoader());
+        try (MavenArtifactRetrieverContext context = new MavenArtifactRetrieverContext()) {
+            assertNotNull(context.getClassLoader());
+        }
+    }
+
+    @Test
+    public void shouldRestoreTheContextClassLoader() throws IOException {
+        ClassLoader expected = ClassLoader.getPlatformClassLoader();
+        Thread.currentThread().setContextClassLoader(expected);
+        try (MavenArtifactRetrieverContext ignored = new MavenArtifactRetrieverContext()) {
+            assertNotNull(ignored);
+        }
+        assertSame(expected, Thread.currentThread().getContextClassLoader());
+    }
+}


### PR DESCRIPTION
MIMA resolves its Runtime with ServiceLoader, which on the background threads of the IDE cannot see the runtime bundled with the plugin.

fixes #1269